### PR TITLE
Fix Seeed E1003 BLE upload hang and 4bpp white background

### DIFF
--- a/src/boot_screen.cpp
+++ b/src/boot_screen.cpp
@@ -228,6 +228,17 @@ static void writeGray4PlaneRow(const uint8_t* row2bpp, int pitch2bpp, int planeP
     bbepWriteData(&bbep, planeRow, planePitch);
 }
 
+static const uint8_t kSchemeWhiteValue[] = {
+    0xFF,  // 0: COLOR_SCHEME_MONO   — 1bpp, bit 1 = white
+    0xFF,  // 1: COLOR_SCHEME_BWR    — 1bpp bitplane, all-ones = white plane
+    0xFF,  // 2: COLOR_SCHEME_BWY    — 1bpp bitplane
+    0x55,  // 3: COLOR_SCHEME_BWRY   — 2bpp, code 01b per pixel = white
+    0x11,  // 4: COLOR_SCHEME_BWGBRY — 4bpp Spectra6, nibble 1 = white
+    0xFF,  // 5: COLOR_SCHEME_GRAY4  — 2bpp gray, code 11b per pixel = white
+    0xFF,  // 6: COLOR_SCHEME_GRAY16 — 4bpp Seeed 16-gray, nibble 15 = white
+    0xFF,  // 7: COLOR_SCHEME_GRAY8  — 1bpp (default)
+};
+
 bool writeBootScreenWithQr() {
     const uint16_t w = globalConfig.displays[0].pixel_width;
     const uint16_t h = globalConfig.displays[0].pixel_height;
@@ -235,17 +246,12 @@ bool writeBootScreenWithQr() {
     const bool useBitplanes = (colorScheme == COLOR_SCHEME_BWR || colorScheme == COLOR_SCHEME_BWY);
     const int bitsPerPixel = getBitsPerPixel();
     int pitch;
-    uint8_t whiteValue;
-    if (bitsPerPixel == 4) {
-        pitch = w / 2;
-        whiteValue = 0x11; // for 4bpp spectra 6 panel, white is 0x11.  It MAY be 0xFF for other panels, so in production need to VERIFY THIS!!!
-    } else if (bitsPerPixel == 2) {
-        pitch = (w + 3) / 4;
-        whiteValue = (colorScheme == COLOR_SCHEME_GRAY4) ? 0xFF : 0x55;
-    } else {
-        pitch = (w + 7) / 8;
-        whiteValue = 0xFF;
-    }
+    if (bitsPerPixel == 4) pitch = w / 2;
+    else if (bitsPerPixel == 2) pitch = (w + 3) / 4;
+    else pitch = (w + 7) / 8;
+    uint8_t whiteValue = (colorScheme < sizeof(kSchemeWhiteValue))
+        ? kSchemeWhiteValue[colorScheme]
+        : 0xFF;
 
     String chipId = getChipIdHex();
     if (chipId.length() < 6) {
@@ -356,7 +362,7 @@ bool writeBootScreenWithQr() {
     // bb_epaper 4-gray (scheme 5) needs the packed 2bpp image split into two
     // 1-bit controller planes, so render the frame once per plane and
     // de-interleave. Every other scheme writes a single packed plane in one pass.
-    const bool gray4Split = (colorScheme == 5)
+    const bool gray4Split = (colorScheme == COLOR_SCHEME_GRAY4)
 #if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
         && !seeed_driver_used()
 #endif

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -1059,7 +1059,7 @@ static void renderChar_4BPP(uint8_t* rowBuffer, const uint8_t* fontData, int fon
 }
 
 static void renderChar_2BPP(uint8_t* rowBuffer, const uint8_t* fontData, int fontRow, int charIdx, int startX, int charWidth, int pitch, uint8_t colorScheme, int fontScale) {
-    uint8_t whiteCode = (colorScheme == 5) ? 0x03 : 0x01;
+    uint8_t whiteCode = (colorScheme == COLOR_SCHEME_GRAY4) ? 0x03 : 0x01;
     int pixelsPerByte = 4;
     for (int col = 0; col < charWidth; col += pixelsPerByte) {
         uint8_t pixelByte = 0;
@@ -1179,9 +1179,9 @@ void initDisplay(){
 
 int getplane() {
     uint8_t colorScheme = globalConfig.displays[0].color_scheme;
-    if (colorScheme == 0 || colorScheme == COLOR_SCHEME_GRAY16) return PLANE_0;
-    if (colorScheme == 1 || colorScheme == 2) return PLANE_0;
-    if (colorScheme == 5) return PLANE_1;
+    if (colorScheme == COLOR_SCHEME_MONO || colorScheme == COLOR_SCHEME_GRAY16) return PLANE_0;
+    if (colorScheme == COLOR_SCHEME_BWR || colorScheme == COLOR_SCHEME_BWY) return PLANE_0;
+    if (colorScheme == COLOR_SCHEME_GRAY4) return PLANE_1;
     return PLANE_1;
 }
 
@@ -1192,9 +1192,9 @@ int getBitsPerPixel() {
         return 4;
     }
 #endif
-    if (globalConfig.displays[0].color_scheme == 4) return 4;
-    if (globalConfig.displays[0].color_scheme == 3) return 2;
-    if (globalConfig.displays[0].color_scheme == 5) return 2;
+    if (globalConfig.displays[0].color_scheme == COLOR_SCHEME_BWGBRY) return 4;
+    if (globalConfig.displays[0].color_scheme == COLOR_SCHEME_BWRY) return 2;
+    if (globalConfig.displays[0].color_scheme == COLOR_SCHEME_GRAY4) return 2;
     return 1;
 }
 
@@ -1346,7 +1346,7 @@ void handleDirectWriteCompressedData(uint8_t* data, uint16_t len) {
 // True when the active display uses the bb_epaper 4-gray scheme (two 1-bit
 // controller planes). The Seeed driver path has its own 4bpp handling.
 static inline bool directWriteIsGray4(void) {
-    return (globalConfig.displays[0].color_scheme == 5)
+    return (globalConfig.displays[0].color_scheme == COLOR_SCHEME_GRAY4)
 #if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
         && !seeed_driver_used()
 #endif
@@ -1420,7 +1420,7 @@ if (partialCtx.active) cleanup_partial_write_state();
     }
 #endif
     uint8_t colorScheme = globalConfig.displays[0].color_scheme;
-    directWriteBitplanes = (colorScheme == 1 || colorScheme == 2);
+    directWriteBitplanes = (colorScheme == COLOR_SCHEME_BWR || colorScheme == COLOR_SCHEME_BWY);
     directWritePlane2 = false;
     directWriteCompressed = (len >= 4);
     directWriteWidth = globalConfig.displays[0].pixel_width;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -407,6 +407,10 @@ void pwrmgm(bool onoff){
             }
             delay(100);
         } else {
+            if (disp.reset_pin != 0xFF) {
+                pinMode(disp.reset_pin, OUTPUT);
+                digitalWrite(disp.reset_pin, HIGH);
+            }
             delay(200);
         }
         initOrRestoreWireForOpenDisplay();
@@ -419,8 +423,8 @@ void pwrmgm(bool onoff){
             Wire.end();
             invalidateOpenDisplayWire();
         }
-        configureDisplayPinsLowPower();
         if (globalConfig.system_config.pwr_pin != 0xFF) {
+            configureDisplayPinsLowPower();
             digitalWrite(globalConfig.system_config.pwr_pin, LOW);
         }
     }


### PR DESCRIPTION
## Summary

- **Seeed E1003 BLE upload hang (regression since 1.73):** `configureDisplayPinsLowPower()` drove RST LOW unconditionally during `pwrmgm(false)`. On Seeed E1003 panels (types 3000/3001) with no `pwr_pin`, the IT8951 TCON stays powered via `ite_enable`/`tft_enable`. RST LOW puts the IT8951 into hardware reset, holding BUSY LOW. The `tconWaitForReady()` call inside `wake()` at the start of every BLE upload then blocked for the full 15-second timeout — long enough for the BLE connection to drop before the initial ACK was sent. Fix: gate `configureDisplayPinsLowPower()` on `pwr_pin != 0xFF` (no power rail being cut = no reason to drive lines low), and add RST de-assertion to the Seeed `pwrmgm(true)` branch for devices that do have a power pin.
- **4bpp gray white background fix:** Added `kSchemeWhiteValue` to enumerate the correct white pixel value per color scheme for the boot screen. Replaced magic numbers with named constants for `color_scheme` throughout.

## Test plan

- [ ] BLE image upload to Seeed E1003 (panel type 3000 or 3001) completes without timeout — ACK `0x00 0x70` received within 1 second of upload start command
- [ ] Boot screen renders correct white background on 4bpp gray panels
- [ ] Non-Seeed panel BLE upload unaffected
- [ ] Deep sleep current unchanged on hardware with `pwr_pin` set (`configureDisplayPinsLowPower` still runs for those)

🤖 Generated with [Claude Code](https://claude.com/claude-code)