### PR TITLE
feat: wake on button press from deep sleep + 0x0052 duration payload

### DIFF
--- a/docs/IMPLEMENTATION_WAKE_ON_BUTTON_2026-07-12.md
+++ b/docs/IMPLEMENTATION_WAKE_ON_BUTTON_2026-07-12.md
@@ -1,0 +1,153 @@
+# Implementation Summary: Wake-on-Button-Press from Deep Sleep
+
+**Date:** 2026-07-12  **Branch:** `feat/button-wake` (from `feat/pipe-partial`)
+**Plan:** `docs/PLAN_WAKE_ON_BUTTON_2026-07-12.md`
+**Build status:** all five environments compile clean — `esp32-N4` (classic),
+`esp32-s3-N16R8`, `esp32-c3-N4`, `esp32-c6-N4`, `nrf52840custom` — with no
+warnings in project sources.
+
+## What was implemented
+
+### New module: `src/wake_button.h` / `src/wake_button.cpp`
+
+Follows the `power_latch.cpp` pattern (whole implementation in
+`#if defined(TARGET_ESP32)`, no-op stubs otherwise). Two functions:
+
+- **`armButtonWakeSources()`** — called from `enterDeepSleep()` between
+  `esp_sleep_enable_timer_wakeup()` and `powerLatchHoldForSleep()`. Builds
+  candidate list from every initialized `buttonStates[]` entry (wake level =
+  pressed level) plus `pwr_pin_3` as an active-low candidate on
+  `DEVICE_FLAG_BATTERY_LATCH` boards. Exclusions, each logged:
+  `SLEEP_FLAG_BUTTON_WAKE_DISABLE` (arm nothing), `pwr_pin_2` (latch hold pin),
+  `pwr_pin_3` on D-FF boards (flip-flop CP clock — arming could cut power),
+  pins failing `esp_sleep_is_valid_wakeup_gpio()`, and pins held at their
+  pressed level at sleep entry (instant-wake ping-pong mitigation). Per-variant
+  arming:
+  - **C3/C6** (`SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP`): `esp_deep_sleep_enable_gpio_wakeup()`
+    once per polarity group; both return codes checked and logged; a failed
+    group degrades to timer-only, never aborts the sleep.
+  - **Classic ESP32** (`CONFIG_IDF_TARGET_ESP32`): HIGH group → ext1 ANY_HIGH;
+    LOW group → ext0 on the lowest-numbered pin (classic silicon has no
+    ANY_LOW); additional LOW pins logged as unarmed.
+  - **S2/S3**: larger polarity group → ext1 (ANY_HIGH or ANY_LOW); first pin of
+    the other group → ext0; extras logged as unarmed.
+  - ext0/ext1 pads get their configured pulls re-asserted through the RTC IO
+    registers (`rtc_gpio_pullup_en`/`rtc_gpio_pulldown_en`); pads with no
+    internal pull get a "floating wake pin" warning but are still armed.
+  - The timer wake source is always left armed alongside the buttons.
+- **`detectButtonWake(int cause)`** — called once in `setup()`. Classifies
+  EXT0 (logs the armed pin from `RTC_DATA_ATTR s_ext0WakePin`; there is no ext0
+  status register), EXT1 / GPIO (logs the waking pin mask from the status
+  APIs), TIMER, and default. Returns true only for the button causes. Does not
+  inject synthetic button press events (the press occurred while the ISR was
+  dead; `initButtons()`'s settle pass would erase or double-count one).
+
+### Shared minimum-wake window (timer refactor)
+
+- `PowerOption.min_wake_time_seconds` (uint16, carved from `reserved[7]` →
+  field + `reserved[5]`; struct size unchanged, old config blobs read 0 →
+  default) and `SLEEP_FLAG_BUTTON_WAKE_DISABLE` (sleep_flags bit 0) in
+  `src/structs.h`.
+- `DEFAULT_MIN_WAKE_TIME_SECONDS = 120`, `minWakeWindowActive`,
+  `minWakeWindowStartMs` in `src/main.h`; the four
+  `FIRST_BOOT_DEEP_SLEEP_DELAY_MS` / `firstBootDelay*` lines deleted.
+- `minWakeTimeMs()` / `minWakeHoldActive()` helpers in `src/main.cpp`. The hold
+  is a **floor layered under the existing quiet-window logic**: sleep requires
+  both the idle/advertising quiet condition AND the hold expired. Armed in
+  `setup()` on (a) button wake and (b) first boot (`deep_sleep_count == 0`,
+  which — per the RTC-reload finding — also covers hidden mid-cycle resets).
+  Timer wakes never arm it, so their behavior is unchanged.
+- Consumers: post-wake advertising branch
+  (`idle_duration >= advertising_timeout_ms && !minWakeHoldActive()`), idle
+  gate (`idleMs < idleHoldMs || minWakeHoldActive()`), and a defense-in-depth
+  guard in `enterDeepSleep()` placed **before** the advertising stop so an
+  aborted sleep can never leave the radio dark. The old first-boot block in
+  `loop()` was deleted (superseded).
+
+### `enterDeepSleep()` changes (`src/main.cpp`)
+
+New signature `enterDeepSleep(bool force = false, uint16_t overrideSleepSeconds = 0)`
+(defaults in the `main.h` declaration and the `device_control.cpp` local
+re-declaration). All three pre-existing guards byte-identical. After the guards:
+`sleepSeconds = override ? override : config`, used for the timer arm and the
+entry log (tagged "(host override, one cycle)" vs "(config)"). The TODO comment
+at the old line 464 is now the `armButtonWakeSources()` call. The incorrect
+"RTC memory survives soft resets" comment in `setup()` was rewritten to state
+the bootloader-reload behavior (per the 2026-07-07 findings capture).
+
+### `0x0052` protocol extension
+
+- `communication.cpp`: dispatch passes `data + 2, len - 2` (dispatcher already
+  guarantees `len >= 2`).
+- `device_control.cpp/.h`: `handleDeepSleepCommand(const uint8_t*, uint16_t)`.
+  Big-endian 2-byte seconds payload; bytes beyond 2 ignored (forward compat);
+  1-byte payload logs a warning and is treated as absent; `0x0000` = explicit
+  no-override. **Eligibility pre-checks with NACK** (payload = duration only,
+  never eligibility): `power_mode != 1` → `{0xFF, 0x52, 0x02, 0x00}`;
+  `deep_sleep_time_seconds == 0` → `{0xFF, 0x52, 0x01, 0x00}`. D-FF path
+  byte-identical to before (ACK + hard power off) plus an ignored-payload log.
+  No ACK on the successful non-DFF path (unchanged from legacy).
+- `config_parser.cpp`: config dump prints `Min Wake Time` and
+  `Button Wake: enabled/disabled (sleep_flags bit0)`.
+
+## Differences between implementation and plan
+
+| # | Difference | Evaluation |
+|---|---|---|
+| 1 | **EXT0/EXT1 cases in `detectButtonWake()` are guarded by `SOC_PM_SUPPORT_EXT0/EXT1_WAKEUP`** — not in the plan. | **Required fix, found by the build matrix.** The plan's verified-framework-facts said `esp_sleep_get_ext1_wakeup_status()` is *declared* unguarded on every chip — true, but the **symbol does not link on C3** (no ext1 hardware; precompiled libs omit it). The esp32-c3-N4 build failed at link; guarding the cases is correct since those causes cannot occur on chips without the hardware, and the `default` case covers them defensively. This validates the plan's caveat that precompiled-lib behavior could not be fully verified offline. |
+| 2 | `detectButtonWake` takes `int`, not `esp_sleep_wakeup_cause_t`; no separate `wokeByButton()` accessor. | Plan-sanctioned option (header must compile on nRF without `esp_sleep.h`). The accessor was unnecessary — `setup()` captures the return value in a local that spans both uses. |
+| 3 | `pwr_pin_2`/`pwr_pin_3` exclusions apply only when those pins are **valid** (`!= 0 && != 0xFF`). | Refinement, agent-initiated. `0` is the "unset" sentinel for these fields; without the validity check, a real button on GPIO0 would be silently excluded on every board with no latch configured. Correct — accepted. |
+| 4 | Pull configuration for wake pads is read from `globalConfig.binary_inputs[instance_index]` via `ButtonState.pin_offset`. | The plan's preferred fallback: `ButtonState` does not cache pull bits, but it does cache `instance_index`/`pin_offset`, so the config lookup is exact — no lossy heuristic needed. |
+| 5 | C3/C6 path checks **both** `esp_deep_sleep_enable_gpio_wakeup()` return codes (plan required only the second, mixed-polarity call). | Strictly more defensive; no behavior downside. |
+| 6 | Config dump lines placed at contextually adjacent anchors (Min Wake Time under Deep Sleep Time; Button Wake under Sleep Flags) rather than one block. | Cosmetic; better readability of the dump. |
+| 7 | nRF branch of `handleDeepSleepCommand` gained `(void)payload; (void)payloadLen;`. | Warning hygiene only; no behavior. |
+| 8 | S2/S3 "larger group" tie-break: equal group sizes put the HIGH group on ext1. | Plan didn't specify tie behavior; either choice is valid — at most one pin of the other polarity is relegated to ext0, which the plan requires anyway. |
+
+Everything else matches the plan exactly: struct layout and offsets, flag bit,
+API signatures, guard ordering (hold guard before advertising stop; arming
+between timer arm and latch hold), one-cycle override-by-parameter, NACK codes,
+hold-as-floor semantics, first-boot refactor, D-FF exclusions, and the
+RTC-comment correction.
+
+## Validation performed
+
+1. **Diff review vs plan** — every hunk in all 9 changed/new files checked
+   against the plan's steps; deviations enumerated above and each evaluated.
+2. **Cross-agent consistency** — the two implementation agents worked disjoint
+   file sets against a shared `enterDeepSleep(bool, uint16_t)` contract;
+   signatures, field names, and macro names line up exactly (verified by
+   compile, not just inspection).
+3. **Compile matrix** — 5/5 environments SUCCESS after the C3 link fix
+   (difference #1). No warnings in project sources.
+4. **Logic checks** —
+   - All new loops bounded (≤ 33 candidates, 16 hex nibbles, 64 warn-mask bits);
+     no unbounded loops, no recursion, no dynamic allocation beyond the
+     codebase's existing `String` logging idiom, no exceptions (none used
+     anywhere in the codebase).
+   - Min-wake hold self-clears by time with wraparound-safe `millis()`
+     subtraction; both call sites short-circuit so the mutation only runs when
+     the gate is actually consulted; a stray armed hold on a wired device is
+     provably inert (every consumer sits behind `power_mode == 1` gates).
+   - Every wake-arming failure degrades to timer-only sleep — no failure mode
+     yields no-sleep or no-wake.
+   - Advertising continuity invariant preserved: the hold guard aborts before
+     the advertising stop; past the stop, `enterDeepSleep()` unconditionally
+     reaches `esp_deep_sleep_start()`.
+   - `0x0052` payload-length underflow impossible (`len >= 2` dispatcher
+     guard); `0xFFFF` payload (≈18.2 h) safe in the 64-bit µs conversion;
+     override cannot leak across cycles (parameter, never stored).
+
+## Not yet validated (requires hardware — see plan's validation task list)
+
+- Actual button wake per variant (classic ext0/ext1, S3, C3/C6 gpio-wake), and
+  the mixed-polarity double `esp_deep_sleep_enable_gpio_wakeup()` accumulation
+  on C3/C6 (plan's flagged-unverified item; the code checks and logs both
+  return codes).
+- MOSFET-latch board: latch held through timer sleep with wake buttons armed;
+  power-button wake; `powerOff()` regression; sleep-current delta from RTC
+  pulls.
+- D-FF board: `0x0052` hard-off regression; `pwr_pin_2/3` never in the logged
+  wake mask.
+- 120 s window timing, `min_wake_time_seconds` override, first-boot window,
+  held-button skip, `0x0052` payload matrix and NACKs, cross-version
+  compatibility against the previous firmware release.

--- a/docs/PLAN_WAKE_ON_BUTTON_2026-07-12.md
+++ b/docs/PLAN_WAKE_ON_BUTTON_2026-07-12.md
@@ -1,0 +1,495 @@
+# Wake-on-Button-Press from Deep Sleep — Implementation Plan
+
+## Context
+
+The ESP32 path of this firmware supports timer-based deep sleep for battery devices (`power_mode == 1`, `deep_sleep_time_seconds > 0`). Today the only wake source armed on the idle/timer sleep path is the RTC timer (`src/main.cpp:463`), with an explicit TODO at `src/main.cpp:464` to add button wake. The user wants: any configured button on a wake-capable pin should wake the display from deep sleep; on button wake, the device should stay awake for a minimum window (default 120 s) so the user can interact; this window should be unified with the existing first-boot 120 s holdoff (`FIRST_BOOT_DEEP_SLEEP_DELAY_MS`); it must be correct with battery latches (MOSFET and D-FF) and must not disturb the idle timer, post-wake advertising window, deep-sleep timer, power-off path, or nRF52840 builds.
+
+**Deliverable 0 (user request):** save the consolidated architecture report below to `docs/architecture-deep-sleep-power-buttons.md` as the first implementation step.
+
+---
+
+## Step 0 — Write `docs/architecture-deep-sleep-power-buttons.md`
+
+Create the file with exactly the following content (update line anchors if the implementation lands after other changes):
+
+~~~markdown
+# Architecture: Deep Sleep, Battery Latch, and Buttons (ESP32 path)
+
+Status: as of branch `feat/pipe-partial`, 2026-07-12. All behavior described here is
+ESP32-only (`TARGET_ESP32`); the nRF52840 target compiles these subsystems as no-op
+stubs and has no deep sleep.
+
+## 1. Deep sleep
+
+There are two distinct deep-sleep entry points.
+
+### 1.1 Timer deep sleep — `enterDeepSleep(bool force)` (`src/main.cpp:431-470`)
+
+The normal battery low-power path. Guards, in order:
+
+1. `globalConfig.power_option.power_mode != 1` (not battery) → return, no sleep.
+2. `deep_sleep_time_seconds == 0` (disabled) → return.
+3. A BLE client is connected and `!force` → return (live link aborts sleep).
+
+Then: sets RTC-persisted `woke_from_deep_sleep = true`, stops advertising,
+`BLEDevice::deinit(true)` + handle clear, arms the timer wake
+(`esp_sleep_enable_timer_wakeup(deep_sleep_time_seconds * 1e6)`, `main.cpp:463`),
+flushes the log, calls `powerLatchHoldForSleep()` (`main.cpp:468`) so a latched
+device keeps its power rail across sleep, and enters `esp_deep_sleep_start()`.
+
+Wake source on this path today: **timer only**. (`main.cpp:464` carries the TODO
+for button wake.)
+
+Callers:
+- `main.cpp:250` — post-wake advertising window timed out.
+- `main.cpp:363` — main idle quiet-window elapsed.
+- `device_control.cpp:711` — BLE command `0x0052` (`force = true`).
+
+### 1.2 Power-off deep sleep — `powerOff()` (`src/power_latch.cpp:83-106`)
+
+User-initiated shutdown on the MOSFET-latch path (3 s long-press on `pwr_pin_3`, or
+a `binary_inputs` button flagged `power_off`). Waits for button release, drives the
+latch pin LOW, `esp_sleep_config_gpio_isolate()`, `gpio_hold_en()`, then — under
+`#if SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP` — arms
+`esp_deep_sleep_enable_gpio_wakeup(1ULL << buttonPin(), ESP_GPIO_WAKEUP_GPIO_LOW)`
+on the shutdown button and calls `esp_deep_sleep_start()`. Wake source: **button
+only** (or hardware re-latch if the rail actually drops).
+
+### 1.3 Wake-cause detection (`src/main.cpp:66-83`, in `setup()`)
+
+`esp_sleep_get_wakeup_cause()` is called once. Any cause other than
+`ESP_SLEEP_WAKEUP_UNDEFINED` is treated identically as "woke from deep sleep":
+sets `is_deep_sleep_wake` / `woke_from_deep_sleep`, increments RTC-persisted
+`deep_sleep_count`. The specific cause (timer vs GPIO) is logged but not acted on.
+
+### 1.4 Boot sequence differences on wake
+
+`setup()` order: serial init → wake detect → `full_config_init()` (which calls
+`powerLatchBegin()` at `config_parser.cpp:856`) → `initio()` → **if cold boot only:**
+`initDisplay()` (EPD power + full refresh) → `ble_init()` → **if cold boot only:**
+`initWiFi(false)` → `updatemsdata()`, `initButtons()`, `initTouchInput()` →
+**if wake:** arm the post-wake advertising window (`advertising_timeout_active = true`,
+`advertising_start_time = millis()`) → `lastActivityMs = millis()`.
+
+On a deep-sleep wake, display init, boot screen, and WiFi are skipped; the e-paper
+image is retained.
+
+## 2. Sleep/wake timers
+
+All timing state lives in `src/main.h`; config fields come from the binary TLV
+config blob (LittleFS-persisted), not NVS.
+
+| Timer / window | Definition | Default | Purpose |
+|---|---|---|---|
+| Deep sleep duration | `PowerOption.deep_sleep_time_seconds` (`structs.h:56`, uint16) | 0 = disabled | Timer wake interval |
+| Idle quiet window ("stay awake") | `PowerOption.sleep_timeout_ms` (`structs.h:47`, uint16 ms) | 0 → `DEFAULT_IDLE_HOLD_MS` | Quiet time before sleeping; also the post-wake advertising window length |
+| Idle hold fallback | `DEFAULT_IDLE_HOLD_MS` (`main.h:325`) | 10 000 ms | Fallback when `sleep_timeout_ms == 0` |
+| First-boot holdoff | `FIRST_BOOT_DEEP_SLEEP_DELAY_MS` (`main.h:328`) | 120 000 ms | Cold-boot grace period before first sleep (gated by `deep_sleep_count == 0`) |
+| Direct-write timeout | inline `main.cpp:293` | 900 000 ms | PIPE/direct-write session timeout |
+| Power-off long-press | `POWER_OFF_HOLD_MS` (`power_latch.cpp:21`) | 3 000 ms | Latch shutdown hold |
+
+Runtime/RTC state: `RTC_DATA_ATTR bool woke_from_deep_sleep` (`main.h:312`),
+`RTC_DATA_ATTR uint32_t deep_sleep_count` (`main.h:313`),
+`advertising_timeout_active` / `advertising_start_time` (`main.h:316-317`),
+`lastActivityMs` (`main.h:323`), first-boot-delay state (`main.h:329-331`).
+
+### 2.1 Loop decision flow (`src/main.cpp:219-389`)
+
+`pollActivity()` (`main.cpp:144-187`) stamps `lastActivityMs` whenever BLE queues,
+connection state, touch, LAN state, or the button MSD payload (`memcmp` of
+`dynamicreturndata`) change — so a button press resets the idle timer indirectly.
+
+- **Post-wake window branch** (`main.cpp:226-260`), active while
+  `woke_from_deep_sleep && advertising_timeout_active`: a BLE connect exits the
+  window into full setup; otherwise after `sleep_timeout_ms` (or 10 s) of quiet →
+  `enterDeepSleep()`.
+- **Normal branch**: drains BLE work; computes `workInFlight`; when idle applies the
+  first-boot 120 s holdoff, then the idle quiet window → `enterDeepSleep()`.
+
+## 3. Battery latch
+
+Two mechanisms, both in `src/power_latch.cpp` (ESP32-only; no-op stubs otherwise),
+selected by `SystemConfig.device_flags` bits and sharing pins `pwr_pin_2`/`pwr_pin_3`
+(`structs.h:29-32`):
+
+| Flag | Bit | Mechanism | pwr_pin_2 | pwr_pin_3 |
+|---|---|---|---|---|
+| `DEVICE_FLAG_BATTERY_LATCH` | 1<<3 | Self-holding MOSFET/load-switch | latch enable | active-low shutdown button |
+| `DEVICE_FLAG_PWR_LATCH_DFF` | 1<<4 | 74AHC1G79 D flip-flop | D (`PWR_HOLD`) | CP clock (`PWR_LOCK`) |
+
+Key behaviors:
+- `powerLatchBegin()` (`power_latch.cpp:110-122`, called from `full_config_init`):
+  releases any RTC hold from a prior sleep (`gpio_hold_dis`), engages the D-FF
+  (drive D high, pulse CP), sets the MOSFET shutdown button to `INPUT_PULLUP`.
+- `powerLatchHoldForSleep()` (`power_latch.cpp:148-167`): before timer deep sleep,
+  drives the hold pin HIGH and latches it with `gpio_hold_en()` +
+  `gpio_deep_sleep_hold_en()` (skipped on C6, which lacks that API) so the rail
+  stays up through deep sleep. **A latched battery device therefore does enter
+  timer deep sleep and self-wakes — it does not cut power on the idle path.**
+- `powerOff()` (MOSFET) — see §1.2. `dffLatchRelease()` (D-FF) clocks Q low → hard
+  power cut, no deep sleep; re-power is via the hardware button re-latching the FF.
+- BLE command `0x0052` (`device_control.cpp:700-714`): D-FF → hard off; otherwise
+  `enterDeepSleep(true)`.
+- There is **no low-battery cutoff logic**; battery voltage (ADC or BQ27220) is
+  measured and reported only.
+
+## 4. Buttons
+
+Configured via the repeatable `binary_inputs` TLV packet (id `0x25`), struct
+`BinaryInputs` (`structs.h:247-268`): up to 4 instances × 8 pins = 32 buttons
+(`MAX_BUTTONS`, `structs.h:400`). Per-pin bitmasks: `input_flags` (active pins),
+`invert` (active-low), `pullups`, `pulldowns`, `power_off_flags`;
+`power_off_hold_sec`; `reserved[12]` spare bytes. Parsed by fixed-size `memcpy`
+(`config_parser.cpp:381-391`) — struct size is ABI.
+
+Runtime:
+- `initButtons()` (`device_control.cpp:551-658`): pinMode with per-pin pull config,
+  `attachInterruptArg(pin, buttonISR, idx, CHANGE)`, 50 ms boot settle that resets
+  `press_count` and discards spurious startup edges. Skips `0xFF` pins and the
+  GT911 touch INT pin.
+- ISR (`device_control.cpp:512-527`, `IRAM_ATTR`): edge-triggered; updates
+  `current_state`, increments 4-bit `press_count` on press, flags
+  `buttonEventPending`.
+- `processButtonEvents()` (`device_control.cpp:420-452`): packs
+  `(button_id | press_count<<3 | state<<7)` into `dynamicreturndata[byte_index]`
+  and re-publishes the BLE advertising MSD. Buttons report to the host; they do
+  not drive local page changes.
+- Power-off: `pollConfiguredPowerOffButtons()` (`device_control.cpp:50-81`) for
+  flagged buttons, `powerButtonPoll()` (`power_latch.cpp:124-145`) for the
+  dedicated `pwr_pin_3` button.
+
+Gaps (pre-feature): no RTC-capability validation of button pins, no
+ext0/ext1/`rtc_gpio_*` usage, and normal buttons never arm a deep-sleep wake —
+only the dedicated latch shutdown button does, and only on the power-off path.
+
+## 5. Variant awareness
+
+A single `TARGET_ESP32` macro covers all ESP32 chips (envs: classic ESP32, S3, C3,
+C6). The only per-chip guards are `#if !defined(CONFIG_IDF_TARGET_ESP32C6)` around
+`gpio_deep_sleep_hold_en()` and `#if SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP` around the
+GPIO wake call in `powerOff()`. Wake-capable pins differ by chip: classic ESP32
+and S2/S3 wake via ext0/ext1 on RTC GPIOs; C3/C6 wake via
+`esp_deep_sleep_enable_gpio_wakeup()` on their low-power GPIO range.
+~~~
+
+---
+
+## Verified framework facts (arduino-esp32 core 3.3.9, checked in `~/.platformio/packages/framework-arduinoespressif32-libs/<chip>/include/`)
+
+| Capability | esp32 classic | esp32s3 | esp32c3 | esp32c6 |
+|---|---|---|---|---|
+| ext0 (`SOC_PM_SUPPORT_EXT0_WAKEUP`) | yes | yes | — | — |
+| ext1 (`SOC_PM_SUPPORT_EXT1_WAKEUP`) | yes (ALL_LOW / ANY_HIGH only) | yes (ANY_LOW / ANY_HIGH) | — | yes (+ per-pin mode) |
+| `SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP` | — | — | yes (GPIO0–5) | yes (GPIO0–7) |
+| Wake-valid pins | 0,2,4,12–15,25–27,32–39 | 0–21 | 0–5 | 0–7 |
+
+- `esp_sleep_is_valid_wakeup_gpio(gpio_num_t)` exists unguarded on every chip (`esp_sleep.h:250`) — use it as the runtime capability check; **no hand-rolled pin tables**.
+- `esp_sleep_get_ext1_wakeup_status()` (unguarded) and `esp_sleep_get_gpio_wakeup_status()` (guarded by `SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP`) identify the waking pin(s). There is **no ext0 status API** — remember the armed ext0 pin in `RTC_DATA_ATTR`.
+- `rtc_gpio_pullup_en` / `rtc_gpio_pulldown_en` exist in `driver/rtc_io.h`.
+- `gpio_deep_sleep_hold_en()` only affects pads on which `gpio_hold_en()` was called (driver/gpio.h:433–450) — so `powerLatchHoldForSleep()` cannot freeze wake-button pads; **power_latch.cpp needs no changes**.
+- `CONFIG_ESP_SLEEP_GPIO_ENABLE_INTERNAL_RESISTORS=y` in shipped sdkconfigs — for C3/C6 GPIO wake, `esp_deep_sleep_start()` auto-enables the pull opposite the wake level.
+- ext1 note (esp_sleep.h:354–361): with RTC_PERIPH powered down, IDF maintains configured pulls via the HOLD feature automatically; `esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ON)` is a fallback only.
+- `ESP_EXT1_WAKEUP_ANY_LOW` does **not exist** on classic ESP32.
+
+**Unverifiable locally (precompiled libs — confirm on hardware, see validation list):**
+1. Two successive `esp_deep_sleep_enable_gpio_wakeup()` calls with different levels accumulate per-pin (true in IDF v5.3–5.5 source; check return code of the second call at runtime).
+2. IDF forces RTC_PERIPH on when ext0 is armed on classic ESP32.
+3. Sleep-current impact of held pulls — hardware measurement.
+
+---
+
+## Step 1 — New module `src/wake_button.h` / `src/wake_button.cpp`
+
+Follow the `power_latch.cpp` pattern: entire implementation inside `#if defined(TARGET_ESP32)`, empty stubs in `#else` (nRF unaffected). Include the local `DEVICE_FLAG_*` fallback defines exactly as `power_latch.cpp:10-15` does.
+
+Public API:
+```cpp
+// Arm all eligible button-wake sources for the upcoming timer deep sleep.
+// Never fails; logs each pin's disposition. No-op on nRF.
+void armButtonWakeSources();
+// Classify wake cause and log the waking pin(s). Call once, early in setup().
+// Returns true for EXT0/EXT1/GPIO causes. Safe pre-config (reads sleep regs only).
+bool detectButtonWake(esp_sleep_wakeup_cause_t cause);
+```
+
+Internal state: `RTC_DATA_ATTR static uint8_t s_ext0WakePin = 0xFF;` (survives sleep; only way to log the ext0 wake pin). Externs for `buttonStates[]`, `buttonStateCount`, `globalConfig` (same style as `device_control.cpp:42`).
+
+### Wake-mask construction (all variants)
+
+Candidates:
+1. Every initialized `buttonStates[i]` pin (these already exclude `0xFF` and the GT911 touch INT pin). Wake level = pressed level = `inverted ? LOW : HIGH`.
+2. `system_config.pwr_pin_3` as an **active-low** candidate **only when** `DEVICE_FLAG_BATTERY_LATCH` is set and the pin is valid — so the MOSFET-latch power button also wakes from timer sleep (mirrors `powerOff()` semantics).
+
+Exclusions, each logged:
+- `power_option.sleep_flags` bit 0 set (`SLEEP_FLAG_BUTTON_WAKE_DISABLE`) → arm nothing (feature default-ON per the "any button press should wake" principle).
+- Pin == `pwr_pin_2` always; pin == `pwr_pin_3` when `DEVICE_FLAG_PWR_LATCH_DFF` (**critical**: on D-FF boards pwr_pin_3 is the flip-flop CP clock — a wake-armed pull could clock the latch off).
+- `!esp_sleep_is_valid_wakeup_gpio(pin)` → warn "pin N not wake-capable on this chip; timer-only for this button".
+- Pin currently reading its pressed level at sleep entry → skip this cycle, log "held at sleep entry" (prevents instant-wake ping-pong; pin re-qualifies next sleep entry after release).
+
+Build 64-bit `lowMask` (wake on LOW) and `highMask` (wake on HIGH).
+
+### Per-variant arming
+
+```cpp
+#if SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP            // C3 (GPIO0-5), C6 (GPIO0-7)
+    if (lowMask)  esp_deep_sleep_enable_gpio_wakeup(lowMask,  ESP_GPIO_WAKEUP_GPIO_LOW);
+    if (highMask) err = esp_deep_sleep_enable_gpio_wakeup(highMask, ESP_GPIO_WAKEUP_GPIO_HIGH);
+    // If the second call errors (mixed-polarity accumulation is the unverified item):
+    // log, keep the first group, never abort sleep. Pulls auto-configured by IDF.
+#elif SOC_PM_SUPPORT_EXT1_WAKEUP                 // classic, S2, S3
+  #if CONFIG_IDF_TARGET_ESP32
+    // classic has no ANY_LOW: HIGH group -> ext1 ANY_HIGH; LOW group -> ext0 (ONE pin,
+    // lowest-numbered), s_ext0WakePin = pin; warn for each additional low pin not armed.
+    if (highMask) esp_sleep_enable_ext1_wakeup(highMask, ESP_EXT1_WAKEUP_ANY_HIGH);
+    if (lowMask)  esp_sleep_enable_ext0_wakeup(firstLowPin, 0);
+  #else
+    // S2/S3: larger polarity group -> ext1 (ANY_HIGH or ANY_LOW); other group's first
+    // pin -> ext0; warn extras. (One ext1 call only — a second call replaces the first.)
+  #endif
+    // Pull retention: rtc_gpio_pullup_en()/rtc_gpio_pulldown_en() per the button's
+    // configured pullups/pulldowns bitmasks (and INPUT_PULLUP for the latch button).
+    // Pins with no internal pull and unknown external hardware: warn "floating wake
+    // pin may cause spurious wakes" but still arm.
+#endif
+```
+
+Timer wake (`esp_sleep_enable_timer_wakeup`, main.cpp:463) is **always left armed** — ext0/ext1/gpio/timer coexist. Both masks empty → single log "no wake-capable buttons — timer-only deep sleep".
+
+### `detectButtonWake(cause)`
+
+Switch on cause: `EXT0` (log `s_ext0WakePin`), `EXT1` (log `esp_sleep_get_ext1_wakeup_status()` mask), `GPIO` under `#if SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP` (log `esp_sleep_get_gpio_wakeup_status()` mask) → return true; `TIMER` → log "timer wake", return false; default → false.
+
+**Decision:** a button wake is logged and arms the stay-awake window but does **not** inject a synthetic press into the BLE MSD payload. The press happened while the ISR was dead; `initButtons()`'s settle pass resets `press_count`/state from live pin levels anyway, so a synthetic event would be erased or double-counted. If the button is still held when `initButtons()` runs, its state lands in MSD naturally.
+
+---
+
+## Step 2 — Shared minimum-wake-time (the timer refactor)
+
+### Config (`src/structs.h`)
+
+`PowerOption` (structs.h:44-61): split `reserved[7]` (line 60) →
+```cpp
+uint16_t min_wake_time_seconds; // Min awake window after first boot or button wake; 0 = default 120 s
+uint8_t reserved[5];
+```
+Struct size unchanged → the fixed-size `memcpy` parse and all existing config blobs stay valid; old blobs read 0 → default 120 s. (`sleep_timeout_ms` is uint16 **ms**, max 65.5 s — cannot hold 120 s, hence a new seconds field.)
+
+Add near structs.h:63:
+```cpp
+#define SLEEP_FLAG_BUTTON_WAKE_DISABLE (1u << 0)  // power_option.sleep_flags bit 0
+```
+(`sleep_flags` bits are all reserved today — verified in firmware and the toolbox schema.)
+
+### One mechanism: a minimum-wake hold deadline (`src/main.h` + `src/main.cpp`)
+
+**Semantics: the hold is a floor layered under the existing quiet-window logic, not a replacement.** Sleep requires both the existing idle/advertising quiet condition AND the hold expired. `pollActivity()`/`lastActivityMs` untouched — interaction keeps extending the quiet window inside and beyond the floor. On timer wake the hold is never armed → behavior bit-identical to today.
+
+`src/main.h`: delete lines 328-331 (`FIRST_BOOT_DEEP_SLEEP_DELAY_MS`, `firstBootDelayInitialized/Elapsed/Start`); add next to the advertising globals (~line 316):
+```cpp
+static constexpr uint16_t DEFAULT_MIN_WAKE_TIME_SECONDS = 120;
+bool minWakeWindowActive = false;   // armed in setup() on first boot or button wake
+uint32_t minWakeWindowStartMs = 0;
+```
+
+`src/main.cpp` helpers (near `pollActivity()`):
+```cpp
+static uint32_t minWakeTimeMs() {
+    uint16_t s = globalConfig.power_option.min_wake_time_seconds;
+    return (uint32_t)(s ? s : DEFAULT_MIN_WAKE_TIME_SECONDS) * 1000UL;
+}
+static bool minWakeHoldActive() {
+    if (!minWakeWindowActive) return false;
+    if (millis() - minWakeWindowStartMs >= minWakeTimeMs()) {
+        minWakeWindowActive = false;
+        writeSerial("Minimum wake window elapsed, deep sleep permitted");
+        return false;
+    }
+    return true;
+}
+```
+
+Documented behavior delta: the first-boot holdoff now counts from end of setup() rather than from the first quiet loop pass — makes "awake ≥ 120 s from power-on" a real guarantee.
+
+---
+
+## Step 3 — `src/main.cpp` edits
+
+1. **setup() wake-cause block (main.cpp:66-83):** after line 68, add `bool woke_by_button = detectButtonWake(wakeup_reason);` — replaces the raw numeric log at line 74 with named cause + waking pin mask.
+2. **Window arming (main.cpp:122-133):** keep the existing advertising-window arm; extend:
+```cpp
+if (is_deep_sleep_wake) {
+    advertising_timeout_active = true;
+    advertising_start_time = millis();
+    if (woke_by_button) {
+        minWakeWindowActive = true;
+        minWakeWindowStartMs = millis();
+        writeSerial("Button wake: holding awake >= " + String(minWakeTimeMs()) + " ms");
+    }
+} else if (deep_sleep_count == 0) {   // first boot (RTC count survives soft resets)
+    minWakeWindowActive = true;
+    minWakeWindowStartMs = millis();
+}
+```
+(Arm regardless of power_mode — every consuming path is already gated by `power_mode == 1` / `deep_sleep_time_seconds > 0`, so the flag is inert on wired devices.)
+3. **Post-wake advertising branch (main.cpp:246):** `if (idle_duration >= advertising_timeout_ms)` → `if (idle_duration >= advertising_timeout_ms && !minWakeHoldActive())`. Timer wake: hold never armed → unchanged short window. Button wake: window ends at max(quiet window, min wake time); `idleDelay(50)` at line 258 keeps servicing buttons/touch throughout.
+4. **Delete the first-boot block (main.cpp:336-352)** — superseded by the hold.
+5. **Idle gate (main.cpp:359):** `if (idleMs < idleHoldMs)` → `if (idleMs < idleHoldMs || minWakeHoldActive())`. Also covers connect-then-drop during a button-wake window (`woke_from_deep_sleep` cleared at line 231 → normal idle logic still honors the floor).
+6. **`enterDeepSleep()` (main.cpp:431-470):**
+   - After the connected-client guard (line 448), defense-in-depth: `if (!force && minWakeHoldActive()) return;` (`force` from BLE 0x0052 bypasses — command behavior unchanged).
+   - Replace the TODO at line 464 with `armButtonWakeSources();` — after `esp_sleep_enable_timer_wakeup()` (463), **before** `powerLatchHoldForSleep()` (468). Ordering: latch-hold manipulation then can't disturb freshly configured RTC pulls, and `gpio_hold_en` applies only to the latch pin.
+
+## Step 4 — Supporting edits
+
+- `src/config_parser.cpp` (~line 681, config dump): print `min_wake_time_seconds` and the `sleep_flags` button-wake bit (log-based verification).
+- `src/power_latch.cpp`: **no changes** — `powerOff()`/`dffLatchRelease()` hard-off paths (with `esp_sleep_config_gpio_isolate`) keep their existing single-button wake arming; `enterDeepSleep()` never calls isolate, so new wake pins stay live through timer sleep.
+- Companion (separate repo, non-blocking): `opendisplay.org/httpdocs/firmware/toolbox/config.yaml` power_option — name `sleep_flags` bit 0 `button_wake_disable`; carve `min_wake_time_seconds` (2 bytes) from reserved.
+
+---
+
+## Step 5 — Protocol change: `0x0052` optional 2-byte sleep-duration payload
+
+**Requirement:** `0x0052` gains an optional 2-byte big-endian payload of seconds — e.g. `00 52 00 FF` commands "sleep for 255 seconds." The value overrides `deep_sleep_time_seconds` for **exactly one** deep-sleep cycle.
+
+### Backward compatibility — verified against the dispatcher
+
+`imageDataWritten()` (`communication.cpp:498-506`) only requires `len >= 2` and parses the big-endian command ID from bytes 0-1; `case 0x0052` (`communication.cpp:655`) currently calls `handleDeepSleepCommand()` with no payload pointer, ignoring any trailing bytes. Therefore:
+- **New host → old firmware:** `00 52 00 FF` matches `0x0052`; the extra 2 bytes are ignored; device sleeps with the config duration. Graceful degradation, no error path.
+- **Old host → new firmware:** bare `00 52` yields zero payload bytes → no override → config duration. Bit-identical to today.
+- Big-endian seconds matches both the user-specified example and the command-ID framing convention; the `data + 2, len - 2` payload convention matches every other parameterized command (0x70, 0x73, 0x77, …).
+
+### Changes
+
+1. **`src/communication.cpp:655-657`:** `case 0x0052: handleDeepSleepCommand(data + 2, len - 2); break;`
+2. **`src/device_control.h:16` / `src/device_control.cpp:700-715`:** `void handleDeepSleepCommand(const uint8_t* payload, uint16_t payloadLen)`. Parse:
+   - `payloadLen >= 2` → `overrideSeconds = ((uint16_t)payload[0] << 8) | payload[1]` (extra bytes beyond 2 ignored for forward compatibility). `0x0000` = explicit "no override" (sentinel, uses config).
+   - `payloadLen == 1` → malformed: log warning, treat as no payload.
+   - `payloadLen == 0` → no override (legacy behavior).
+   - **D-FF path:** payload is meaningless (hard power cut has no timer, no self-wake) — log "duration payload ignored (D-FF hard power off)" if `overrideSeconds != 0`, then proceed with the existing ACK + `powerLatchPowerOff()` unchanged.
+   - **Non-DFF path — eligibility pre-check with NACK (consistency decision, see below):** before calling `enterDeepSleep`, the handler checks the same two config guards `enterDeepSleep` enforces and reports rejection using the codebase's standard response convention (success `{0x00, cmd, 0x00, 0x00}` / error `{0xFF, cmd, code, 0x00}`, as in `handleLedActivate`, device_control.cpp:374-417):
+     - `power_mode != 1` → NACK `{0xFF, 0x52, 0x02, 0x00}`, return (no sleep — wired guard, unchanged eligibility).
+     - `deep_sleep_time_seconds == 0` → NACK `{0xFF, 0x52, 0x01, 0x00}`, return (**the payload does NOT enable sleep on a config-disabled device**).
+     - Otherwise: `enterDeepSleep(true, overrideSeconds);`
+     Backward compatible: today's non-DFF `0x0052` sends no response at all, so old hosts ignore the new unsolicited NACK; new hosts gain observable rejection.
+3. **`enterDeepSleep()` signature (`src/main.cpp:431`, decl in main.h):** `void enterDeepSleep(bool force = false, uint16_t overrideSleepSeconds = 0)`. Inside:
+   - **All existing guards unchanged** (power_mode 432, `deep_sleep_time_seconds == 0` 437, BLE-connected 444). The override never changes *eligibility* — only the duration of an otherwise-permitted sleep.
+   - After the guards: `uint16_t sleepSeconds = overrideSleepSeconds ? overrideSleepSeconds : globalConfig.power_option.deep_sleep_time_seconds;` — timer arm (line 462-463) uses `sleepSeconds`; the entry log prints the effective duration and whether it came from the command override.
+
+**Consistency decision — why the override does NOT enable sleep when `deep_sleep_time_seconds == 0`:** the two config guards in `enterDeepSleep` are uniformly absolute today — both reject even the forced BLE command — and `deep_sleep_time_seconds == 0` is the firmware-wide deep-sleep disable switch (idle gate, first-boot holdoff, and `enterDeepSleep` all treat 0 as "disabled"; structs.h:56 "0 if not used"). Letting a payload bypass one guard but not the other would be asymmetric, and would give the same command different *eligibility* with vs without payload (bare `0x0052` already rejects on such devices). Rule adopted: **payload = duration only; eligibility is config's alone.** The legitimate future use case (host-driven duty cycling on a device with no autonomous timer) should be an explicit opt-in — e.g. a new `sleep_flags` bit — not a silent side effect of the duration payload; noted as out of scope.
+4. **One-cycle semantics by construction:** the override is threaded as a **parameter**, never stored in a global and never `RTC_DATA_ATTR`. The idle-timer callers (`main.cpp:250`, `main.cpp:363`) use the default `0` → config duration. If the guarded entry aborts (wired device), the override is discarded with the call — it cannot leak into a later sleep. After the override sleep, wake → boot reinitializes everything → every subsequent cycle uses config. No clearing logic needed, no invalid state possible.
+5. **Interaction with button wake:** none required — `armButtonWakeSources()` runs identically; a button can cut an override sleep short, and the subsequent wake windows behave per the boot-side table (timer wake → short window; button wake → 120 s floor).
+6. **Docs:** note the payload in `docs/architecture-deep-sleep-power-buttons.md` §3.1 and in the companion host-side command reference (separate repo, non-blocking).
+
+### Logic table addendum (replaces/refines rows 9-10)
+
+| # | Trigger | Latch | Payload | Behavior |
+|---|---|---|---|---|
+| 9a | `0x0052`, D-FF | D-FF | none | ACK, hard power cut — unchanged |
+| 9b | `0x0052`, D-FF | D-FF | N seconds | payload logged + ignored, ACK, hard power cut (no timer exists once power drops) |
+| 10a | `0x0052`, non-DFF | any/none | none or `0x0000` | `enterDeepSleep(true, 0)` — config duration; buttons + timer armed |
+| 10b | `0x0052`, non-DFF | any/none | N seconds | sleeps N seconds (config overridden this cycle only); buttons + timer armed; next idle sleep uses config |
+| 10c | `0x0052`, non-DFF, config `deep_sleep_time_seconds == 0` | any/none | any (or none) | rejected: NACK `{0xFF, 0x52, 0x01, 0x00}`, no sleep — payload does not enable a config-disabled device |
+| 10d | `0x0052`, non-DFF, `power_mode != 1` | any/none | any | rejected: NACK `{0xFF, 0x52, 0x02, 0x00}`, no sleep (wired guard unchanged) |
+| 10e | `0x0052`, malformed 1-byte payload | any | 1 byte | warning logged, treated as 10a |
+
+---
+
+## Logic / state table
+
+Sleep-entry rows (non-forced `enterDeepSleep()`; timer source armed in every "sleeps" row):
+
+| # | power_mode / deep_sleep_time | Latch | Buttons | Armed wake sources at sleep entry | Notes |
+|---|---|---|---|---|---|
+| 1 | wired (≠1) or time=0 | any | any | never sleeps (early return 432/437) | unchanged |
+| 2 | battery, >0 | none | none | timer only; log "timer-only" | unchanged + 1 log |
+| 3 | battery, >0 | none | all non-capable pins | timer only; per-pin warn | e.g. C3 button on GPIO9 |
+| 4 | battery, >0 | none | active-low capable | classic: ext0 (first) + warn rest; S3: ext1 ANY_LOW; C3/C6: gpio LOW | |
+| 5 | battery, >0 | none | active-high capable | classic/S3: ext1 ANY_HIGH; C3/C6: gpio HIGH | |
+| 6 | battery, >0 | none | mixed polarity | classic: ext1 ANY_HIGH + ext0 one low; S3: ext1 larger group + ext0 first of other; C3/C6: two gpio calls (hw-verify) | warns list unarmed pins |
+| 7 | battery, >0 | MOSFET | rows 2–6 | same + pwr_pin_3 joins low group if capable; pwr_pin_2 excluded, held HIGH via gpio_hold_en | power button wakes; hold unaffected |
+| 8 | battery, >0 | D-FF | rows 2–6 | same, but pwr_pin_2 AND pwr_pin_3 force-excluded (CP clock) | latch cannot be clocked off |
+| 9 | BLE 0x0052, D-FF | D-FF | any | hard power cut — no wake sources; duration payload ignored/logged | see Step 5 addendum |
+| 10 | BLE 0x0052, non-DFF | any | any | timer (config or 2-byte payload override, one cycle) + buttons | see Step 5 addendum rows 10a-10e |
+| 11 | MOSFET 3 s power-off | MOSFET | any | unchanged `powerOff()`: isolate + gpio wake on pwr_pin_3 only | untouched path |
+| 12 | any sleeps-row, button held at entry | any | held pin | held pin skipped (logged); if only wake pin → timer-only this cycle | ping-pong mitigation |
+
+Boot-side rows:
+
+| Wake cause | woke_from_deep_sleep | Window(s) armed |
+|---|---|---|
+| UNDEFINED, deep_sleep_count==0 (true first boot OR hidden mid-cycle reset — see below) | false | min-wake hold (120 s default); full display init |
+| UNDEFINED, deep_sleep_count>0 | false | none — defensive row only; unreachable in practice (see "Hidden mid-cycle resets") |
+| TIMER | true | short advertising window only — unchanged |
+| EXT0 / EXT1 / GPIO | true | advertising window + min-wake floor |
+| GPIO after MOSFET `powerOff()` | per prior RTC flag | as row above when flag set; additionally gets the floor (improvement) |
+| other (UART/ULP — never armed) | true | treated like timer wake (default case) — safe |
+
+### Hidden mid-cycle resets (wake cause UNDEFINED after a crash) — focused analysis
+
+**Question: when a hidden mid-cycle reset occurs (panic / WDT / brownout / `esp_restart()` between deep-sleep cycles), what is correct behavior — and should it do a full display init? Answer: yes, full display init is correct and required, and the plan's first-boot rule already delivers the right window behavior. Details:**
+
+**Empirical fact (changes the state model):** `docs/FINDINGS_DEEP_SLEEP_WAKE_BOOT_SCREEN_2026-07-07.md` captured this exact scenario on hardware (reTerminal E1001): a PANIC on the wake path → `RTC_SW_CPU_RST` → `=== NORMAL BOOT ===  Deep sleep count (RTC): 0` — the count was 2 immediately before the panic. `RTC_DATA_ATTR` variables do **not** survive non-deep-sleep resets on this platform: the second-stage bootloader reloads RTC memory segments from the app image on every reset except a deep-sleep wake. So after any panic/WDT/SW/brownout reset, the device boots with `deep_sleep_count = 0`, `woke_from_deep_sleep = false`, `rebootFlag = 1`, `displayed_etag = 0` — **indistinguishable from a true first boot.** The `UNDEFINED + count>0` table row is defensive only; the code comment at `main.cpp:79-81` claiming RTC survives soft resets is contradicted by the captured log and must be fixed during implementation.
+
+**Why full display init is correct here:**
+1. **Panel controller state is unknown.** The crash may have hit mid-refresh; an EPD controller abandoned mid-waveform (rails up, charge on the panel) must be re-initialized. `initDisplay()` (rail power cycle + controller init + full refresh) is the only path that guarantees a known-good panel state. Skipping it to preserve the image would trade a cosmetic flash for an unverifiable panel state.
+2. **Host re-sync is forced automatically.** `rebootFlag = 1` (reloaded initializer) is advertised in MSD, and `displayed_etag = 0` makes any partial/etag-gated write NACK into a full push. The crash recovery contract is self-healing — full init + boot screen is consistent with it.
+3. **Diagnostic value.** The boot screen appearing on a battery device is precisely how the 2026-07-07 panic was discovered. Silent "seamless" recovery would hide crash loops on headless devices.
+
+**Window behavior on a hidden reset (what this plan produces):** since the reset presents as `count == 0`, the 120 s min-wake hold arms. This is desirable: after an abnormal reset the device stays connectable long enough for the host to re-push the image (and for a developer to capture logs). It is also **not a behavior change** — today's first-boot gate (`!woke_from_deep_sleep && deep_sleep_count == 0`) already fires after a crash for the same reason, so the crash reboot already waits 2 minutes before its first sleep. A crash *loop* therefore costs ~120 s awake per crash; that is accepted — a crash loop is a firmware bug to fix, not a state to optimize battery for.
+
+**If the defensive row ever fires** (`UNDEFINED + count>0`, e.g. a future IDF/bootloader that preserves RTC segments): no hold is armed, the device full-inits the display, and sleeps after the normal idle quiet window — safe, no invalid state. If distinguishing a true cold boot from a crash reset ever becomes necessary, the correct tool is `esp_reset_reason()` (already logged at `main.cpp:66-67`: `ESP_RST_POWERON` vs `PANIC`/`SW`/`WDT`/`BROWNOUT`), not RTC counters.
+
+### Advertising continuity during the awake windows (EXT0/EXT1/GPIO wake) — verified
+
+The button-wake windows do not introduce any state where the device is awake with advertising stopped:
+
+1. **Start:** on every deep-sleep wake, `ble_init_esp32()` starts advertising unconditionally in setup (`ble_init.cpp:331`) before the windows are armed, so the post-wake branch always begins with the radio advertising.
+2. **Only two deliberate stop sites exist while disconnected, and neither strands the device:**
+   - `updatemsdata()` (`display_service.cpp:1376-1389`) stops advertising only to swap in a fresh MSD payload and restarts it ~50 ms later in the same call (pre-existing refresh blip, unchanged by this feature).
+   - `enterDeepSleep()` stops advertising (`main.cpp:450-456`) — but every abort guard precedes that point, and after the stop there is no return path: it always reaches `esp_deep_sleep_start()`. **Ordering requirement:** the new `if (!force && minWakeHoldActive()) return;` guard MUST be inserted after the connected-client guard (line 448) and before the advertising stop (line 450), so an aborted sleep can never leave advertising stopped. (Step 3 item 6 places it there.)
+3. **Disconnect healing:** a connect-then-drop sets `bleRestartAdvertisingPending` (`esp32_ble_callbacks.h:69`), serviced in both loop branches (window branch `main.cpp:236-238`, normal branch `main.cpp:288-290`). The pending flag is also in `pollActivity()`'s watch list (`main.cpp:174`), so a pending restart stamps `lastActivityMs` — no window can expire while a re-advertise is owed. `esp32_restart_ble_advertising()` defers while `epdRefreshInProgress` (`ble_init.cpp:251-253`), but that flag also sets `workInFlight` and counts as activity, so the device stays awake and retries.
+4. **The hold adds no stop point:** when `minWakeHoldActive()` keeps a branch alive past its quiet timeout, the branch only runs `idleDelay(50)`/`idleDelay(5)` (buttons/touch serviced); advertising is untouched. While a client is connected, advertising is off — standard single-connection BLE peripheral behavior, not a gap.
+
+Net guarantee: for the entire button-wake awake window (advertising window + 120 s min-wake floor), the device is either advertising, momentarily restarting advertising to refresh MSD, connected to a client, or deferring a restart behind an in-flight refresh that itself holds the device awake.
+
+**Implementation additions from this analysis:**
+- Fix the incorrect comment at `main.cpp:79-81` (RTC does not survive soft resets; a non-zero count on NORMAL BOOT is not an expected signal).
+- Validation task: force a mid-cycle crash (`abort()` or a test command) between sleep cycles → verify full display init, `count` reset to 0, 120 s hold armed, host re-push succeeds (etag 0 → full write).
+- **Optional hardening, out of scope for this feature:** brownout-aware boot. The findings doc (source #4) documents the loop: brownout → boot → full-refresh current spike → brownout again. A follow-up could special-case `ESP_RST_BROWNOUT` (defer the full refresh, shorten the awake window, sleep quickly to let the battery recover). Not part of the wake-on-button change.
+
+**No invalid states:** `minWakeWindowActive` on a wired device is inert (all consumers power_mode-gated); the hold self-clears by time (single `millis()` compare, wraparound-safe subtraction); every failure mode degrades to "timer-only sleep" or "shorter window" — never to no-sleep or no-wake lockup. The only loop-like scenario (button held across sleep entry) is skipped at arming time and self-limiting regardless. No dynamic allocation, no exceptions, no unbounded loops in any new code.
+
+**No new latency:** `armButtonWakeSources()` runs only inside `enterDeepSleep()` (already a slow teardown with delays); `detectButtonWake()` once in setup(); loop() gains exactly two short-circuit `minWakeHoldActive()` calls in branches that only execute when idle. The hot BLE/WiFi path (main.cpp:264-334), `pollActivity()`, idle-timer math, and deep-sleep timer are untouched.
+
+---
+
+## Validation tasks
+
+**Compile matrix** (all must build clean): `pio run` for every ESP32 env (esp32-s3-* variants, esp32-c3-N4/N16, esp32-c6-N4, esp32-N4) plus the nRF env (must compile against wake_button stubs with no behavior change).
+
+**Hardware, per variant (S3 + C3/C6 + classic where available):**
+1. Timer wake regression: sleeps, wakes after `deep_sleep_time_seconds`, log shows "timer wake", short window, re-sleeps after quiet window.
+2. Button wake: press during sleep → boots, log shows named cause + pin mask + "holding awake >= 120000 ms"; device connectable ≥ 120 s with no interaction, then sleeps.
+3. `min_wake_time_seconds` override (e.g. 30) honored for both first boot and button wake.
+4. First boot after flash/battery insert: ≥ 120 s before first sleep.
+5. Button held at sleep entry: "held at sleep entry" logged, timer-only sleep, no wake ping-pong.
+6. Non-capable pin (e.g. C3 button on GPIO > 5): warning logged, timer wake unaffected.
+7. Mixed polarity on C3/C6: second `esp_deep_sleep_enable_gpio_wakeup` returns ESP_OK and both polarities wake (unverified item 1).
+8. MOSFET latch board: timer sleep keeps rail up; pwr_pin_3 wakes from timer sleep; 3 s hold power-off + button-on still works; sleep current measured vs pre-change.
+9. D-FF board: 0x0052 hard-off unchanged; config-button wake works; pwr_pin_2/3 never appear in the logged wake mask.
+10. BLE 0x0052 on non-DFF: sleeps immediately even inside the 120 s window (force path); button press wakes it.
+10a. `0x0052` payload matrix: bare `00 52` → config duration (regression); `00 52 00 1E` → wakes after 30 s, next idle sleep uses config again (one-cycle check); `00 52 00 00` → config duration; `00 52 00 FF` on a device with `deep_sleep_time_seconds = 0` → NACK `{0xFF, 0x52, 0x01, 0x00}`, stays awake; same on a wired device (`power_mode != 1`) → NACK `{0xFF, 0x52, 0x02, 0x00}`; 1-byte payload → warning + config duration; payload sent to a D-FF board → ignored-payload log + hard off unchanged.
+10b. Cross-version compatibility: new host with payload against previous firmware release → device sleeps with config duration, no error (backward-compat check).
+11. Idle-timer/advertising-window timings identical to current firmware logs on timer-wake cycles.
+12. Log checks: config dump prints `min_wake_time_seconds`/`sleep_flags`; sleep entry prints per-pin arming dispositions; boot prints named wake cause + pin mask.
+
+## Critical files
+
+- `src/wake_button.h` / `src/wake_button.cpp` — new module
+- `src/main.cpp` — setup() wake detect (66-83), window arming (122-133), advertising branch (246), first-boot block removal (336-352), idle gate (359), enterDeepSleep (448, 464)
+- `src/main.h` — remove first-boot statics (328-331), add min-wake globals (~316)
+- `src/structs.h` — `PowerOption.min_wake_time_seconds` from reserved (60), `SLEEP_FLAG_BUTTON_WAKE_DISABLE` (~63)
+- `src/config_parser.cpp` — config dump line (~681)
+- `src/communication.cpp` — 0x0052 dispatch passes payload (655-657)
+- `src/device_control.cpp` / `.h` — `handleDeepSleepCommand(payload, len)` (700-715, decl device_control.h:16)
+- `docs/architecture-deep-sleep-power-buttons.md` — new (Step 0 content above)
+- `src/power_latch.cpp` — reference only, must remain unchanged

--- a/docs/architecture-deep-sleep-power-buttons.md
+++ b/docs/architecture-deep-sleep-power-buttons.md
@@ -1,0 +1,276 @@
+# Architecture: Deep Sleep, Battery Latch, and Buttons (ESP32 path)
+
+Status: as of branch `feat/button-wake`, 2026-07-12 (includes the wake-on-button
+feature — see `docs/IMPLEMENTATION_WAKE_ON_BUTTON_2026-07-12.md`). All behavior
+described here is ESP32-only (`TARGET_ESP32`); the nRF52840 target compiles these
+subsystems as no-op stubs and has no deep sleep.
+
+## 1. Deep sleep
+
+There are two distinct deep-sleep entry points.
+
+### 1.1 Timer deep sleep — `enterDeepSleep(bool force)` (`src/main.cpp:431-470`)
+
+The normal battery low-power path. Guards, in order:
+
+1. `globalConfig.power_option.power_mode != 1` (not battery) → return, no sleep.
+2. `deep_sleep_time_seconds == 0` (disabled) → return.
+3. A BLE client is connected and `!force` → return (live link aborts sleep).
+
+Then: sets RTC-persisted `woke_from_deep_sleep = true`, stops advertising,
+`BLEDevice::deinit(true)` + handle clear, arms the timer wake
+(`esp_sleep_enable_timer_wakeup(deep_sleep_time_seconds * 1e6)`, `main.cpp:463`),
+flushes the log, calls `powerLatchHoldForSleep()` (`main.cpp:468`) so a latched
+device keeps its power rail across sleep, and enters `esp_deep_sleep_start()`.
+
+Wake sources on this path: **timer plus every wake-capable configured button**
+(`armButtonWakeSources()` in `src/wake_button.cpp`, called after the timer arm and
+before `powerLatchHoldForSleep()`). Button wake is default-on; `power_option.
+sleep_flags` bit 0 (`SLEEP_FLAG_BUTTON_WAKE_DISABLE`) opts a device out. The
+duration can be overridden for one cycle by the `0x0052` payload (see §3.1).
+
+Callers:
+- `main.cpp:250` — post-wake advertising window timed out.
+- `main.cpp:363` — main idle quiet-window elapsed.
+- `device_control.cpp:711` — BLE command `0x0052` (`force = true`).
+
+### 1.2 Power-off deep sleep — `powerOff()` (`src/power_latch.cpp:83-106`)
+
+User-initiated shutdown on the MOSFET-latch path (3 s long-press on `pwr_pin_3`, or
+a `binary_inputs` button flagged `power_off`). Waits for button release, drives the
+latch pin LOW, `esp_sleep_config_gpio_isolate()`, `gpio_hold_en()`, then — under
+`#if SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP` — arms
+`esp_deep_sleep_enable_gpio_wakeup(1ULL << buttonPin(), ESP_GPIO_WAKEUP_GPIO_LOW)`
+on the shutdown button and calls `esp_deep_sleep_start()`. Wake source: **button
+only** (or hardware re-latch if the rail actually drops).
+
+### 1.3 Wake-cause detection (`src/main.cpp:66-83`, in `setup()`)
+
+`esp_sleep_get_wakeup_cause()` is called once. Any cause other than
+`ESP_SLEEP_WAKEUP_UNDEFINED` is treated as "woke from deep sleep": sets
+`is_deep_sleep_wake` / `woke_from_deep_sleep`, increments RTC-persisted
+`deep_sleep_count`. `detectButtonWake()` (`src/wake_button.cpp`) classifies the
+cause: EXT0/EXT1/GPIO (button) wakes additionally arm the minimum-wake hold
+(default 120 s, `PowerOption.min_wake_time_seconds`) so the device stays
+connectable; timer wakes keep the short advertising window only.
+
+**RTC persistence caveat:** `RTC_DATA_ATTR` variables survive deep sleep only.
+On any other reset (panic, WDT, `esp_restart()`, brownout) the second-stage
+bootloader reloads the RTC memory segments from the app image, so
+`deep_sleep_count`, `woke_from_deep_sleep`, `rebootFlag`, and `displayed_etag`
+all return to their initializers. This was observed on hardware in
+`FINDINGS_DEEP_SLEEP_WAKE_BOOT_SCREEN_2026-07-07.md` (count 2 → panic → NORMAL
+BOOT with count 0). Consequence: a hidden mid-cycle reset is indistinguishable
+from a true first boot (`UNDEFINED` + `count == 0`) and takes the full cold-boot
+path — display re-init (guaranteeing a known-good panel state after a possible
+mid-refresh crash), `rebootFlag = 1` advertised, `displayed_etag = 0` forcing a
+host full re-push, and the first-boot sleep holdoff. This is the intended
+crash-recovery behavior. (The comment at `main.cpp:79-81` claiming RTC survives
+soft resets is contradicted by the captured log.) To distinguish a cold boot
+from a crash reset, use `esp_reset_reason()` — `ESP_RST_POWERON` vs
+`PANIC`/`SW`/`WDT`/`BROWNOUT` — not RTC counters.
+
+### 1.4 Boot sequence differences on wake
+
+`setup()` order: serial init → wake detect → `full_config_init()` (which calls
+`powerLatchBegin()` at `config_parser.cpp:856`) → `initio()` → **if cold boot only:**
+`initDisplay()` (EPD power + full refresh) → `ble_init()` → **if cold boot only:**
+`initWiFi(false)` → `updatemsdata()`, `initButtons()`, `initTouchInput()` →
+**if wake:** arm the post-wake advertising window (`advertising_timeout_active = true`,
+`advertising_start_time = millis()`) → `lastActivityMs = millis()`.
+
+On a deep-sleep wake, display init, boot screen, and WiFi are skipped; the e-paper
+image is retained.
+
+## 2. Sleep/wake timers
+
+All timing state lives in `src/main.h`; config fields come from the binary TLV
+config blob (LittleFS-persisted), not NVS.
+
+| Timer / window | Definition | Default | Purpose |
+|---|---|---|---|
+| Deep sleep duration | `PowerOption.deep_sleep_time_seconds` (`structs.h:56`, uint16) | 0 = disabled | Timer wake interval |
+| Idle quiet window ("stay awake") | `PowerOption.sleep_timeout_ms` (`structs.h:47`, uint16 ms) | 0 → `DEFAULT_IDLE_HOLD_MS` | Quiet time before sleeping; also the post-wake advertising window length |
+| Idle hold fallback | `DEFAULT_IDLE_HOLD_MS` (`main.h:325`) | 10 000 ms | Fallback when `sleep_timeout_ms == 0` |
+| First-boot holdoff | `FIRST_BOOT_DEEP_SLEEP_DELAY_MS` (`main.h:328`) | 120 000 ms | Cold-boot grace period before first sleep (gated by `deep_sleep_count == 0`) |
+| Direct-write timeout | inline `main.cpp:293` | 900 000 ms | PIPE/direct-write session timeout |
+| Power-off long-press | `POWER_OFF_HOLD_MS` (`power_latch.cpp:21`) | 3 000 ms | Latch shutdown hold |
+
+Runtime/RTC state: `RTC_DATA_ATTR bool woke_from_deep_sleep` (`main.h:312`),
+`RTC_DATA_ATTR uint32_t deep_sleep_count` (`main.h:313`),
+`advertising_timeout_active` / `advertising_start_time` (`main.h:316-317`),
+`lastActivityMs` (`main.h:323`), first-boot-delay state (`main.h:329-331`).
+
+### 2.1 Loop decision flow (`src/main.cpp:219-389`)
+
+`pollActivity()` (`main.cpp:144-187`) stamps `lastActivityMs` whenever BLE queues,
+connection state, touch, LAN state, or the button MSD payload (`memcmp` of
+`dynamicreturndata`) change — so a button press resets the idle timer indirectly.
+
+- **Post-wake window branch** (`main.cpp:226-260`), active while
+  `woke_from_deep_sleep && advertising_timeout_active`: a BLE connect exits the
+  window into full setup; otherwise after `sleep_timeout_ms` (or 10 s) of quiet →
+  `enterDeepSleep()`.
+- **Normal branch**: drains BLE work; computes `workInFlight`; when idle applies the
+  first-boot 120 s holdoff, then the idle quiet window → `enterDeepSleep()`.
+
+## 3. Battery latch
+
+Two mechanisms, both in `src/power_latch.cpp` (ESP32-only; no-op stubs otherwise),
+selected by `SystemConfig.device_flags` bits and sharing pins `pwr_pin_2`/`pwr_pin_3`
+(`structs.h:29-32`):
+
+| Flag | Bit | Mechanism | pwr_pin_2 | pwr_pin_3 |
+|---|---|---|---|---|
+| `DEVICE_FLAG_BATTERY_LATCH` | 1<<3 | Self-holding MOSFET/load-switch | latch enable | active-low shutdown button |
+| `DEVICE_FLAG_PWR_LATCH_DFF` | 1<<4 | 74AHC1G79 D flip-flop | D (`PWR_HOLD`) | CP clock (`PWR_LOCK`) |
+
+Key behaviors:
+- `powerLatchBegin()` (`power_latch.cpp:110-122`, called from `full_config_init`):
+  releases any RTC hold from a prior sleep (`gpio_hold_dis`), engages the D-FF
+  (drive D high, pulse CP), sets the MOSFET shutdown button to `INPUT_PULLUP`.
+- `powerLatchHoldForSleep()` (`power_latch.cpp:148-167`): before timer deep sleep,
+  drives the hold pin HIGH and latches it with `gpio_hold_en()` +
+  `gpio_deep_sleep_hold_en()` (skipped on C6, which lacks that API) so the rail
+  stays up through deep sleep. **A latched battery device therefore does enter
+  timer deep sleep and self-wakes — it does not cut power on the idle path.**
+- `powerOff()` (MOSFET) — see §1.2. `dffLatchRelease()` (D-FF) clocks Q low → hard
+  power cut, no deep sleep; re-power is via the hardware button re-latching the FF.
+- BLE command `0x0052` (`device_control.cpp:700-714`): D-FF → hard off; otherwise
+  `enterDeepSleep(true)`.
+
+### 3.1 D-FF hard power off vs non-DFF deep sleep (BLE `0x0052`)
+
+The same host command produces fundamentally different power states depending on
+the latch hardware:
+
+- **D-FF boards (`DEVICE_FLAG_PWR_LATCH_DFF`): hard power off.** The 74AHC1G79
+  flip-flop's Q output gates the power rail. `dffLatchRelease()`
+  (`power_latch.cpp:63-81`) drives D (`pwr_pin_2`) LOW and pulses CP
+  (`pwr_pin_3`) → Q latches low → the rail is physically cut. This is not a
+  sleep state: the MCU loses power entirely, so **no firmware wake source
+  (timer, GPIO, button) exists** — RTC memory, wake configuration, and held
+  GPIOs are all gone. The only way back is the hardware power button, which
+  re-clocks the flip-flop and re-latches Q high, producing a cold boot
+  (`ESP_RST_POWERON`, `deep_sleep_count == 0`, full display init).
+  `handleDeepSleepCommand()` sends the ACK *before* releasing the latch, since
+  nothing can be sent afterward.
+- **Non-DFF boards (MOSFET latch or no latch): timer deep sleep.** `0x0052`
+  calls `enterDeepSleep(true)` — the MCU stays powered (a MOSFET latch is held
+  via `powerLatchHoldForSleep()`), the RTC timer wake stays armed, and the
+  device self-wakes after `deep_sleep_time_seconds`. `force = true` bypasses
+  the connected-client guard because the command inherently arrives over a
+  live BLE link.
+
+Implication for button wake: on the non-DFF path, `0x0052` flows through
+`enterDeepSleep()`, so button wake sources armed there also apply to a
+commanded sleep. On D-FF boards, wake arming is meaningless after `0x0052`
+(power is cut), and during normal *timer* sleep `pwr_pin_3` must never be
+armed as a wake pin — it is the flip-flop's CP clock input, and driving or
+pulling it could clock the latch and power the board off
+(`armButtonWakeSources()` force-excludes it on D-FF boards).
+
+**`0x0052` payload (protocol extension):** an optional 2-byte big-endian
+seconds payload overrides the configured sleep duration for exactly one cycle
+(`00 52 00 FF` = "sleep 255 s"); `0x0000` or no payload = config duration. The
+payload changes only the duration, never eligibility: on non-DFF boards the
+command is NACKed with `{0xFF, 0x52, 0x01, 0x00}` when
+`deep_sleep_time_seconds == 0` (deep sleep disabled in config) and
+`{0xFF, 0x52, 0x02, 0x00}` when `power_mode != 1` (not battery). D-FF boards
+ignore the payload (logged) — a hard power cut has no timer. Backward
+compatible both directions: old firmware ignores the extra bytes; old hosts
+send no payload and may ignore the new NACKs.
+- There is **no low-battery cutoff logic**; battery voltage (ADC or BQ27220) is
+  measured and reported only.
+
+## 4. Buttons
+
+Configured via the repeatable `binary_inputs` TLV packet (id `0x25`), struct
+`BinaryInputs` (`structs.h:247-268`): up to 4 instances × 8 pins = 32 buttons
+(`MAX_BUTTONS`, `structs.h:400`). Per-pin bitmasks: `input_flags` (active pins),
+`invert` (active-low), `pullups`, `pulldowns`, `power_off_flags`;
+`power_off_hold_sec`; `reserved[12]` spare bytes. Parsed by fixed-size `memcpy`
+(`config_parser.cpp:381-391`) — struct size is ABI.
+
+Runtime:
+- `initButtons()` (`device_control.cpp:551-658`): pinMode with per-pin pull config,
+  `attachInterruptArg(pin, buttonISR, idx, CHANGE)`, 50 ms boot settle that resets
+  `press_count` and discards spurious startup edges. Skips `0xFF` pins and the
+  GT911 touch INT pin.
+- ISR (`device_control.cpp:512-527`, `IRAM_ATTR`): edge-triggered; updates
+  `current_state`, increments 4-bit `press_count` on press, flags
+  `buttonEventPending`.
+- `processButtonEvents()` (`device_control.cpp:420-452`): packs
+  `(button_id | press_count<<3 | state<<7)` into `dynamicreturndata[byte_index]`
+  and re-publishes the BLE advertising MSD. Buttons report to the host; they do
+  not drive local page changes.
+- Power-off: `pollConfiguredPowerOffButtons()` (`device_control.cpp:50-81`) for
+  flagged buttons, `powerButtonPoll()` (`power_latch.cpp:124-145`) for the
+  dedicated `pwr_pin_3` button.
+
+Gaps (pre-feature): no RTC-capability validation of button pins, no
+ext0/ext1/`rtc_gpio_*` usage, and normal buttons never arm a deep-sleep wake —
+only the dedicated latch shutdown button does, and only on the power-off path.
+
+## 5. Variant awareness
+
+A single `TARGET_ESP32` macro covers all ESP32 chips (envs: classic ESP32, S3, C3,
+C6). The only per-chip guards are `#if !defined(CONFIG_IDF_TARGET_ESP32C6)` around
+`gpio_deep_sleep_hold_en()` and `#if SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP` around the
+GPIO wake call in `powerOff()`. Wake-capable pins differ by chip: classic ESP32
+and S2/S3 wake via ext0/ext1 on RTC GPIOs; C3/C6 wake via
+`esp_deep_sleep_enable_gpio_wakeup()` on their low-power GPIO range.
+
+### Wake-capability matrix (verified against arduino-esp32 core 3.3.9)
+
+| Capability | esp32 classic | esp32s3 | esp32c3 | esp32c6 |
+|---|---|---|---|---|
+| ext0 (`SOC_PM_SUPPORT_EXT0_WAKEUP`) | yes | yes | — | — |
+| ext1 (`SOC_PM_SUPPORT_EXT1_WAKEUP`) | yes (ALL_LOW / ANY_HIGH only) | yes (ANY_LOW / ANY_HIGH) | — | yes (+ per-pin mode) |
+| `SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP` | — | — | yes (GPIO0–5) | yes (GPIO0–7) |
+| Wake-valid pins | 0,2,4,12–15,25–27,32–39 | 0–21 | 0–5 | 0–7 |
+
+- `esp_sleep_is_valid_wakeup_gpio(gpio_num_t)` exists unguarded on every chip — the
+  correct runtime capability check (no hand-rolled pin tables needed).
+- `esp_sleep_get_ext1_wakeup_status()` / `esp_sleep_get_gpio_wakeup_status()`
+  identify the waking pin(s); there is **no ext0 status API** (the armed ext0 pin
+  must be remembered in RTC memory).
+- `gpio_deep_sleep_hold_en()` only affects pads on which `gpio_hold_en()` was
+  called, so the power-latch hold cannot freeze other (e.g. wake-button) pads.
+- `CONFIG_ESP_SLEEP_GPIO_ENABLE_INTERNAL_RESISTORS=y` in the shipped sdkconfigs:
+  for C3/C6 GPIO deep-sleep wake, IDF auto-enables the pull opposite the wake level.
+- `ESP_EXT1_WAKEUP_ANY_LOW` does **not exist** on classic ESP32 — multiple
+  active-low wake buttons on classic silicon require ext0 (one pin) alongside
+  ext1 ANY_HIGH for active-high buttons.
+
+### 5.1 Button-wake capability matrix (as implemented in `armButtonWakeSources()`)
+
+| | Classic ESP32 (`esp32-N4`) | ESP32-S2 *(no env; code covers it)* | ESP32-S3 (`esp32-s3-*`) | ESP32-C3 (`esp32-c3-N4/N16`) | ESP32-C6 (`esp32-c6-N4`) | nRF52840 (`nrf52840custom`) |
+|---|---|---|---|---|---|---|
+| **Wake-capable pins** | RTC GPIOs: 0, 2, 4, 12–15, 25–27, 32–39 (18 pins) | GPIO 0–21 (22 pins) | GPIO 0–21 (22 pins) | GPIO 0–5 only (6 pins) | GPIO 0–7 only (8 pins) | n/a — no deep sleep path |
+| **Mechanism firmware uses** | ext1 ANY_HIGH + ext0 | ext1 (one mode) + ext0 | ext1 (one mode) + ext0 | `esp_deep_sleep_enable_gpio_wakeup` | `esp_deep_sleep_enable_gpio_wakeup` (LP GPIO; ext1 exists but unused) | none |
+| **Active-high buttons wakeable** | all (ext1 ANY_HIGH) | all, if HIGH is the larger group; else 1 via ext0 | same as S2 | all on GPIO 0–5 | all on GPIO 0–7 | 0 |
+| **Active-low buttons wakeable** | **1 only** (ext0; classic has no ANY_LOW) | all, if LOW is the larger group; else 1 via ext0 | same as S2 | all on GPIO 0–5 | all on GPIO 0–7 | 0 |
+| **Mixed polarity** | all HIGH + 1 LOW | larger group in full + 1 of the other | same as S2 | both groups in full (two gpio-wake calls — needs hardware confirm) | both groups in full (same caveat) | n/a |
+| **Which pin woke us, in logs** | ext1: status mask; ext0: pin remembered in RTC RAM (`s_ext0WakePin`) | same | same | status mask | status mask | n/a |
+| **Pull handling during sleep** | `rtc_gpio_pullup/pulldown_en` re-asserted per config | same | same | auto: IDF enables the pull opposite the wake level | same as C3 | n/a |
+
+Practical readings:
+
+- **The worst case is classic ESP32 with multiple active-low buttons** — the
+  common wiring (button to GND, internal pullup). Only the lowest-numbered one
+  wakes; the rest are logged as "not armed … timer-only for this button." A
+  classic-ESP32 board needing several wake buttons should wire them
+  active-high (or use an S3).
+- **C3 is the most pin-constrained**: a button on GPIO 6+ can never wake
+  (logged as not wake-capable). C6 extends the window to GPIO 7.
+- **S3 is the most capable** target: 22 wake-capable pins and whole-group wake
+  for either polarity; only a *mixed* population costs anything (the minority
+  polarity gets one ext0 slot).
+- Ceilings before pin capability applies: 32 configured buttons max
+  (`MAX_BUTTONS`), minus exclusions — the latch hold pin (`pwr_pin_2`), the
+  D-FF clock pin (`pwr_pin_3` on D-FF boards), the touch INT pin, and any
+  button held down at sleep entry (skipped for that cycle).
+- On MOSFET-latch boards, `pwr_pin_3` (the power button, active-low) joins the
+  LOW group — on classic ESP32 it competes for the single ext0 slot with any
+  other active-low button (lowest pin number wins).

--- a/docs/loop-flowchart.html
+++ b/docs/loop-flowchart.html
@@ -1,0 +1,886 @@
+<title>loop() Control Flow — ESP32 &amp; nRF</title>
+<style>
+  :root {
+    --bg:        #f4f6f5;
+    --panel:     #ffffff;
+    --ink:       #16201f;
+    --ink-soft:  #4a5654;
+    --ink-faint: #7c8785;
+    --hair:      #dde3e1;
+    --rail:      #c9d2cf;
+
+    --teal:      #0f8f80;
+    --teal-bg:   #e6f4f1;
+    --amber:     #b8730a;
+    --amber-bg:  #fbf0dd;
+    --rose:      #c43a53;
+    --rose-bg:   #fbe6ea;
+    --indigo:    #4f57c9;
+    --indigo-bg: #e9eafb;
+
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg:        #0e1414;
+      --panel:     #141c1b;
+      --ink:       #e7eeec;
+      --ink-soft:  #a7b3b0;
+      --ink-faint: #6f7c79;
+      --hair:      #223029;
+      --rail:      #2c3a37;
+
+      --teal:      #35d6c1;
+      --teal-bg:   #10322d;
+      --amber:     #f0b45e;
+      --amber-bg:  #33260f;
+      --rose:      #fb7185;
+      --rose-bg:   #35141c;
+      --indigo:    #9aa2f5;
+      --indigo-bg: #1c1e3a;
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg:#0e1414; --panel:#141c1b; --ink:#e7eeec; --ink-soft:#a7b3b0; --ink-faint:#6f7c79;
+    --hair:#223029; --rail:#2c3a37;
+    --teal:#35d6c1; --teal-bg:#10322d; --amber:#f0b45e; --amber-bg:#33260f;
+    --rose:#fb7185; --rose-bg:#35141c; --indigo:#9aa2f5; --indigo-bg:#1c1e3a;
+  }
+  :root[data-theme="light"] {
+    --bg:#f4f6f5; --panel:#ffffff; --ink:#16201f; --ink-soft:#4a5654; --ink-faint:#7c8785;
+    --hair:#dde3e1; --rail:#c9d2cf;
+    --teal:#0f8f80; --teal-bg:#e6f4f1; --amber:#b8730a; --amber-bg:#fbf0dd;
+    --rose:#c43a53; --rose-bg:#fbe6ea; --indigo:#4f57c9; --indigo-bg:#e9eafb;
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--sans);
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap {
+    max-width: 980px;
+    margin: 0 auto;
+    padding: clamp(1.5rem, 4vw, 4rem) clamp(1rem, 4vw, 2.5rem) 5rem;
+  }
+
+  /* ---- Masthead ---- */
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: .72rem;
+    letter-spacing: .22em;
+    text-transform: uppercase;
+    color: var(--teal);
+    margin: 0 0 .9rem;
+  }
+  h1 {
+    font-family: var(--mono);
+    font-weight: 600;
+    font-size: clamp(1.7rem, 4.5vw, 2.7rem);
+    line-height: 1.12;
+    letter-spacing: -.01em;
+    text-wrap: balance;
+    margin: 0 0 1rem;
+  }
+  h1 .paren { color: var(--ink-faint); font-weight: 400; }
+  .lede {
+    max-width: 62ch;
+    color: var(--ink-soft);
+    font-size: 1.02rem;
+    margin: 0 0 1.4rem;
+  }
+  .source {
+    font-family: var(--mono);
+    font-size: .82rem;
+    color: var(--ink-soft);
+    display: inline-flex;
+    align-items: center;
+    gap: .5rem;
+    padding: .4rem .7rem;
+    border: 1px solid var(--hair);
+    border-radius: 7px;
+    background: var(--panel);
+  }
+  .source b { color: var(--teal); font-weight: 600; }
+
+  /* ---- Legend ---- */
+  .legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem 1.4rem;
+    margin: 2rem 0 0;
+    padding: 1rem 1.2rem;
+    border: 1px solid var(--hair);
+    border-radius: 10px;
+    background: var(--panel);
+  }
+  .legend .item {
+    display: inline-flex;
+    align-items: center;
+    gap: .55rem;
+    font-family: var(--mono);
+    font-size: .78rem;
+    color: var(--ink-soft);
+  }
+  .swatch { width: 26px; height: 16px; border-radius: 4px; flex: none; border: 1px solid var(--hair); }
+  .sw-step { background: var(--teal-bg); border-color: var(--teal); }
+  .sw-cond { background: var(--amber-bg); border-color: var(--amber); }
+  .sw-exit { background: var(--rose-bg); border-color: var(--rose); }
+  .sw-nrf  { background: var(--indigo-bg); border-color: var(--indigo); }
+
+  /* ---- Section ---- */
+  section { margin-top: 3.4rem; }
+  .sec-head {
+    display: flex;
+    align-items: baseline;
+    gap: .8rem;
+    padding-bottom: .7rem;
+    margin-bottom: 1.6rem;
+    border-bottom: 1px solid var(--hair);
+  }
+  .sec-num {
+    font-family: var(--mono);
+    font-size: .82rem;
+    color: var(--ink-faint);
+  }
+  .sec-head h2 {
+    font-family: var(--mono);
+    font-size: 1.15rem;
+    font-weight: 600;
+    margin: 0;
+    letter-spacing: .01em;
+  }
+  .sec-head .tag {
+    margin-left: auto;
+    font-family: var(--mono);
+    font-size: .68rem;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    padding: .2rem .55rem;
+    border-radius: 5px;
+  }
+  .tag-esp { color: var(--teal); background: var(--teal-bg); }
+  .tag-nrf { color: var(--indigo); background: var(--indigo-bg); }
+  .tag-common { color: var(--ink-soft); background: var(--hair); }
+
+  /* ---- Flow primitives ---- */
+  .flow { display: flex; flex-direction: column; gap: 0; }
+
+  .node {
+    position: relative;
+    border: 1px solid var(--hair);
+    border-left: 3px solid var(--teal);
+    background: var(--panel);
+    border-radius: 9px;
+    padding: .8rem 1rem;
+  }
+  .node + .node { margin-top: 1.3rem; }
+  /* connector between stacked siblings */
+  .node + .node::before,
+  .branchset + .node::before,
+  .node + .branchset::before {
+    content: "";
+    position: absolute;
+    top: -1.3rem;
+    left: 20px;
+    width: 2px;
+    height: 1.3rem;
+    background: var(--rail);
+  }
+  .branchset { position: relative; }
+
+  .node .title {
+    font-family: var(--mono);
+    font-size: .9rem;
+    font-weight: 600;
+    letter-spacing: .01em;
+    display: flex;
+    align-items: baseline;
+    gap: .5rem;
+  }
+  .node .ln {
+    margin-left: auto;
+    font-family: var(--mono);
+    font-size: .68rem;
+    color: var(--ink-faint);
+    font-weight: 400;
+    white-space: nowrap;
+  }
+  .calls {
+    list-style: none;
+    margin: .6rem 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: .28rem;
+  }
+  .calls li {
+    font-family: var(--mono);
+    font-size: .8rem;
+    color: var(--ink-soft);
+    padding-left: 1.1rem;
+    position: relative;
+    line-height: 1.45;
+    word-break: break-word;
+  }
+  .calls li::before {
+    content: "›";
+    position: absolute;
+    left: 0;
+    color: var(--teal);
+  }
+  .calls li.note::before { content: "//"; color: var(--ink-faint); }
+  .calls li.note { color: var(--ink-faint); font-style: italic; }
+
+  /* decision node */
+  .node.cond { border-left-color: var(--amber); }
+  .node.cond .title::before {
+    content: "◆";
+    color: var(--amber);
+    font-size: .78rem;
+  }
+  .node.cond .calls li::before { color: var(--amber); }
+
+  /* exit / return node */
+  .node.exit {
+    border-left-color: var(--rose);
+    border-style: dashed;
+    background: var(--rose-bg);
+  }
+  .node.exit .title { color: var(--rose); }
+  .node.exit .title::before { content: "⏎"; }
+
+  /* nRF-keyed nodes */
+  .path-nrf .node { border-left-color: var(--indigo); }
+  .path-nrf .node .calls li::before { color: var(--indigo); }
+  .path-nrf .node.cond { border-left-color: var(--amber); }
+  .path-nrf .node.cond .calls li::before { color: var(--amber); }
+
+  /* branches */
+  .branches {
+    margin-top: 1.3rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.3rem;
+  }
+  .branch {
+    position: relative;
+    padding-left: 1.4rem;
+    border-left: 2px solid var(--rail);
+    margin-left: 20px;
+  }
+  .branch::before {
+    content: "";
+    position: absolute;
+    top: -1.3rem;
+    left: -2px;
+    width: 2px;
+    height: 1.3rem;
+    background: var(--rail);
+  }
+  .blabel {
+    display: inline-flex;
+    align-items: center;
+    gap: .4rem;
+    font-family: var(--mono);
+    font-size: .7rem;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+    padding: .18rem .55rem;
+    border-radius: 5px;
+    margin-bottom: .9rem;
+  }
+  .blabel.t { color: var(--teal); background: var(--teal-bg); }
+  .blabel.f { color: var(--rose); background: var(--rose-bg); }
+  .blabel.branchcase { color: var(--amber); background: var(--amber-bg); }
+
+  .fallthrough {
+    font-family: var(--mono);
+    font-size: .76rem;
+    color: var(--ink-faint);
+    padding: .5rem 0 0 20px;
+    position: relative;
+  }
+  .fallthrough::before {
+    content: "";
+    position: absolute;
+    top: -1.3rem;
+    left: 20px;
+    width: 2px;
+    height: 1.3rem;
+    background: var(--rail);
+  }
+
+  .loopback {
+    margin-top: 1.3rem;
+    position: relative;
+    font-family: var(--mono);
+    font-size: .78rem;
+    color: var(--ink-faint);
+    padding: .55rem .9rem;
+    border: 1px dashed var(--rail);
+    border-radius: 8px;
+    text-align: center;
+  }
+  .loopback::before {
+    content: "";
+    position: absolute;
+    top: -1.3rem;
+    left: 20px;
+    width: 2px;
+    height: 1.3rem;
+    background: var(--rail);
+  }
+
+  .foot {
+    margin-top: 4rem;
+    padding-top: 1.4rem;
+    border-top: 1px solid var(--hair);
+    color: var(--ink-faint);
+    font-size: .82rem;
+    font-family: var(--mono);
+  }
+
+  a { color: var(--teal); }
+
+  @media (prefers-reduced-motion: no-preference) {
+    section { animation: rise .5s ease both; }
+    @keyframes rise { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+  }
+</style>
+
+<div class="wrap">
+
+  <p class="eyebrow">Firmware · Control-flow reference</p>
+  <h1>loop() <span class="paren">— the main runtime, both targets</span></h1>
+  <p class="lede">
+    A node-by-node chart of the <code>loop()</code> body exactly as written. Scope is the
+    function itself; every callee is treated as opaque and listed inside the box that invokes it.
+    Every conditional in the source appears as a decision node. The function splits at compile
+    time, so both the ESP32 and nRF branches are charted.
+  </p>
+  <span class="source">src/main.cpp <b>L190–357</b></span>
+
+  <div class="legend">
+    <span class="item"><span class="swatch sw-step"></span> Process — function calls / assignments</span>
+    <span class="item"><span class="swatch sw-cond"></span> ◆ Conditional</span>
+    <span class="item"><span class="swatch sw-exit"></span> ⏎ Early return</span>
+    <span class="item"><span class="swatch sw-nrf"></span> nRF-path node</span>
+  </div>
+
+  <!-- ============ COMMON PROLOGUE ============ -->
+  <section>
+    <div class="sec-head">
+      <span class="sec-num">00</span>
+      <h2>Common prologue &amp; target split</h2>
+      <span class="tag tag-common">Both targets</span>
+    </div>
+    <div class="flow">
+      <div class="node">
+        <div class="title">Entry <span class="ln">L191</span></div>
+        <ul class="calls"><li>processLedFlash()</li></ul>
+      </div>
+      <div class="branchset">
+        <div class="node cond">
+          <div class="title">#ifdef TARGET_ESP32 <span class="ln">L192–194</span></div>
+          <ul class="calls"><li class="note">first guard — wraps pollActivity() only</li></ul>
+        </div>
+        <div class="branches">
+          <div class="branch">
+            <span class="blabel branchcase">ESP32</span>
+            <div class="node"><div class="title">pollActivity() <span class="ln">L193</span></div></div>
+          </div>
+          <div class="branch">
+            <span class="blabel branchcase">nRF</span>
+            <div class="fallthrough">(skipped — no call)</div>
+          </div>
+        </div>
+      </div>
+      <div class="branchset">
+        <div class="node cond">
+          <div class="title">#ifdef TARGET_ESP32 <span class="ln">L195 / #else L345</span></div>
+          <ul class="calls"><li class="note">second guard — wraps the entire remaining body</li></ul>
+        </div>
+        <div class="branches">
+          <div class="branch"><span class="blabel branchcase">ESP32</span><div class="fallthrough">→ Section 01</div></div>
+          <div class="branch"><span class="blabel branchcase">nRF</span><div class="fallthrough">→ Section 02</div></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ ESP32 PATH ============ -->
+  <section>
+    <div class="sec-head">
+      <span class="sec-num">01</span>
+      <h2>ESP32 path</h2>
+      <span class="tag tag-esp">TARGET_ESP32</span>
+    </div>
+    <div class="flow">
+
+      <!-- Post-wake advertising window -->
+      <div class="branchset">
+        <div class="node cond">
+          <div class="title">woke_from_deep_sleep &amp;&amp; advertising_timeout_active <span class="ln">L196</span></div>
+        </div>
+        <div class="branches">
+          <div class="branch">
+            <span class="blabel t">true — post-wake window</span>
+            <div class="flow">
+              <div class="branchset">
+                <div class="node cond">
+                  <div class="title">pServer &amp;&amp; getConnectedCount() &gt; 0 <span class="ln">L197</span></div>
+                </div>
+                <div class="branches">
+                  <div class="branch">
+                    <span class="blabel t">true — client connected</span>
+                    <div class="node">
+                      <div class="title">Switch to full mode <span class="ln">L198–201</span></div>
+                      <ul class="calls">
+                        <li>writeSerial("BLE connection established…")</li>
+                        <li>advertising_timeout_active = false</li>
+                        <li>fullSetupAfterConnection()</li>
+                        <li>woke_from_deep_sleep = false</li>
+                      </ul>
+                    </div>
+                    <div class="node exit"><div class="title">return <span class="ln">L202</span></div></div>
+                  </div>
+                  <div class="branch">
+                    <span class="blabel f">false</span>
+                    <div class="flow">
+                      <div class="branchset">
+                        <div class="node cond">
+                          <div class="title">bleRestartAdvertisingPending <span class="ln">L206</span></div>
+                        </div>
+                        <div class="branches">
+                          <div class="branch"><span class="blabel t">true</span>
+                            <div class="node"><div class="title">esp32_restart_ble_advertising() <span class="ln">L207</span></div></div>
+                          </div>
+                          <div class="branch"><span class="blabel f">false</span><div class="fallthrough">(skip)</div></div>
+                        </div>
+                      </div>
+                      <div class="branchset">
+                        <div class="node cond">
+                          <div class="title">advertising_timeout_ms == 0 <span class="ln">L209–210</span></div>
+                          <ul class="calls"><li>advertising_timeout_ms = power_option.sleep_timeout_ms</li></ul>
+                        </div>
+                        <div class="branches">
+                          <div class="branch"><span class="blabel t">true</span>
+                            <div class="node"><div class="title">= DEFAULT_IDLE_HOLD_MS <span class="ln">L211</span></div></div>
+                          </div>
+                          <div class="branch"><span class="blabel f">false</span><div class="fallthrough">(keep configured value)</div></div>
+                        </div>
+                      </div>
+                      <div class="branchset">
+                        <div class="node cond">
+                          <div class="title">idle_duration &gt;= advertising_timeout_ms <span class="ln">L215–216</span></div>
+                          <ul class="calls"><li>idle_duration = millis() − lastActivityMs</li></ul>
+                        </div>
+                        <div class="branches">
+                          <div class="branch">
+                            <span class="blabel t">true — window expired</span>
+                            <div class="node">
+                              <div class="title">Return to deep sleep <span class="ln">L217–220</span></div>
+                              <ul class="calls">
+                                <li>writeSerial("BLE advertising timeout…")</li>
+                                <li>advertising_timeout_active = false</li>
+                                <li>enterDeepSleep()</li>
+                              </ul>
+                            </div>
+                            <div class="node exit"><div class="title">return <span class="ln">L221</span></div></div>
+                          </div>
+                          <div class="branch">
+                            <span class="blabel f">false — window still open</span>
+                            <div class="node"><div class="title">delay(50) <span class="ln">L223</span></div></div>
+                            <div class="node exit"><div class="title">return <span class="ln">L224</span></div></div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="branch">
+            <span class="blabel f">false — normal servicing</span>
+
+            <div class="flow">
+              <!-- command queue -->
+              <div class="branchset">
+                <div class="node cond">
+                  <div class="title">commandQueueTail != commandQueueHead <span class="ln">L226</span></div>
+                </div>
+                <div class="branches">
+                  <div class="branch"><span class="blabel t">true — process one command</span>
+                    <div class="node">
+                      <div class="title">Dequeue &amp; apply <span class="ln">L227–232</span></div>
+                      <ul class="calls">
+                        <li>imageWriteLogQuietFrame(…)</li>
+                        <li>writeSerial("Processing queued command") <span>[if !quietCmd]</span></li>
+                        <li>imageDataWritten(…)</li>
+                        <li>pending = false; advance tail</li>
+                        <li>writeSerial("Command processed") <span>[if !quietCmd]</span></li>
+                      </ul>
+                    </div>
+                  </div>
+                  <div class="branch"><span class="blabel f">false</span><div class="fallthrough">(skip)</div></div>
+                </div>
+              </div>
+
+              <!-- response queue -->
+              <div class="branchset">
+                <div class="node cond">
+                  <div class="title">responseQueueTail != responseQueueHead <span class="ln">L234</span></div>
+                </div>
+                <div class="branches">
+                  <div class="branch">
+                    <span class="blabel t">true</span>
+                    <div class="branchset">
+                      <div class="node cond">
+                        <div class="title">esp32_ble_notify_enabled() <span class="ln">L235</span></div>
+                      </div>
+                      <div class="branches">
+                        <div class="branch"><span class="blabel branchcase">notify enabled</span>
+                          <div class="node">
+                            <div class="title">Drain up to 16 responses <span class="ln">L237–245</span></div>
+                            <ul class="calls">
+                              <li class="note">while queue not empty &amp;&amp; bleDrain &lt; 16:</li>
+                              <li>imageWriteLogQuietFrame(…)</li>
+                              <li>writeSerial("Sending queued response") <span>[if !quietAck]</span></li>
+                              <li>pTxCharacteristic-&gt;setValue(…)</li>
+                              <li>pTxCharacteristic-&gt;notify()</li>
+                              <li>pending = false; advance tail</li>
+                            </ul>
+                          </div>
+                        </div>
+                        <div class="branch"><span class="blabel branchcase">else-if: connected, CCCD off <span class="ln">L247</span></span>
+                          <div class="node"><div class="title">Keep responses queued</div>
+                            <ul class="calls"><li class="note">no-op — wait for notify enable</li></ul>
+                          </div>
+                        </div>
+                        <div class="branch"><span class="blabel branchcase">else: not connected <span class="ln">L249</span></span>
+                          <div class="node"><div class="title">Discard queue <span class="ln">L250–253</span></div>
+                            <ul class="calls"><li class="note">while not empty: pending=false; advance tail</li></ul>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="branch"><span class="blabel f">false</span><div class="fallthrough">(skip)</div></div>
+                </div>
+              </div>
+
+              <!-- restart advertising -->
+              <div class="branchset">
+                <div class="node cond">
+                  <div class="title">bleRestartAdvertisingPending <span class="ln">L256</span></div>
+                </div>
+                <div class="branches">
+                  <div class="branch"><span class="blabel t">true</span>
+                    <div class="node"><div class="title">esp32_restart_ble_advertising() <span class="ln">L257</span></div></div>
+                  </div>
+                  <div class="branch"><span class="blabel f">false</span><div class="fallthrough">(skip)</div></div>
+                </div>
+              </div>
+
+              <!-- direct write timeout -->
+              <div class="branchset">
+                <div class="node cond">
+                  <div class="title">directWriteActive &amp;&amp; directWriteStartTime &gt; 0 <span class="ln">L259</span></div>
+                </div>
+                <div class="branches">
+                  <div class="branch"><span class="blabel t">true</span>
+                    <div class="branchset">
+                      <div class="node cond">
+                        <div class="title">directWriteDuration &gt; 900000 ms <span class="ln">L261</span></div>
+                      </div>
+                      <div class="branches">
+                        <div class="branch"><span class="blabel t">true — stuck</span>
+                          <div class="node"><div class="title">Clean up stuck state <span class="ln">L262–263</span></div>
+                            <ul class="calls">
+                              <li>writeSerial("ERROR: Direct write timeout…")</li>
+                              <li>cleanupDirectWriteState(true)</li>
+                            </ul>
+                          </div>
+                        </div>
+                        <div class="branch"><span class="blabel f">false</span><div class="fallthrough">(skip)</div></div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="branch"><span class="blabel f">false</span><div class="fallthrough">(skip)</div></div>
+                </div>
+              </div>
+
+              <!-- housekeeping -->
+              <div class="node">
+                <div class="title">Housekeeping <span class="ln">L266–269</span></div>
+                <ul class="calls">
+                  <li>checkPartialWriteTimeout()</li>
+                  <li>handleWiFiServer()</li>
+                </ul>
+              </div>
+
+              <!-- wifi maintenance -->
+              <div class="branchset">
+                <div class="node cond">
+                  <div class="title">wifiInitialized &amp;&amp; (millis() − lastWiFiCheck &gt; 10000) <span class="ln">L271</span></div>
+                </div>
+                <div class="branches">
+                  <div class="branch">
+                    <span class="blabel t">true — 10 s tick</span>
+                    <div class="branchset">
+                      <div class="node cond">
+                        <div class="title">WiFi.status() != WL_CONNECTED &amp;&amp; wifiConnected <span class="ln">L273</span></div>
+                      </div>
+                      <div class="branches">
+                        <div class="branch"><span class="blabel branchcase">connection lost</span>
+                          <div class="node"><div class="title">Mark down <span class="ln">L274–278</span></div>
+                            <ul class="calls">
+                              <li>writeSerial("WiFi connection lost…")</li>
+                              <li>wifiConnected = false</li>
+                              <li class="note">if wifiServerConnected → disconnectWiFiServer()</li>
+                            </ul>
+                          </div>
+                        </div>
+                        <div class="branch"><span class="blabel branchcase">else-if: reconnected <span class="ln">L279</span></span>
+                          <div class="node"><div class="title">Mark up <span class="ln">L280–282</span></div>
+                            <ul class="calls">
+                              <li>writeSerial("WiFi reconnected…")</li>
+                              <li>wifiConnected = true</li>
+                              <li>restartWiFiLanAfterReconnect()</li>
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="branch"><span class="blabel f">false</span><div class="fallthrough">(skip)</div></div>
+                </div>
+              </div>
+
+              <!-- workInFlight compute -->
+              <div class="node">
+                <div class="title">Compute idle gate <span class="ln">L286–298</span></div>
+                <ul class="calls">
+                  <li>wifiLanSession = wifiInitialized &amp;&amp; wifiServerConnected &amp;&amp; wifiClient.connected()</li>
+                  <li class="note">workInFlight = cmd-queue || resp-queue || connected ||</li>
+                  <li class="note">bleRestartAdvertisingPending || epdRefreshInProgress || wifiLanSession</li>
+                </ul>
+              </div>
+
+              <!-- workInFlight decision -->
+              <div class="branchset">
+                <div class="node cond">
+                  <div class="title">workInFlight <span class="ln">L299</span></div>
+                </div>
+                <div class="branches">
+                  <div class="branch">
+                    <span class="blabel t">true — stay awake, spin</span>
+                    <div class="node"><div class="title">Service inputs <span class="ln">L300–302</span></div>
+                      <ul class="calls">
+                        <li>processButtonEvents()</li>
+                        <li>processTouchInput()</li>
+                        <li>delay(1)</li>
+                      </ul>
+                    </div>
+                  </div>
+
+                  <div class="branch">
+                    <span class="blabel f">false — idle / sleep candidate</span>
+                    <div class="flow">
+
+                      <!-- first boot delay -->
+                      <div class="branchset">
+                        <div class="node cond">
+                          <div class="title">!woke_from_deep_sleep &amp;&amp; deep_sleep_count == 0 &amp;&amp; power_mode == 1 <span class="ln">L304</span></div>
+                        </div>
+                        <div class="branches">
+                          <div class="branch">
+                            <span class="blabel t">true — first-boot grace</span>
+                            <div class="flow">
+                              <div class="branchset">
+                                <div class="node cond">
+                                  <div class="title">!firstBootDelayInitialized <span class="ln">L305</span></div>
+                                </div>
+                                <div class="branches">
+                                  <div class="branch"><span class="blabel t">true — arm timer</span>
+                                    <div class="node"><div class="title">Start grace window <span class="ln">L306–309</span></div>
+                                      <ul class="calls">
+                                        <li>firstBootDelayInitialized = true</li>
+                                        <li>firstBootDelayStart = millis()</li>
+                                        <li>processButtonEvents()</li>
+                                        <li>writeSerial("First boot: waiting 2 minutes…")</li>
+                                      </ul>
+                                    </div>
+                                  </div>
+                                  <div class="branch"><span class="blabel f">false</span><div class="fallthrough">(already armed)</div></div>
+                                </div>
+                              </div>
+                              <div class="branchset">
+                                <div class="node cond">
+                                  <div class="title">elapsed &lt; FIRST_BOOT_DEEP_SLEEP_DELAY_MS <span class="ln">L311–312</span></div>
+                                  <ul class="calls"><li>elapsed = millis() − firstBootDelayStart</li></ul>
+                                </div>
+                                <div class="branches">
+                                  <div class="branch">
+                                    <span class="blabel t">true — still in grace</span>
+                                    <div class="node"><div class="title">idleDelay(5) <span class="ln">L313</span></div></div>
+                                    <div class="node exit"><div class="title">return <span class="ln">L314</span></div></div>
+                                  </div>
+                                  <div class="branch">
+                                    <span class="blabel f">false — grace elapsed</span>
+                                    <div class="branchset">
+                                      <div class="node cond"><div class="title">!firstBootDelayElapsed <span class="ln">L316</span></div></div>
+                                      <div class="branches">
+                                        <div class="branch"><span class="blabel t">true</span>
+                                          <div class="node"><div class="title">Log once <span class="ln">L317–318</span></div>
+                                            <ul class="calls">
+                                              <li>firstBootDelayElapsed = true</li>
+                                              <li>writeSerial("…deep sleep permitted")</li>
+                                            </ul>
+                                          </div>
+                                        </div>
+                                        <div class="branch"><span class="blabel f">false</span><div class="fallthrough">(skip)</div></div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div class="branch"><span class="blabel f">false</span><div class="fallthrough">(skip grace)</div></div>
+                        </div>
+                      </div>
+
+                      <!-- deep sleep decision -->
+                      <div class="branchset">
+                        <div class="node cond">
+                          <div class="title">deep_sleep_time_seconds &gt; 0 &amp;&amp; power_mode == 1 <span class="ln">L321</span></div>
+                        </div>
+                        <div class="branches">
+                          <div class="branch">
+                            <span class="blabel t">true — deep-sleep enabled</span>
+                            <div class="flow">
+                              <div class="node">
+                                <div class="title">Measure idle <span class="ln">L322–326</span></div>
+                                <ul class="calls">
+                                  <li>idleHoldMs = sleep_timeout_ms (0 → DEFAULT_IDLE_HOLD_MS)</li>
+                                  <li>idleMs = millis() − lastActivityMs</li>
+                                </ul>
+                              </div>
+                              <div class="branchset">
+                                <div class="node cond"><div class="title">idleMs &lt; idleHoldMs <span class="ln">L327</span></div></div>
+                                <div class="branches">
+                                  <div class="branch"><span class="blabel t">true — still within hold</span>
+                                    <div class="node"><div class="title">idleDelay(5) <span class="ln">L328</span></div></div>
+                                  </div>
+                                  <div class="branch"><span class="blabel f">false — quiet window met</span>
+                                    <div class="node"><div class="title">Sleep <span class="ln">L330–331</span></div>
+                                      <ul class="calls">
+                                        <li>writeSerial("Idle … entering deep sleep")</li>
+                                        <li>enterDeepSleep()</li>
+                                      </ul>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div class="branch">
+                            <span class="blabel f">false — sleep disabled</span>
+                            <div class="node"><div class="title">idleDelay(2000) <span class="ln">L335</span></div></div>
+                          </div>
+                        </div>
+                      </div>
+
+                      <!-- msdata + inputs -->
+                      <div class="branchset">
+                        <div class="node cond">
+                          <div class="title">millis() − lastMsdUpdate &gt;= 60000 <span class="ln">L338</span></div>
+                        </div>
+                        <div class="branches">
+                          <div class="branch"><span class="blabel t">true — once a minute</span>
+                            <div class="node"><div class="title">Refresh telemetry <span class="ln">L339–340</span></div>
+                              <ul class="calls">
+                                <li>lastMsdUpdate = millis()</li>
+                                <li>updatemsdata()</li>
+                              </ul>
+                            </div>
+                          </div>
+                          <div class="branch"><span class="blabel f">false</span><div class="fallthrough">(skip)</div></div>
+                        </div>
+                      </div>
+                      <div class="node">
+                        <div class="title">Service inputs <span class="ln">L342–343</span></div>
+                        <ul class="calls">
+                          <li>processButtonEvents()</li>
+                          <li>processTouchInput()</li>
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="loopback">↺ end of loop() → Arduino core re-enters</div>
+    </div>
+  </section>
+
+  <!-- ============ nRF PATH ============ -->
+  <section class="path-nrf">
+    <div class="sec-head">
+      <span class="sec-num">02</span>
+      <h2>nRF path <span class="ln"></span></h2>
+      <span class="tag tag-nrf">#else — TARGET_NRF</span>
+    </div>
+    <div class="flow">
+      <div class="branchset">
+        <div class="node cond">
+          <div class="title">power_option.sleep_timeout_ms &gt; 0 <span class="ln">L346</span></div>
+        </div>
+        <div class="branches">
+          <div class="branch">
+            <span class="blabel t">true</span>
+            <div class="node"><div class="title">Idle + telemetry <span class="ln">L347–348</span></div>
+              <ul class="calls">
+                <li>idleDelay(sleep_timeout_ms)</li>
+                <li>updatemsdata()</li>
+              </ul>
+            </div>
+          </div>
+          <div class="branch">
+            <span class="blabel f">false</span>
+            <div class="node"><div class="title">idleDelay(500) <span class="ln">L351</span></div></div>
+          </div>
+        </div>
+      </div>
+      <div class="node">
+        <div class="title">Tick radio &amp; inputs <span class="ln">L353–355</span></div>
+        <ul class="calls">
+          <li>ble_nrf_advertising_tick()</li>
+          <li>processButtonEvents()</li>
+          <li>processTouchInput()</li>
+        </ul>
+      </div>
+      <div class="loopback">↺ end of loop() → Arduino core re-enters</div>
+    </div>
+  </section>
+
+  <p class="foot">
+    Charted from src/main.cpp L190–357 · callees opaque · ESP32 has four early returns
+    (L202, L221, L224, L314); the nRF path has none and no in-loop deep-sleep logic.
+  </p>
+
+</div>

--- a/docs/loop-flowchart.md
+++ b/docs/loop-flowchart.md
@@ -1,0 +1,175 @@
+# `loop()` Control-Flow Analysis
+
+**Source:** [src/main.cpp:190-357](../src/main.cpp#L190-L357)
+
+This document charts the control flow of `loop()` exactly as written, limited to the
+`loop()` body itself (functions it calls are treated as opaque). The function is split
+at compile time: a small common prologue, followed by a large `#ifdef TARGET_ESP32`
+block and an `#else` nRF block. Both compile-time paths are shown.
+
+Every branching conditional in the source is represented as a decision node, and every
+function call is listed inside the box where it occurs.
+
+---
+
+## Legend
+
+- **Rectangles** = straight-line work (function calls / assignments listed inside).
+- **Diamonds** = conditionals (each `if` / `else if` / `while` guard in the source).
+- **`return`** nodes exit `loop()` early (control returns to the Arduino main loop, which
+  immediately re-enters `loop()`).
+- Compile-time branches (`#ifdef`) are drawn as decision nodes labelled *(compile-time)*.
+
+---
+
+## Common prologue + top-level target split
+
+```mermaid
+flowchart TD
+    START([loop entry]) --> P1["processLedFlash()"]
+    P1 --> CT1{"#ifdef TARGET_ESP32<br/>(compile-time)"}
+    CT1 -- ESP32 --> POLL["pollActivity()"]
+    POLL --> CT2{"#ifdef TARGET_ESP32<br/>(compile-time)"}
+    CT1 -- nRF --> CT2
+    CT2 -- ESP32 --> ESP32_ENTRY([ESP32 path])
+    CT2 -- nRF --> NRF_ENTRY([nRF path])
+```
+
+Note: there are two separate `#ifdef TARGET_ESP32` guards in a row. The first wraps only
+`pollActivity()`; the second wraps the entire remaining body versus the nRF `#else`.
+
+---
+
+## ESP32 path
+
+```mermaid
+flowchart TD
+    ESP32_ENTRY([ESP32 path]) --> A{"woke_from_deep_sleep<br/>&& advertising_timeout_active ?"}
+
+    %% ---- Post-wake advertising window ----
+    A -- true --> A1{"pServer &&<br/>getConnectedCount() > 0 ?"}
+    A1 -- true --> A1a["writeSerial(...)<br/>advertising_timeout_active = false<br/>fullSetupAfterConnection()<br/>woke_from_deep_sleep = false"]
+    A1a --> RET1([return])
+    A1 -- false --> A2{"bleRestartAdvertisingPending ?"}
+    A2 -- true --> A2a["esp32_restart_ble_advertising()"]
+    A2 -- false --> A3
+    A2a --> A3["advertising_timeout_ms =<br/>power_option.sleep_timeout_ms"]
+    A3 --> A4{"advertising_timeout_ms == 0 ?"}
+    A4 -- true --> A4a["advertising_timeout_ms =<br/>DEFAULT_IDLE_HOLD_MS"]
+    A4 -- false --> A5
+    A4a --> A5["idle_duration =<br/>millis() - lastActivityMs"]
+    A5 --> A6{"idle_duration >=<br/>advertising_timeout_ms ?"}
+    A6 -- true --> A6a["writeSerial(...)<br/>advertising_timeout_active = false<br/>enterDeepSleep()"]
+    A6a --> RET2([return])
+    A6 -- false --> A6b["delay(50)"]
+    A6b --> RET3([return])
+
+    %% ---- Normal ESP32 servicing ----
+    A -- false --> B{"commandQueueTail !=<br/>commandQueueHead ?"}
+    B -- true --> B1["imageWriteLogQuietFrame(...)<br/>writeSerial(...) [if !quietCmd]<br/>imageDataWritten(...)<br/>pending = false; advance tail<br/>writeSerial('Command processed') [if !quietCmd]"]
+    B -- false --> C
+    B1 --> C{"responseQueueTail !=<br/>responseQueueHead ?"}
+
+    C -- true --> C1{"esp32_ble_notify_enabled() ?"}
+    C1 -- true --> C1a["while (queue not empty && drain < 16):<br/>imageWriteLogQuietFrame(...)<br/>writeSerial(...) [if !quietAck]<br/>pTxCharacteristic->setValue(...)<br/>pTxCharacteristic->notify()<br/>pending = false; advance tail"]
+    C1 -- false --> C2{"pServer &&<br/>getConnectedCount() > 0 ?"}
+    C2 -- true --> C2a["(keep responses queued —<br/>CCCD not enabled yet)"]
+    C2 -- false --> C2b["while (queue not empty):<br/>pending = false; advance tail<br/>(discard responses)"]
+    C -- false --> D
+    C1a --> D
+    C2a --> D
+    C2b --> D
+
+    D{"bleRestartAdvertisingPending ?"}
+    D -- true --> D1["esp32_restart_ble_advertising()"]
+    D -- false --> E
+    D1 --> E{"directWriteActive &&<br/>directWriteStartTime > 0 ?"}
+
+    E -- true --> E1{"directWriteDuration<br/>> 900000 ms ?"}
+    E1 -- true --> E1a["writeSerial(ERROR ...)<br/>cleanupDirectWriteState(true)"]
+    E1 -- false --> F
+    E1a --> F
+    E -- false --> F
+
+    F["checkPartialWriteTimeout()<br/>handleWiFiServer()"]
+    F --> G{"wifiInitialized &&<br/>(millis() - lastWiFiCheck > 10000) ?"}
+    G -- true --> G1{"WiFi.status() != WL_CONNECTED<br/>&& wifiConnected ?"}
+    G1 -- true --> G1a["writeSerial(...)<br/>wifiConnected = false"]
+    G1a --> G1b{"wifiServerConnected ?"}
+    G1b -- true --> G1c["disconnectWiFiServer()"]
+    G1b -- false --> H
+    G1c --> H
+    G1 -- false --> G2{"WiFi.status() == WL_CONNECTED<br/>&& !wifiConnected ?"}
+    G2 -- true --> G2a["writeSerial(...)<br/>wifiConnected = true<br/>restartWiFiLanAfterReconnect()"]
+    G2 -- false --> H
+    G2a --> H
+    G -- false --> H
+
+    H["wifiLanSession = wifiInitialized &&<br/>wifiServerConnected && wifiClient.connected()<br/>workInFlight = (cmd queue) || (resp queue) ||<br/>(connected) || bleRestartAdvertisingPending ||<br/>epdRefreshInProgress || wifiLanSession"]
+    H --> J{"workInFlight ?"}
+
+    J -- true --> J1["processButtonEvents()<br/>processTouchInput()<br/>delay(1)"]
+    J1 --> ESP_END([end of loop])
+
+    J -- false --> K{"!woke_from_deep_sleep &&<br/>deep_sleep_count == 0 &&<br/>power_mode == 1 ?"}
+    K -- true --> K1{"!firstBootDelayInitialized ?"}
+    K1 -- true --> K1a["firstBootDelayInitialized = true<br/>firstBootDelayStart = millis()<br/>processButtonEvents()<br/>writeSerial('First boot: waiting 2 min ...')"]
+    K1 -- false --> K2
+    K1a --> K2["elapsed = millis() - firstBootDelayStart"]
+    K2 --> K3{"elapsed <<br/>FIRST_BOOT_DEEP_SLEEP_DELAY_MS ?"}
+    K3 -- true --> K3a["idleDelay(5)"]
+    K3a --> RET4([return])
+    K3 -- false --> K4{"!firstBootDelayElapsed ?"}
+    K4 -- true --> K4a["firstBootDelayElapsed = true<br/>writeSerial('...deep sleep permitted')"]
+    K4 -- false --> L
+    K4a --> L
+    K -- false --> L
+
+    L{"deep_sleep_time_seconds > 0 &&<br/>power_mode == 1 ?"}
+    L -- true --> L1["idleHoldMs = sleep_timeout_ms<br/>(if 0 -> DEFAULT_IDLE_HOLD_MS)<br/>idleMs = millis() - lastActivityMs"]
+    L1 --> L2{"idleMs < idleHoldMs ?"}
+    L2 -- true --> L2a["idleDelay(5)"]
+    L2 -- false --> L2b["writeSerial('Idle ... entering deep sleep')<br/>enterDeepSleep()"]
+    L2a --> M
+    L2b --> M
+    L -- false --> L3["idleDelay(2000)"]
+    L3 --> M
+
+    M{"millis() - lastMsdUpdate<br/>>= 60000 ?"}
+    M -- true --> M1["lastMsdUpdate = millis()<br/>updatemsdata()"]
+    M1 --> N
+    M -- false --> N
+    N["processButtonEvents()<br/>processTouchInput()"]
+    N --> ESP_END
+```
+
+---
+
+## nRF path (`#else`)
+
+```mermaid
+flowchart TD
+    NRF_ENTRY([nRF path]) --> NA{"power_option.sleep_timeout_ms > 0 ?"}
+    NA -- true --> NA1["idleDelay(sleep_timeout_ms)<br/>updatemsdata()"]
+    NA -- false --> NA2["idleDelay(500)"]
+    NA1 --> NB
+    NA2 --> NB
+    NB["ble_nrf_advertising_tick()<br/>processButtonEvents()<br/>processTouchInput()"]
+    NB --> NRF_END([end of loop])
+```
+
+---
+
+## Notes on the two paths
+
+- **Common code** before the split: `processLedFlash()` (always), then `pollActivity()`
+  (ESP32 only).
+- The **ESP32 path** is the bulk of `loop()`: a post-wake BLE advertising window, BLE
+  command/response queue servicing, WiFi/LAN maintenance, a `workInFlight` gate, and the
+  deep-sleep decision (first-boot delay + idle quiet-window hold).
+- The **nRF path** is minimal: an idle delay, optional `updatemsdata()`, then a BLE
+  advertising tick and input polling. It has no deep-sleep logic in `loop()` and no BLE
+  queue servicing here.
+- **Early `return`s** (ESP32 only) occur at: BLE connection established post-wake,
+  advertising-window timeout to deep sleep, advertising window still open (`delay(50)`),
+  and during the first-boot delay (`idleDelay(5)`).

--- a/docs/loop-functions.html
+++ b/docs/loop-functions.html
@@ -1,0 +1,449 @@
+<title>loop() Callees — Function Reference</title>
+<style>
+  :root {
+    --bg:#f4f6f5; --panel:#ffffff; --ink:#16201f; --ink-soft:#4a5654; --ink-faint:#7c8785;
+    --hair:#dde3e1; --rail:#c9d2cf;
+    --teal:#0f8f80; --teal-bg:#e6f4f1;
+    --amber:#b8730a; --amber-bg:#fbf0dd;
+    --rose:#c43a53; --rose-bg:#fbe6ea;
+    --indigo:#4f57c9; --indigo-bg:#e9eafb;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg:#0e1414; --panel:#141c1b; --ink:#e7eeec; --ink-soft:#a7b3b0; --ink-faint:#6f7c79;
+      --hair:#223029; --rail:#2c3a37;
+      --teal:#35d6c1; --teal-bg:#10322d; --amber:#f0b45e; --amber-bg:#33260f;
+      --rose:#fb7185; --rose-bg:#35141c; --indigo:#9aa2f5; --indigo-bg:#1c1e3a;
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg:#0e1414; --panel:#141c1b; --ink:#e7eeec; --ink-soft:#a7b3b0; --ink-faint:#6f7c79;
+    --hair:#223029; --rail:#2c3a37;
+    --teal:#35d6c1; --teal-bg:#10322d; --amber:#f0b45e; --amber-bg:#33260f;
+    --rose:#fb7185; --rose-bg:#35141c; --indigo:#9aa2f5; --indigo-bg:#1c1e3a;
+  }
+  :root[data-theme="light"] {
+    --bg:#f4f6f5; --panel:#ffffff; --ink:#16201f; --ink-soft:#4a5654; --ink-faint:#7c8785;
+    --hair:#dde3e1; --rail:#c9d2cf;
+    --teal:#0f8f80; --teal-bg:#e6f4f1; --amber:#b8730a; --amber-bg:#fbf0dd;
+    --rose:#c43a53; --rose-bg:#fbe6ea; --indigo:#4f57c9; --indigo-bg:#e9eafb;
+  }
+
+  * { box-sizing: border-box; }
+  body { margin:0; background:var(--bg); color:var(--ink); font-family:var(--sans);
+    line-height:1.6; -webkit-font-smoothing:antialiased; }
+  .wrap { max-width:1040px; margin:0 auto; padding:clamp(1.5rem,4vw,4rem) clamp(1rem,4vw,2.5rem) 5rem; }
+
+  .eyebrow { font-family:var(--mono); font-size:.72rem; letter-spacing:.22em;
+    text-transform:uppercase; color:var(--teal); margin:0 0 .9rem; }
+  h1 { font-family:var(--mono); font-weight:600; font-size:clamp(1.7rem,4.5vw,2.6rem);
+    line-height:1.14; letter-spacing:-.01em; text-wrap:balance; margin:0 0 1rem; }
+  h1 .paren { color:var(--ink-faint); font-weight:400; }
+  .lede { max-width:64ch; color:var(--ink-soft); font-size:1.02rem; margin:0 0 1.5rem; }
+  .source { font-family:var(--mono); font-size:.82rem; color:var(--ink-soft);
+    display:inline-flex; align-items:center; gap:.5rem; padding:.4rem .7rem;
+    border:1px solid var(--hair); border-radius:7px; background:var(--panel); }
+  .source b { color:var(--teal); font-weight:600; }
+
+  .legend { display:flex; flex-wrap:wrap; gap:.5rem 1.4rem; margin:1.6rem 0 0;
+    padding:.9rem 1.2rem; border:1px solid var(--hair); border-radius:10px; background:var(--panel); }
+  .legend .item { display:inline-flex; align-items:center; gap:.55rem;
+    font-family:var(--mono); font-size:.78rem; color:var(--ink-soft); }
+  .badge { font-family:var(--mono); font-size:.66rem; letter-spacing:.08em; text-transform:uppercase;
+    padding:.16rem .5rem; border-radius:5px; white-space:nowrap; font-weight:600; }
+  .b-esp { color:var(--teal); background:var(--teal-bg); }
+  .b-nrf { color:var(--indigo); background:var(--indigo-bg); }
+  .b-both { color:var(--ink-soft); background:var(--hair); }
+
+  section { margin-top:3rem; }
+  .sec-head { display:flex; align-items:baseline; gap:.8rem; padding-bottom:.6rem;
+    margin-bottom:1.3rem; border-bottom:1px solid var(--hair); }
+  .sec-num { font-family:var(--mono); font-size:.82rem; color:var(--ink-faint); }
+  .sec-head h2 { font-family:var(--mono); font-size:1.12rem; font-weight:600; margin:0; letter-spacing:.01em; }
+  .sec-head .count { margin-left:auto; font-family:var(--mono); font-size:.72rem; color:var(--ink-faint); }
+
+  .grid { display:flex; flex-direction:column; gap:1rem; }
+  .fn { border:1px solid var(--hair); border-left:3px solid var(--teal); background:var(--panel);
+    border-radius:9px; padding:1rem 1.15rem; }
+  .fn.nrf { border-left-color:var(--indigo); }
+  .fn.both { border-left-color:var(--rail); }
+  .fn-top { display:flex; flex-wrap:wrap; align-items:baseline; gap:.6rem .8rem; }
+  .fn-name { font-family:var(--mono); font-size:.98rem; font-weight:600; color:var(--ink); }
+  .fn-name .args { color:var(--ink-faint); font-weight:400; }
+  .fn-loc { font-family:var(--mono); font-size:.72rem; color:var(--ink-faint); }
+  .fn-loc a { color:var(--ink-faint); text-decoration:none; border-bottom:1px dotted var(--rail); }
+  .fn-badges { margin-left:auto; display:inline-flex; gap:.4rem; }
+  .fn-desc { margin:.7rem 0 0; color:var(--ink-soft); font-size:.93rem; }
+  .fn-desc b { color:var(--ink); font-weight:600; }
+  .fn-note { margin:.55rem 0 0; font-family:var(--mono); font-size:.76rem; color:var(--amber);
+    background:var(--amber-bg); border-radius:6px; padding:.4rem .6rem; display:inline-block; }
+  code { font-family:var(--mono); font-size:.86em; background:var(--hair);
+    padding:.05rem .3rem; border-radius:4px; }
+
+  .foot { margin-top:3.5rem; padding-top:1.3rem; border-top:1px solid var(--hair);
+    color:var(--ink-faint); font-size:.82rem; font-family:var(--mono); }
+
+  @media (prefers-reduced-motion: no-preference) {
+    section { animation:rise .5s ease both; }
+    @keyframes rise { from{opacity:0; transform:translateY(8px);} to{opacity:1; transform:none;} }
+  }
+</style>
+
+<div class="wrap">
+  <p class="eyebrow">Firmware · loop() call reference</p>
+  <h1>What each function in <span class="paren">loop()</span> does</h1>
+  <p class="lede">
+    Every function invoked from the <code>loop()</code> body, grouped by subsystem. For each:
+    where it lives, which build it runs on, and what it actually does — including the side effects
+    and guards that matter when reasoning about the main loop. Standard Arduino core calls
+    (<code>millis()</code>, <code>delay()</code>) and raw BLE library methods
+    (<code>setValue()</code>/<code>notify()</code>) are noted inline rather than catalogued.
+  </p>
+  <span class="source">Callees of loop() · src/main.cpp <b>L190–357</b></span>
+
+  <div class="legend">
+    <span class="item"><span class="badge b-esp">ESP32</span> ESP32-only path</span>
+    <span class="item"><span class="badge b-nrf">nRF</span> nRF-only path</span>
+    <span class="item"><span class="badge b-both">Both</span> compiled on both targets</span>
+  </div>
+
+  <!-- ============ POWER & SLEEP ============ -->
+  <section>
+    <div class="sec-head">
+      <span class="sec-num">01</span>
+      <h2>Power &amp; sleep lifecycle</h2>
+      <span class="count">4 functions</span>
+    </div>
+    <div class="grid">
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">pollActivity<span class="args">()</span></span>
+          <span class="fn-loc"><a href="../src/main.cpp#L144">main.cpp:144</a></span>
+          <span class="fn-badges"><span class="badge b-esp">ESP32</span></span>
+        </div>
+        <p class="fn-desc">
+          Runs first on every ESP32 pass. Compares BLE queue heads, connection count, LAN-session
+          state, the dynamic advertising payload, and the <code>bleRestartAdvertisingPending</code>
+          flag against their previous values; if <b>anything changed — or work is simply in
+          flight — it stamps <code>lastActivityMs = millis()</code></b>. That timestamp is the sole
+          input to the deep-sleep quiet window, so this function is what keeps the device awake
+          while it's busy.
+        </p>
+        <p class="fn-note">Edge-detects connect+drop blips that leave connCount at 0 on both sides.</p>
+      </div>
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">enterDeepSleep<span class="args">(bool force = false)</span></span>
+          <span class="fn-loc"><a href="../src/main.cpp#L399">main.cpp:399</a></span>
+          <span class="fn-badges"><span class="badge b-esp">ESP32</span></span>
+        </div>
+        <p class="fn-desc">
+          Puts the ESP32 into timer-wake deep sleep. <b>Bails early</b> if not battery-powered
+          (<code>power_mode != 1</code>), if <code>deep_sleep_time_seconds == 0</code>, or — unless
+          <code>force</code> — if a BLE client is connected (re-checked here to avoid tearing down a
+          live link). Otherwise sets <code>woke_from_deep_sleep</code>, stops advertising,
+          deinits the BLE stack, arms the wake timer, latches power for sleep, and calls
+          <code>esp_deep_sleep_start()</code> — which does not return.
+        </p>
+      </div>
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">fullSetupAfterConnection<span class="args">()</span></span>
+          <span class="fn-loc"><a href="../src/main.cpp#L379">main.cpp:379</a></span>
+          <span class="fn-badges"><span class="badge b-esp">ESP32</span></span>
+        </div>
+        <p class="fn-desc">
+          Called once when a client connects during the post-wake advertising window. Promotes the
+          device from the lightweight wake state to full operation: brings up WiFi
+          (<code>initWiFi(false)</code>) and, for bb_epaper panels, zeroes and re-initializes the
+          panel driver (<code>bbepSetPanelType</code> / rotation). Seeed-GFX panels skip the
+          bb_epaper re-init.
+        </p>
+      </div>
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">idleDelay<span class="args">(uint32_t delayMs)</span></span>
+          <span class="fn-loc"><a href="../src/main.cpp#L361">main.cpp:361</a></span>
+          <span class="fn-badges"><span class="badge b-both">Both</span></span>
+        </div>
+        <p class="fn-desc">
+          An <b>interruptible replacement for <code>delay()</code></b>. Sleeps in 100 ms chunks, and
+          between chunks keeps the device responsive: nRF advertising tick, button events, touch
+          input, and LED flash all get serviced. Used everywhere the loop wants to pause without
+          going deaf to input.
+        </p>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ============ BLE & COMMAND PATH ============ -->
+  <section>
+    <div class="sec-head">
+      <span class="sec-num">02</span>
+      <h2>BLE &amp; command path</h2>
+      <span class="count">5 functions</span>
+    </div>
+    <div class="grid">
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">imageDataWritten<span class="args">(conn, chr, data, len)</span></span>
+          <span class="fn-loc"><a href="../src/communication.cpp#L482">communication.cpp:482</a></span>
+          <span class="fn-badges"><span class="badge b-both">Both</span></span>
+        </div>
+        <p class="fn-desc">
+          The <b>central command dispatcher</b>. Reads a 2-byte big-endian opcode and routes to the
+          matching handler (authenticate, firmware version, image write, etc.), enforcing the
+          authentication/encryption gate for everything except 0x0050 and 0x0043. In the loop it's
+          driven from the ESP32 command queue; it's also the BLE write callback on nRF and the LAN
+          frame handler on WiFi — the single funnel all commands pass through.
+        </p>
+      </div>
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">esp32_ble_notify_enabled<span class="args">()</span></span>
+          <span class="fn-loc"><a href="../src/ble_init.cpp#L153">ble_init.cpp:153</a></span>
+          <span class="fn-badges"><span class="badge b-esp">ESP32</span></span>
+        </div>
+        <p class="fn-desc">
+          Predicate: true only when a client is connected <i>and</i> has subscribed to notifications
+          (CCCD 0x2902 enabled, or the NimBLE subscribe flag). The loop uses it to decide whether the
+          response queue can actually be flushed — if a client is connected but hasn't enabled
+          notifications yet, responses stay queued rather than being dropped.
+        </p>
+      </div>
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">esp32_restart_ble_advertising<span class="args">()</span></span>
+          <span class="fn-loc"><a href="../src/ble_init.cpp#L165">ble_init.cpp:165</a></span>
+          <span class="fn-badges"><span class="badge b-esp">ESP32</span></span>
+        </div>
+        <p class="fn-desc">
+          Restarts BLE advertising after a disconnect — but <b>defers via
+          <code>bleRestartAdvertisingPending</code></b> if the server isn't ready or an e-paper
+          refresh is in progress, and no-ops if a client is already connected. On success it
+          restarts advertising and refreshes the manufacturer data. The loop calls it both inside
+          the post-wake window and in normal servicing to drain that pending flag.
+        </p>
+      </div>
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">ble_nrf_advertising_tick<span class="args">()</span></span>
+          <span class="fn-loc"><a href="../src/ble_init.cpp#L67">ble_init.cpp:67</a></span>
+          <span class="fn-badges"><span class="badge b-nrf">nRF</span></span>
+        </div>
+        <p class="fn-desc">
+          The nRF counterpart to the ESP32 advertising housekeeping. After a button press temporarily
+          <i>boosts</i> the advertising interval for faster discovery, this tick <b>reverts to the
+          normal interval</b> once the boost window expires, restarting advertising with the slower
+          timing. Does nothing while the boost is still active.
+        </p>
+      </div>
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">imageWriteLogQuietFrame<span class="args">(data, len)</span></span>
+          <span class="fn-loc"><a href="../src/display_service.cpp#L1462">display_service.cpp:1462</a></span>
+          <span class="fn-badges"><span class="badge b-esp">ESP32</span></span>
+        </div>
+        <p class="fn-desc">
+          A tiny logging predicate: true when the frame is an image-write chunk (opcode 0x0071) that's
+          past the first chunk and should be logged quietly. The loop uses it purely to <b>suppress
+          per-frame serial spam</b> during an image upload — the 5% progress meter reports instead.
+        </p>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ============ WIFI / LAN ============ -->
+  <section>
+    <div class="sec-head">
+      <span class="sec-num">03</span>
+      <h2>WiFi / LAN session</h2>
+      <span class="count">3 functions</span>
+    </div>
+    <div class="grid">
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">handleWiFiServer<span class="args">()</span></span>
+          <span class="fn-loc"><a href="../src/wifi_service.cpp#L170">wifi_service.cpp:170</a></span>
+          <span class="fn-badges"><span class="badge b-esp">ESP32</span></span>
+        </div>
+        <p class="fn-desc">
+          The LAN TCP server pump, run every pass. Detects the WiFi-up edge and starts the server;
+          <b>accepts an incoming client</b> (replacing any previous one), reads available bytes into a
+          receive buffer, and de-frames the stream (2-byte length prefix) — handing each complete
+          frame to <code>imageDataWritten()</code>. Tears the session down on WiFi loss, buffer
+          overflow, or an invalid frame length.
+        </p>
+      </div>
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">disconnectWiFiServer<span class="args">()</span></span>
+          <span class="fn-loc"><a href="../src/wifi_service.cpp#L160">wifi_service.cpp:160</a></span>
+          <span class="fn-badges"><span class="badge b-esp">ESP32</span></span>
+        </div>
+        <p class="fn-desc">
+          Closes the active LAN client: clears the encryption session, stops the socket, resets the
+          server-connected flag and receive-buffer position. The loop calls it when the 10-second
+          WiFi check sees the connection has dropped.
+        </p>
+      </div>
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">restartWiFiLanAfterReconnect<span class="args">()</span></span>
+          <span class="fn-loc"><a href="../src/wifi_service.cpp#L249">wifi_service.cpp:249</a></span>
+          <span class="fn-badges"><span class="badge b-esp">ESP32</span></span>
+        </div>
+        <p class="fn-desc">
+          Recovery path after WiFi comes back: closes any stale client, re-<code>begin()</code>s the
+          TCP server on its port, and restarts the LAN service. Invoked from the loop's reconnect
+          branch so the server is listening again after an outage.
+        </p>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ============ DISPLAY & WRITE STATE ============ -->
+  <section>
+    <div class="sec-head">
+      <span class="sec-num">04</span>
+      <h2>Display &amp; write-state watchdogs</h2>
+      <span class="count">2 functions</span>
+    </div>
+    <div class="grid">
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">checkPartialWriteTimeout<span class="args">()</span></span>
+          <span class="fn-loc"><a href="../src/display_service.cpp#L180">display_service.cpp:180</a></span>
+          <span class="fn-badges"><span class="badge b-both">Both</span></span>
+        </div>
+        <p class="fn-desc">
+          Watchdog for a stalled partial-write transfer. If one has been active longer than
+          <b>15 minutes</b> (900 000 ms), it logs an error and calls
+          <code>cleanup_partial_write_state()</code> so a client that vanished mid-transfer can't
+          wedge the device permanently.
+        </p>
+      </div>
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">cleanupDirectWriteState<span class="args">(bool refreshDisplay)</span></span>
+          <span class="fn-loc"><a href="../src/display_service.cpp#L1527">display_service.cpp:1527</a></span>
+          <span class="fn-badges"><span class="badge b-esp">ESP32</span></span>
+        </div>
+        <p class="fn-desc">
+          Resets the entire direct-write upload state machine (all the <code>directWrite*</code>
+          counters and flags back to zero). When <code>refreshDisplay</code> is set and the panel is
+          powered, it also <b>puts the panel to sleep</b> (bb_epaper or Seeed path). The loop invokes
+          it via the 15-minute direct-write timeout guard to recover stuck uploads.
+        </p>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ============ INPUT, SENSORS, HOUSEKEEPING ============ -->
+  <section>
+    <div class="sec-head">
+      <span class="sec-num">05</span>
+      <h2>Input, sensors &amp; housekeeping</h2>
+      <span class="count">5 functions</span>
+    </div>
+    <div class="grid">
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">processButtonEvents<span class="args">()</span></span>
+          <span class="fn-loc"><a href="../src/device_control.cpp#L411">device_control.cpp:411</a></span>
+          <span class="fn-badges"><span class="badge b-both">Both</span></span>
+        </div>
+        <p class="fn-desc">
+          Polls power buttons (and, on ESP32, configured power-off buttons), then handles any pending
+          button-ISR event: reads the pin, resolves logical press state (honoring inversion), packs
+          <code>button_id / press_count / state</code> into the dynamic return data, and <b>refreshes
+          the advertising payload</b> via <code>updatemsdata()</code>. On nRF it also boosts
+          advertising so a press is discoverable quickly.
+        </p>
+      </div>
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">processTouchInput<span class="args">()</span></span>
+          <span class="fn-loc"><a href="../src/touch_input.cpp#L575">touch_input.cpp:575</a></span>
+          <span class="fn-badges"><span class="badge b-both">Both</span></span>
+        </div>
+        <p class="fn-desc">
+          Services GT911 touch controllers, <b>rate-limited</b> to a minimum interval and — on ESP32 —
+          skipped entirely while a direct write or e-paper refresh is in progress (to keep the SPI/I2C
+          buses clear). Supports both IRQ-edge and timed polling, with an I2C-failure backoff. No-ops
+          when no touch controller is configured.
+        </p>
+      </div>
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">updatemsdata<span class="args">()</span></span>
+          <span class="fn-loc"><a href="../src/display_service.cpp#L1283">display_service.cpp:1283</a></span>
+          <span class="fn-badges"><span class="badge b-both">Both</span></span>
+        </div>
+        <p class="fn-desc">
+          Rebuilds the 16-byte BLE <b>manufacturer-data advertising payload</b>. Polls SHT40 / BQ27220
+          sensors, reads battery voltage and chip temperature, encodes them alongside the dynamic
+          button data and a status byte (reboot flag, connection-requested, loop counter). The loop
+          runs it on a 60-second cadence, and it's also triggered on button/sensor changes so the
+          advertised state stays fresh.
+        </p>
+      </div>
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">processLedFlash<span class="args">()</span></span>
+          <span class="fn-loc"><a href="../src/device_control.cpp#L350">device_control.cpp:350</a></span>
+          <span class="fn-badges"><span class="badge b-both">Both</span></span>
+        </div>
+        <p class="fn-desc">
+          The <b>first call in every loop iteration</b>. Advances a non-blocking LED flash animation by
+          one step — but only if a flash is active and any inter-step delay has elapsed. Returns
+          immediately otherwise, so it's essentially free when no LED sequence is running.
+        </p>
+      </div>
+
+      <div class="fn">
+        <div class="fn-top">
+          <span class="fn-name">writeSerial<span class="args">(String, bool newLine = true)</span></span>
+          <span class="fn-loc"><a href="../src/main.cpp#L562">main.cpp:562</a></span>
+          <span class="fn-badges"><span class="badge b-both">Both</span></span>
+        </div>
+        <p class="fn-desc">
+          The logging helper used throughout the loop. Writes to the dedicated log UART when
+          <code>OPENDISPLAY_LOG_UART</code> is configured, otherwise to USB serial — and compiles to
+          nothing when serial is disabled. Not control flow, but it's the most-called name in the
+          function.
+        </p>
+      </div>
+
+    </div>
+  </section>
+
+  <p class="foot">
+    19 project functions called from loop() · src/main.cpp L190–357 ·
+    Arduino core (millis/delay) and raw BLE characteristic setValue/notify omitted as library calls.
+  </p>
+</div>

--- a/docs/pipe-write-protocol.md
+++ b/docs/pipe-write-protocol.md
@@ -1,0 +1,396 @@
+# PIPE_WRITE Wire Protocol
+
+Sliding-window, selectively-acknowledged image transfer for OpenDisplay panels.
+Opcodes **0x0080–0x0082**. Introduced in commit `bcfad8b`.
+
+This document walks the protocol end to end: **negotiation → data transfer →
+acknowledgement → error recovery → completion**. It is written against the
+firmware in [src/display_service.cpp](../src/display_service.cpp),
+[src/structs.h](../src/structs.h), [src/communication.cpp](../src/communication.cpp),
+and [src/esp32_ble_callbacks.h](../src/esp32_ble_callbacks.h).
+
+---
+
+## 1. Overview & motivation
+
+The legacy image path (`0x70/0x71/0x72`) is strictly in-order and stop-and-wait:
+the client sends a chunk, waits for an ACK, sends the next. Over BLE, that
+round-trip latency dominates transfer time.
+
+PIPE_WRITE replaces the stop-and-wait loop with a **sliding window**. The client
+may have up to *W* frames outstanding (unacknowledged) at once, and the device
+acknowledges with a **QUIC-style selective ACK (SACK)** that reports the highest
+sequence number seen plus a bitmask of which earlier frames arrived. This lets a
+single lost frame be retransmitted without stalling the whole stream.
+
+Key design point: **data streams directly to the panel controller — there is no
+framebuffer.** Bytes for frame *k* are written to the display IC as soon as frame
+*k* is accepted in order. Because the controller stream cannot skip a hole, a
+small **reorder queue** holds out-of-order frames until the missing one arrives.
+
+The legacy `0x70/0x71/0x72` (and partial `0x76`) paths are byte-for-byte
+unchanged. A new client probes with `0x0080`; if it goes unanswered (old
+firmware) the client falls back to legacy. Old clients are unaffected.
+
+### Opcode family
+
+| Opcode   | Name              | Direction     | Purpose                              |
+|----------|-------------------|---------------|--------------------------------------|
+| `0x0080` | PIPE_WRITE_START  | client→device | Negotiate window / cadence / frame   |
+| `0x0081` | PIPE_WRITE_DATA   | client→device | Carry one sequenced payload frame     |
+| `0x0082` | PIPE_WRITE_END    | client→device | Finalize, refresh, commit etag        |
+
+The device replies on the same notify channel with status-prefixed responses
+(`0x00…` success / SACK, `0xFF…` NACK) described below.
+
+### Framing convention
+
+The 2-byte **big-endian** opcode is stripped by the dispatcher
+([communication.cpp:621-635](../src/communication.cpp)) before the handler runs.
+Inside a handler, `data[0]` is therefore the first *post-opcode* byte and `len`
+is the post-opcode payload length. All multi-byte fields **in the transfer body
+are little-endian** — except the END etag, which mirrors legacy and is big-endian
+(see §6).
+
+### Negotiated constants
+
+Defined in [structs.h:108-124](../src/structs.h). Two profiles: the default and a
+reduced profile (`PIPE_SMALL_DRAM_WINDOW`) used only by the classic-ESP32
+`env:esp32-N4` build, whose static DRAM cannot hold the full queue.
+
+| Constant                 | Default | Small-DRAM | Meaning                                    |
+|--------------------------|---------|-----------|--------------------------------------------|
+| `PIPE_VERSION`           | `0x01`  | `0x01`    | Protocol version                           |
+| `PIPE_MAX_W`             | 32      | 16        | Device max window                          |
+| `PIPE_MAX_N`             | 32      | 16        | Device max ACK cadence                     |
+| `PIPE_MAX_FRAME`         | 244     | 244       | Device max frame size (HA ATT write ceiling)|
+| `PIPE_ACK_MASK_BITS`     | 32      | 32        | SACK bitmask width                         |
+| `PIPE_REORDER_SLOTS`     | 33      | 17        | Reorder queue depth (= max window + 1)     |
+| `PIPE_REORDER_SLOT_SIZE` | 248     | 248       | Per-slot buffer bytes                      |
+| `PIPE_FLAG_COMPRESSED`   | `0x01`  | `0x01`    | START flag bit: payload is a zlib stream   |
+
+---
+
+## 2. Negotiation — PIPE_WRITE_START (0x0080)
+
+One round trip establishes the whole session. Handler:
+[handlePipeWriteStart, display_service.cpp:2057-2141](../src/display_service.cpp).
+
+A new START **aborts any in-flight transfer** (of any family) and calls
+`resetPipeWriteState()` before parsing.
+
+### 2.1 Request (client → device)
+
+10 bytes, little-endian, after the `00 80` opcode:
+
+| Offset | Field              | Size | Notes                                             |
+|--------|--------------------|------|---------------------------------------------------|
+| 0      | `ver`              | 1    | Must equal `PIPE_VERSION` (`0x01`)                |
+| 1      | `flags`            | 1    | bit0 = `PIPE_FLAG_COMPRESSED` (zlib); other bits reserved |
+| 2      | `req_w`            | 1    | Proposed window size                              |
+| 3      | `req_n`            | 1    | Proposed ACK cadence (ack every N)                |
+| 4–5    | `client_max_frame` | 2 LE | Proposed max frame size                           |
+| 6–9    | `total_size`       | 4 LE | Decompressed panel byte total                     |
+
+The guard is `if (len < 10)` — trailing bytes are tolerated for future fields.
+
+> **Historical bug (fixed in `a39082e`).** The handler is dispatched as
+> `handlePipeWriteStart(data+2, len-2)`, so `len` is the 10-byte post-opcode
+> length. The original guard required `len >= 12` (the full on-wire frame
+> including the opcode), so **every valid request was rejected** with
+> `sendPipeStartNack(0x01)` and clients silently fell back to legacy on every
+> upload. The parse itself was correct; only the guard was wrong.
+
+### 2.2 Negotiation rule (min of both sides)
+
+The device computes effective values ([display_service.cpp:2092-2098](../src/display_service.cpp)):
+
+- `W_eff  = clamp(min(req_w, PIPE_MAX_W), 1..)` — additionally clamped to ≤32
+  when encryption is active (the ACK mask is 32 bits wide).
+- `N_eff  = min(clamp(min(req_n, PIPE_MAX_N), 1..), W_eff)` — cadence never
+  exceeds the window.
+- `frame_eff = min(client_max_frame, PIPE_MAX_FRAME)` (≤ 244).
+
+`total_size` must **exactly** match the device-computed geometry
+(`directWriteComputeGeometry`), else NACK `0x03`.
+
+### 2.3 Response (device → client)
+
+8 bytes ([display_service.cpp:2126-2128](../src/display_service.cpp)):
+
+```
+00 80  VER  MAX_W  MAX_N  FRAME_LO FRAME_HI  FLAGS
+```
+
+| Offset | Value                         | Meaning                                    |
+|--------|-------------------------------|--------------------------------------------|
+| 0–1    | `00 80`                       | Success + opcode echo                       |
+| 2      | `0x01`                        | Device protocol version                     |
+| 3      | `PIPE_MAX_W`                  | Device max window                           |
+| 4      | `PIPE_MAX_N`                  | Device max ACK cadence                      |
+| 5–6    | `PIPE_MAX_FRAME` (244 → `F4 00`) | Device max frame, LE                     |
+| 7      | flags — **bit0 = 1**          | Device buffers out-of-order (selective repeat) |
+
+The response returns device **maxima**, not the effective values. The client
+applies the same `min` rule to arrive at the identical `W_eff / N_eff /
+frame_eff`. Both sides now agree without a second round trip.
+
+> The response is sent **before** the panel is powered up
+> ([display_service.cpp:2117-2140](../src/display_service.cpp)) so that slow
+> panel init cannot exceed the client's 2-second probe timeout.
+
+### 2.4 START NACK
+
+`sendPipeStartNack(err)` → 4 bytes `FF 80 <err> 00`. No teardown is needed (the
+geometry check is pure config math before any hardware is touched).
+
+| `err`  | Cause                                                     |
+|--------|-----------------------------------------------------------|
+| `0x01` | Bad length (`len < 10`) or version mismatch               |
+| `0x02` | Unsupported flag bits set                                 |
+| `0x03` | `total_size` disagrees with device geometry              |
+
+---
+
+## 3. Data transfer — PIPE_WRITE_DATA (0x0081)
+
+Handler: [handlePipeWriteData, display_service.cpp:2143-2229](../src/display_service.cpp).
+
+### 3.1 Frame layout
+
+After the `00 81` opcode:
+
+| Offset | Field     | Size   | Notes                                    |
+|--------|-----------|--------|------------------------------------------|
+| 0      | `seq`     | 1      | Rolling sequence number, wraps mod 256    |
+| 1…     | `payload` | ≤243   | Controller bytes (or zlib stream)         |
+
+`plen = len - 1`. A frame carries at most `frame_eff - 1` payload bytes (the seq
+consumes one), so at the 244-byte cap the payload is ≤243 bytes.
+
+### 3.2 Sequence numbers and the window
+
+- The transfer starts at `expected_seq = 0` and increments per in-order accept.
+- `seq` is a `uint8_t`; it wraps 255 → 0. Distances use unsigned 8-bit
+  subtraction so wrap is automatic:
+  - `fwd  = (uint8_t)(seq - expected_seq)` — `0` = exactly in order; `1..W-1` =
+    ahead, within window.
+  - `back = (uint8_t)(expected_seq - seq)` — `≥1` = at/below expected (duplicate
+    or stale).
+- The window width is `W = W_eff`. Because a live window spans at most *W* < 33
+  distinct seqs, `seq % PIPE_REORDER_SLOTS` indexes the reorder queue without
+  collisions even across the mod-256 wrap.
+
+### 3.3 The three cases
+
+**(a) In order — `fwd == 0`** ([display_service.cpp:2155-2184](../src/display_service.cpp)):
+
+1. `pipeConsumePayload()` streams the bytes straight to the panel controller
+   (same machinery as legacy `0x71`: raw write, or zlib inflate, or gray4 plane
+   split). A failure NACKs (`0x02` compressed / `0x03` uncompressed).
+2. `expected_seq++`, counters advance, `highest_seen` updates.
+3. **Drain the queue:** while the slot for the new `expected_seq` holds a
+   matching frame, consume it, free the slot, `queued_count--`, and advance
+   `expected_seq` again. This is how the stream catches up past a filled hole.
+4. If the queue is now empty, `gap_open = false`.
+5. Cadence: if `frames_since_ack >= N_eff`, send a SACK (§4).
+
+**(b) Ahead, in window — `0 < fwd < W`** ([display_service.cpp:2187-2211](../src/display_service.cpp)):
+
+This is the **pause point** — nothing past the hole reaches the controller. The
+frame is `memcpy`'d into `pipeReorder[seq % SLOTS]`, `queued_count++`. If this
+opens a new gap (`gap_open` was false), a SACK is sent **immediately** so the
+sender learns which frame is missing (fast retransmit). While the gap stays open,
+further out-of-order arrivals are rate-limited to one SACK per `N_eff` arrivals.
+Queue overflow (`queued_count >= PIPE_REORDER_SLOTS`) NACKs `0x03` — a protocol
+violation the sender's window rule should make impossible.
+
+**(c) Duplicate / stale — `back <= W`** ([display_service.cpp:2216-2224](../src/display_service.cpp)):
+
+The frame is discarded but a rate-limited SACK is sent so the sender re-learns
+the receiver's position. Anything outside the window on both sides (`fwd >= W`
+and `back > W`) is a protocol violation → NACK `0x04`.
+
+### 3.4 ESP32 ingest ring (transport, not protocol)
+
+On ESP32 the BLE callback copies each command into a lock-free SPSC ring
+(`COMMAND_QUEUE_SIZE = 33`, `MAX_COMMAND_SIZE = 256`) with acquire/release
+atomics; the main loop drains up to 33 per pass and flushes responses **between**
+commands so small ACK cadences can't overflow the response ring. Sized to hold a
+full W=32 window plus END across an SPI stall.
+
+---
+
+## 4. Acknowledgement — QUIC-style SACK
+
+Builder: [pipeBuildAckPayload, display_service.cpp:1967-1979](../src/display_service.cpp).
+
+### 4.1 Format
+
+A data ACK is 7 bytes:
+
+```
+00 81  highest_seen  mask[0] mask[1] mask[2] mask[3]
+```
+
+- Byte 2 `highest_seen` — the highest seq received (accepted **or** queued),
+  mod 256. If nothing has arrived yet, it reports `expected_seq - 1`.
+  `highest_seen` is itself implicitly acknowledged.
+- Bytes 3–6 — a **32-bit mask, little-endian**. Bit *i* (LSB first, i = 0..31)
+  means **chunk `(highest_seen - 1 - i)` was received**. So bit0 = `hs−1`,
+  bit1 = `hs−2`, …, bit31 = `hs−32`.
+
+"Received" means either accepted in the in-order prefix *or* currently held in
+the reorder queue ([pipeChunkReceived, display_service.cpp:1957-1963](../src/display_service.cpp)).
+The accepted-prefix depth is bounded by `received_count` so the first 32 chunks
+of a transfer never set phantom bits from mod-256 wrap. A zeroed bit is the
+sender's cue to retransmit that seq.
+
+### 4.2 When a SACK is sent
+
+| Trigger                        | Behaviour                                          |
+|--------------------------------|----------------------------------------------------|
+| Cadence                        | Every `N_eff` in-order accepts                      |
+| Gap opens                      | **Immediately** (fast retransmit)                   |
+| Out-of-order / duplicate while gap open | Rate-limited: one per `N_eff` such arrivals |
+| END / auto-complete            | Tail flush before the final result                  |
+
+`sendPipeAck()` resets both the cadence counter (`frames_since_ack`) and the
+gap-ACK rate-limit counter (`ooo_acks_since_gap`).
+
+### 4.3 Worked example
+
+Window 8, cadence 4. Frames 0,1,2 arrive, then 3 is lost, then 4,5 arrive:
+
+- After 0,1,2 in order: `expected_seq = 3`. (No ACK yet — only 3 accepts, cadence
+  is 4.)
+- Frame 4 arrives, `fwd = 1` → queued, gap opens → **immediate SACK**
+  `highest_seen = 4`, mask bit for seq 3 is **0** (missing), bit for seq 2 is 1.
+  The sender sees the hole at 3.
+- Frame 5 arrives, `fwd = 2` → queued; rate-limited, no new ACK yet.
+- Sender retransmits 3. It arrives `fwd = 0` → written, then the drain loop
+  writes queued 4 and 5, `expected_seq = 6`. The next cadence SACK reports
+  `highest_seen = 5` with a full mask.
+
+---
+
+## 5. Error recovery
+
+### 5.1 Data NACK — all fatal
+
+`sendPipeNack(err)` → 8 bytes `FF 81 <err> highest_seen mask[0..3]`
+([display_service.cpp:1999-2005](../src/display_service.cpp)). The SACK tail is
+built from state **before** any teardown so the reported position stays
+consistent.
+
+Every `0x81` NACK is **fatal**:
+
+1. `pipeState.error = true`.
+2. `cleanupDirectWriteState(true)` runs the **same** hardware cleanup as the
+   legacy mid-stream `0xFF 71` failure: sleep a powered controller cleanly, cut
+   power, resume touch.
+3. `pipeState` and the reorder queue are **deliberately not reset**, so
+   subsequent `0x0081` frames are silently discarded until the next `0x0080`
+   START or a BLE disconnect.
+
+| `err`  | Cause                                                              |
+|--------|--------------------------------------------------------------------|
+| `0x02` | Compressed (zlib) consume failure                                  |
+| `0x03` | Uncompressed consume failure, over-size frame, or reorder overflow |
+| `0x04` | Out of window on both sides (protocol violation)                   |
+
+### 5.2 Loss recovery flow (the normal case)
+
+Loss recovery is **not** a NACK — it is the SACK mechanism:
+
+1. A frame lands ahead of the hole → device queues it and sends an immediate SACK
+   whose zeroed mask bits name the missing seqs.
+2. The sender retransmits exactly those seqs.
+3. The retransmit arrives in order → written, and the contiguous run of queued
+   successors drains → the stream resumes.
+
+NACKs are reserved for unrecoverable conditions (bad payload, protocol
+violation), not ordinary packet loss.
+
+### 5.3 Stuck-transfer timeout
+
+The main loop enforces a 15-minute (`900000 ms`) ceiling on a stalled
+direct-write / pipe transfer ([main.cpp](../src/main.cpp)), after which the panel
+hardware is released even if no END or NACK ever arrives.
+
+---
+
+## 6. Completion — PIPE_WRITE_END (0x0082)
+
+Handler: [handlePipeWriteEnd, display_service.cpp:2231-2266](../src/display_service.cpp).
+END shares the legacy `0x72` finalizer `directWriteFinishAndRefresh(data, len, 0x82)`.
+
+### 6.1 Payload (after `00 82`)
+
+| Offset | Field         | Size   | Notes                                              |
+|--------|---------------|--------|----------------------------------------------------|
+| 0      | `refresh_mode`| 1      | `1` = fast refresh; anything else = full refresh   |
+| 1–4    | `etag`        | 4 **BE** | New etag, big-endian (`parse_be_u32`), optional  |
+
+The etag is big-endian to match legacy `0x72` exactly. A nonzero etag is
+committed on a successful refresh; a zero/absent etag clears `displayed_etag` so a
+later partial update falls back cleanly on an etag mismatch.
+
+### 6.2 Flow
+
+1. Not active → `FF 82`. Already in fatal error → `FF 82` + defensive cleanup +
+   reset.
+2. **Tail-flush SACK** (`sendPipeAck()`) so the sender sees the final receiver
+   state.
+3. **Completeness check:** if the reorder queue is non-empty (`queued_count > 0`),
+   or (uncompressed) fewer than `total_size` bytes were written, the transfer is
+   incomplete → `FF 82` + `cleanupDirectWriteState(true)` + reset. (Compressed
+   incompleteness surfaces as a zlib-flush NACK inside the shared finalizer.)
+4. Otherwise finalize: success `00 82`, panel refresh, then `00 73` on refresh
+   success or `00 74` on refresh timeout, then `resetPipeWriteState()`.
+
+### 6.3 Auto-complete (uncompressed only)
+
+When an in-order accept pushes `directWriteBytesWritten >= total_size`, the device
+finalizes **without** waiting for an END frame
+([display_service.cpp:2177-2182](../src/display_service.cpp)): it flushes a final
+SACK, calls `directWriteFinishAndRefresh(nullptr, 0, 0x82)` (an unsolicited
+`00 82` + full refresh, no etag), and resets. This mirrors the legacy
+auto-finish behaviour.
+
+---
+
+## 7. End-to-end sequence
+
+```
+Client                                   Device
+  |  00 80  ver flags W N frame total  -->|   negotiate
+  |<-- 00 80  01 MAXW MAXN FRAME flags     |   grant (device maxima)
+  |                                        |
+  |  00 81  00 <payload>              ---->|   seq 0  -> panel
+  |  00 81  01 <payload>              ---->|   seq 1  -> panel
+  |  00 81  02 <payload>              ---->|   seq 2  -> panel
+  |  00 81  03 <payload>   (LOST)      -x  |
+  |  00 81  04 <payload>              ---->|   queued; gap opens
+  |<-- 00 81  04  mask(bit@3=0)             |   immediate SACK
+  |  00 81  03 <payload>  (retransmit)---->|   seq 3 -> panel, drains 4
+  |             ... cadence SACKs ...       |
+  |  00 82  mode etag                 ---->|   finalize
+  |<-- 00 81  hs mask   (tail flush)        |
+  |<-- 00 82                                |   success
+  |<-- 00 73                                |   refresh complete
+```
+
+---
+
+## 8. Compatibility
+
+- Legacy `0x70/0x71/0x72` and partial `0x76` paths are **byte-identical** — old
+  clients are unaffected.
+- A new client that sends `0x0080` and gets no response within its 2 s probe
+  assumes legacy-only firmware and falls back to `0x70`.
+- Pipe data ACKs at `highest_seen` = `0xFE`/`0xFF` stay **encrypted**: the
+  `sendResponse` encryption-skip heuristic (which normally treats a `0xFE`/`0xFF`
+  status byte as an unencrypted response) is scoped to exclude the 7-byte
+  `00 81 …` ACK shape ([communication.cpp:170-182](../src/communication.cpp)).
+```

--- a/platformio.ini
+++ b/platformio.ini
@@ -223,6 +223,10 @@ platform = https://github.com/pioarduino/platform-espressif32/releases/download/
 framework = arduino
 build_flags =
   -DTARGET_ESP32
+  # Classic ESP32 (esp32dev) only: 320KB RAM has far less static DRAM than the
+  # S3/C3/C6 parts, so the full 33-slot PIPE_WRITE reorder queue overflows
+  # dram0_0_seg at link. Shrink the window/queue on THIS env only (see structs.h).
+  -DPIPE_SMALL_DRAM_WINDOW
   #-DOPENDISPLAY_ZLIB_WINDOW_BITS=15
   -DOPENDISPLAY_ZLIB_USE_HEAP_WINDOW=1
   -DCONFIG_FREERTOS_WATCHDOG_TIMEOUT_S=120

--- a/src/ble_init.cpp
+++ b/src/ble_init.cpp
@@ -160,12 +160,6 @@ void ble_nrf_stack_init() {
     Bluefruit.autoConnLed(false);
     Bluefruit.setTxPower(globalConfig.power_option.tx_power);
     Bluefruit.begin(1, 0);
-    if (!isEncryptionEnabled()) {
-        bledfu.begin();
-        writeSerial("BLE DFU initialized successfully (encryption disabled)");
-    } else {
-        writeSerial("BLE DFU service NOT initialized (encryption enabled - use CMD_ENTER_DFU)");
-    }
     writeSerial("BLE initialized successfully");
     writeSerial("Setting up BLE service 0x2446...");
     imageService.begin();
@@ -174,6 +168,18 @@ void ble_nrf_stack_init() {
     writeSerial("BLE write callback set");
     imageCharacteristic.begin();
     writeSerial("BLE characteristic started");
+    // Register the DFU service LAST so its presence/absence (it is only added when
+    // encryption is disabled) never shifts the handles of imageCharacteristic and its
+    // CCCD. GATT handles are assigned in begin() order; keeping the app characteristic
+    // ahead of the conditional DFU service keeps its handles stable across encryption
+    // on/off, so a client's cached CCCD handle stays valid and notify setup won't fail
+    // with ATT "Invalid handle". Must stay after Bluefruit.begin() (SoftDevice up first).
+    if (!isEncryptionEnabled()) {
+        bledfu.begin();
+        writeSerial("BLE DFU initialized successfully (encryption disabled)");
+    } else {
+        writeSerial("BLE DFU service NOT initialized (encryption enabled - use CMD_ENTER_DFU)");
+    }
     Bluefruit.Periph.setConnectCallback(connect_callback);
     Bluefruit.Periph.setDisconnectCallback(disconnect_callback);
     writeSerial("BLE callbacks registered");

--- a/src/ble_init.cpp
+++ b/src/ble_init.cpp
@@ -83,6 +83,51 @@ void ble_nrf_advertising_tick(void) {
     Bluefruit.Advertising.start(0);
 }
 
+// --- Link-layer diagnostics -------------------------------------------------
+// DLE (Data Length Extension) sets the max Link-Layer PDU payload: 27 octets by
+// default, up to 251 once negotiated. The nRF peripheral only auto-accepts the
+// central's request, which arrives AFTER connect_callback, so we log twice: once
+// at connect (baseline) and once ~2.5 s later (negotiated).
+void ble_nrf_log_link_params(uint16_t conn_handle, const char* phase) {
+    BLEConnection* conn = Bluefruit.Connection(conn_handle);
+    if (conn == nullptr) {
+        writeSerial(String("[LINK ") + phase + "] no connection (handle " + String(conn_handle) + ")");
+        return;
+    }
+    uint8_t  phy = conn->getPHY();
+    uint16_t mtu = conn->getMtu();                // ATT MTU (23 default; 247 cap here)
+    uint16_t dle = conn->getDataLength();         // LL PDU payload octets (27 default; 251 max)
+    uint16_t ci  = conn->getConnectionInterval(); // units of 1.25 ms
+    const char* phyStr = (phy == BLE_GAP_PHY_2MBPS) ? "2M" :
+                         (phy == BLE_GAP_PHY_1MBPS) ? "1M" : "?";
+    writeSerial(String("[LINK ") + phase + "] PHY=" + phyStr +
+                "  ATT_MTU=" + String(mtu) +
+                "  DLE=" + String(dle) + " octets" +
+                "  connInterval=" + String(ci * 1.25f, 2) + " ms");
+}
+
+// One-shot timer (armed only in connect_callback — no per-loop polling). Fires
+// once on the FreeRTOS timer task after the central finishes negotiation.
+static SoftwareTimer s_link_diag_timer;
+static uint16_t      s_link_diag_conn = BLE_CONN_HANDLE_INVALID;
+
+static void ble_nrf_link_diag_cb(TimerHandle_t /*xTimer*/) {
+    if (Bluefruit.connected()) {
+        ble_nrf_log_link_params(s_link_diag_conn, "negotiated");
+    }
+}
+
+void ble_nrf_arm_link_diag(uint16_t conn_handle) {
+    s_link_diag_conn = conn_handle;
+    static bool created = false;
+    if (!created) {
+        // Create the one-shot (repeating=false) on the first connection only.
+        s_link_diag_timer.begin(2500, ble_nrf_link_diag_cb, NULL, false);
+        created = true;
+    }
+    s_link_diag_timer.reset();   // start/restart the one-shot from now; fires ~2.5 s later
+}
+
 void ble_nrf_stack_init() {
     Bluefruit.configCentralBandwidth(BANDWIDTH_MAX);
     Bluefruit.configPrphBandwidth(BANDWIDTH_MAX);

--- a/src/ble_init.cpp
+++ b/src/ble_init.cpp
@@ -117,12 +117,38 @@ static void ble_nrf_link_diag_cb(TimerHandle_t /*xTimer*/) {
     }
 }
 
+// Proactively upgrade the link for throughput: the nRF peripheral only auto-accepts
+// the central's PHY/DLE requests, so if the phone never asks we stay at 1M / 27 octets.
+// Requesting here (both are no-ops if the peer already negotiated the same or better).
+void ble_nrf_request_fast_link(uint16_t conn_handle) {
+    BLEConnection* conn = Bluefruit.Connection(conn_handle);
+    if (conn == nullptr) return;
+
+    // 2 Mbps PHY (tx + rx). Peer may decline and stay at 1M.
+    conn->requestPHY(BLE_GAP_PHY_2MBPS);
+
+    // 251-octet Link-Layer PDUs (max DLE). AUTO time lets the controller derive the
+    // PHY-appropriate on-air duration.
+    ble_gap_data_length_params_t dl;
+    dl.max_tx_octets  = 251;
+    dl.max_rx_octets  = 251;
+    dl.max_tx_time_us = BLE_GAP_DATA_LENGTH_AUTO;
+    dl.max_rx_time_us = BLE_GAP_DATA_LENGTH_AUTO;
+    ble_gap_data_length_limitation_t limit = { 0, 0, 0 };
+    if (!conn->requestDataLengthUpdate(&dl, &limit)) {
+        writeSerial("DLE 251 request rejected (tx_lim=" + String(limit.tx_payload_limited_octets) +
+                    " rx_lim=" + String(limit.rx_payload_limited_octets) +
+                    " time_lim_us=" + String(limit.tx_rx_time_limited_us) + ")");
+    }
+    writeSerial("Requested fast link: 2M PHY + 251-octet DLE");
+}
+
 void ble_nrf_arm_link_diag(uint16_t conn_handle) {
     s_link_diag_conn = conn_handle;
     static bool created = false;
     if (!created) {
         // Create the one-shot (repeating=false) on the first connection only.
-        s_link_diag_timer.begin(2500, ble_nrf_link_diag_cb, NULL, false);
+        s_link_diag_timer.begin(500, ble_nrf_link_diag_cb, NULL, false);
         created = true;
     }
     s_link_diag_timer.reset();   // start/restart the one-shot from now; fires ~2.5 s later

--- a/src/ble_init.h
+++ b/src/ble_init.h
@@ -1,12 +1,17 @@
 #ifndef BLE_INIT_H
 #define BLE_INIT_H
 
+#include <stdint.h>
+
 #ifdef TARGET_NRF
 void ble_nrf_stack_init();
 void ble_nrf_advertising_start();
 void ble_nrf_boost_advertising(void);
 void ble_nrf_apply_adv_interval(void);
 void ble_nrf_advertising_tick(void);
+// Link diagnostics: log negotiated PHY / ATT MTU / DLE (LL PDU octets) / conn interval.
+void ble_nrf_log_link_params(uint16_t conn_handle, const char* phase);
+void ble_nrf_arm_link_diag(uint16_t conn_handle);   // one-shot: re-log ~2.5 s after connect
 #endif
 #ifdef TARGET_ESP32
 void ble_init();

--- a/src/ble_init.h
+++ b/src/ble_init.h
@@ -12,6 +12,7 @@ void ble_nrf_advertising_tick(void);
 // Link diagnostics: log negotiated PHY / ATT MTU / DLE (LL PDU octets) / conn interval.
 void ble_nrf_log_link_params(uint16_t conn_handle, const char* phase);
 void ble_nrf_arm_link_diag(uint16_t conn_handle);   // one-shot: re-log ~2.5 s after connect
+void ble_nrf_request_fast_link(uint16_t conn_handle); // request 2M PHY + 251-octet DLE (max throughput)
 #endif
 #ifdef TARGET_ESP32
 void ble_init();

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -163,10 +163,20 @@ void sendResponse(uint8_t* response, uint16_t len) {
     // stream is past its first chunk (chunk 1's ack still logs). Computed before
     // `response` is swapped to the encrypted buffer. Errors/NACKs start with 0xFF
     // and never match, so they always log.
-    const bool quietAck = (len == 2 && response[0] == 0x00 && response[1] == 0x71 && imageWriteLogQuietAck());
+    // Also suppress the 7-byte PIPE ACK {00 81 highest_seen mask:4} mid-stream.
+    // Length test uses the plaintext ACK (encryption happens after this check).
+    const bool quietAck = (len == 2 && response[0] == 0x00 && response[1] == 0x71 && imageWriteLogQuietAck())
+                       || (len == 7 && response[0] == 0x00 && response[1] == 0x81 && imageWriteLogQuietAck());
     if (isAuthenticated() && len >= 2) {
         uint16_t command = (response[0] << 8) | response[1];
-        uint8_t status = (len >= 3) ? response[2] : 0x00;
+        // The 7-byte PIPE data ACK {0x00,0x81,highest_seen,mask:4} carries a rolling
+        // seq at byte[2]; a highest_seen of 0xFE/0xFF (any image >= 255 chunks) must
+        // not trip the unencrypted-status heuristic below — pipe ACKs encrypt
+        // normally when authenticated (plan 1.6). Other pipe shapes never collide:
+        // 0x80 response byte[2] = ver (0x01), pipe NACK byte[2] = err (0x01-0x04),
+        // 0x82 acks are 2 bytes (status defaults to 0x00).
+        const bool pipeDataAck = (len == 7 && response[0] == 0x00 && response[1] == 0x81);
+        uint8_t status = (len >= 3 && !pipeDataAck) ? response[2] : 0x00;
         // Encrypt all authenticated responses except auth/version handshakes and FE/FF status.
         // Direct-write / partial-write / LED acks must be encrypted too; LAN/BLE clients decrypt every response.
         if (command != 0x0050 && command != 0x0043 && status != 0xFE && status != 0xFF) {
@@ -224,8 +234,14 @@ void sendResponse(uint8_t* response, uint16_t len) {
             writeSerial(nrfHexDump, true);
             writeSerial("NRF: BLE notification sent (" + String(len) + " bytes)", true);
         }
-        imageCharacteristic.notify(response, len);
-        delay(20);
+        // Bounded retry only when the SoftDevice TX queue is full (notify()==false).
+        // Replaces an unconditional delay(20): pays latency only on backpressure and
+        // speeds the legacy per-chunk path ~20 ms/chunk.
+        bool notified = imageCharacteristic.notify(response, len);
+        for (uint8_t attempt = 0; !notified && attempt < 4; ++attempt) {
+            delay(5);
+            notified = imageCharacteristic.notify(response, len);
+        }
     } else {
         writeSerial("ERROR: Cannot send BLE response - not connected or notifications not enabled", true);
         writeSerial("  Connected: " + String(Bluefruit.connected() ? "yes" : "no"), true);
@@ -490,7 +506,7 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
     uint16_t command = (data[0] << 8) | data[1];
     // Silence the per-frame command spam for image-write data (0x0071) once the
     // stream is past its first chunk; the display handler's 5% meter reports it.
-    const bool quietCmd = (command == 0x0071) && imageWriteLogQuietCmd();
+    const bool quietCmd = (command == 0x0071 || command == 0x0081) && imageWriteLogQuietCmd();
     if (!quietCmd) writeSerial("Processing command: 0x" + String(command, HEX));
 
     if (command == 0x0050) {
@@ -601,6 +617,21 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
         case 0x0072:
             writeSerial("=== DIRECT WRITE END COMMAND (0x0072) ===");
             handleDirectWriteEnd(data + 2, len - 2);
+            break;
+        case 0x0080:
+            writeSerial("=== PIPE WRITE START COMMAND (0x0080) ===");
+            handlePipeWriteStart(data + 2, len - 2);
+            break;
+        case 0x0081:
+            // The replay counter (verifyNonceReplay) already advanced at decrypt time,
+            // above this switch, for every 0x0081 frame — including ones the handler
+            // then queues or discards — so drops/dupes never desync it and the counter
+            // delta stays within in-flight <= W <= 32 <= the +-32 replay window.
+            handlePipeWriteData(data + 2, len - 2);
+            break;
+        case 0x0082:
+            writeSerial("=== PIPE WRITE END COMMAND (0x0082) ===");
+            handlePipeWriteEnd(data + 2, len - 2);
             break;
         case 0x0076:
             handlePartialWriteStart(data + 2, len - 2);

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -653,7 +653,7 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
             enterDFUMode();
             break;
         case 0x0052:
-            handleDeepSleepCommand();
+            handleDeepSleepCommand(data + 2, len - 2);
             break;
         default:
             writeSerial("ERROR: Unknown command: 0x" + String(command, HEX));

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -679,8 +679,10 @@ void printConfigSummary(){
                " " + String(globalConfig.power_option.battery_capacity_mah[2]) + " mAh");
     writeSerial("Awake Timeout: " + String(globalConfig.power_option.sleep_timeout_ms) + " ms");
     writeSerial("Deep Sleep Time: " + String(globalConfig.power_option.deep_sleep_time_seconds) + " seconds");
+    writeSerial("Min Wake Time: " + String(globalConfig.power_option.min_wake_time_seconds) + " seconds");
     writeSerial("TX Power: " + String(globalConfig.power_option.tx_power));
     writeSerial("Sleep Flags: 0x" + String(globalConfig.power_option.sleep_flags, HEX));
+    writeSerial("Button Wake: " + String((globalConfig.power_option.sleep_flags & SLEEP_FLAG_BUTTON_WAKE_DISABLE) ? "disabled" : "enabled") + " (sleep_flags bit0)");
     writeSerial("Battery Sense Pin: " + String(globalConfig.power_option.battery_sense_pin));
     writeSerial("Battery Sense Enable Pin: " + String(globalConfig.power_option.battery_sense_enable_pin));
     writeSerial("Battery Sense Flags: 0x" + String(globalConfig.power_option.battery_sense_flags, HEX));

--- a/src/device_control.cpp
+++ b/src/device_control.cpp
@@ -88,7 +88,7 @@ void connect_callback(uint16_t conn_handle) {
     updatemsdata();
 #ifdef TARGET_NRF
     ble_nrf_log_link_params(conn_handle, "at connect");  // baseline (pre-negotiation)
-    ble_nrf_request_fast_link(conn_handle);              // request 2M PHY + 251-octet DLE
+    // ble_nrf_request_fast_link(conn_handle);              // request 2M PHY + 251-octet DLE (disabled)
     ble_nrf_arm_link_diag(conn_handle);                  // re-log once negotiation settles
 #endif
 }

--- a/src/device_control.cpp
+++ b/src/device_control.cpp
@@ -6,7 +6,7 @@
 #include <string.h>
 
 #ifdef TARGET_ESP32
-void enterDeepSleep(bool force = false);
+void enterDeepSleep(bool force = false, uint16_t overrideSleepSeconds = 0);
 #endif
 
 #ifdef TARGET_NRF
@@ -697,19 +697,45 @@ void enterDFUMode() {
 #endif
 }
 
-void handleDeepSleepCommand() {
+void handleDeepSleepCommand(const uint8_t* payload, uint16_t payloadLen) {
     writeSerial("=== DEEP SLEEP COMMAND (0x0052) ===", true);
 #ifdef TARGET_ESP32
+    // Optional 2-byte big-endian seconds payload overrides the configured
+    // deep-sleep duration for exactly one cycle. 0x0000 = explicit no-override.
+    uint16_t overrideSeconds = 0;
+    if (payloadLen >= 2) {
+        overrideSeconds = ((uint16_t)payload[0] << 8) | payload[1];
+        // Bytes beyond 2 ignored for forward compatibility.
+    } else if (payloadLen == 1) {
+        writeSerial("WARNING: malformed 0x0052 payload length 1 - ignoring", true);
+    }
     if (powerLatchDffConfigured()) {
+        if (overrideSeconds != 0) {
+            writeSerial("0x0052 duration payload ignored (D-FF hard power off has no timer)", true);
+        }
         uint8_t ok[] = {0x00, 0x52, 0x00, 0x00};
         sendResponse(ok, sizeof(ok));
         delay(100);
         powerLatchPowerOff();
         return;
     }
+    if (globalConfig.power_option.power_mode != 1) {
+        writeSerial("Device not battery powered - 0x0052 rejected", true);
+        uint8_t errorResponse[] = {0xFF, 0x52, 0x02, 0x00};
+        sendResponse(errorResponse, sizeof(errorResponse));
+        return;
+    }
+    if (globalConfig.power_option.deep_sleep_time_seconds == 0) {
+        writeSerial("Deep sleep disabled in config - 0x0052 rejected", true);
+        uint8_t errorResponse[] = {0xFF, 0x52, 0x01, 0x00};
+        sendResponse(errorResponse, sizeof(errorResponse));
+        return;
+    }
     // Explicit host request: sleep even though the requesting client is connected.
-    enterDeepSleep(true);
+    enterDeepSleep(true, overrideSeconds);
 #else
+    (void)payload;
+    (void)payloadLen;
     writeSerial("Deep sleep command not supported on this target", true);
 #endif
 }

--- a/src/device_control.cpp
+++ b/src/device_control.cpp
@@ -34,6 +34,7 @@ extern volatile bool buttonEventPending;
 extern volatile uint8_t lastChangedButtonIndex;
 void updatemsdata();
 void cleanupDirectWriteState(bool refreshDisplay);
+void resetPipeWriteState(void);
 void sendResponse(uint8_t* response, uint16_t len);
 void writeSerial(String message, bool newLine = true);
 
@@ -92,6 +93,7 @@ void disconnect_callback(uint16_t conn_handle, uint8_t reason) {
     writeSerial("=== BLE CLIENT DISCONNECTED ===", true);
     writeSerial("Disconnect reason: " + String(reason), true);
     cleanupDirectWriteState(true);
+    resetPipeWriteState();   // clear any pipe transfer + reorder queue on disconnect
 }
 
 void reboot(){

--- a/src/device_control.cpp
+++ b/src/device_control.cpp
@@ -34,6 +34,7 @@ extern volatile bool buttonEventPending;
 extern volatile uint8_t lastChangedButtonIndex;
 void updatemsdata();
 void cleanupDirectWriteState(bool refreshDisplay);
+void cleanupPartialWriteOnDisconnect(void);
 void resetPipeWriteState(void);
 void sendResponse(uint8_t* response, uint16_t len);
 void writeSerial(String message, bool newLine = true);
@@ -85,6 +86,10 @@ void connect_callback(uint16_t conn_handle) {
     writeSerial("=== BLE CLIENT CONNECTED ===", true);
     rebootFlag = 0;
     updatemsdata();
+#ifdef TARGET_NRF
+    ble_nrf_log_link_params(conn_handle, "at connect");  // baseline (pre-negotiation)
+    ble_nrf_arm_link_diag(conn_handle);                  // re-log once negotiation settles
+#endif
 }
 
 void disconnect_callback(uint16_t conn_handle, uint8_t reason) {
@@ -93,6 +98,7 @@ void disconnect_callback(uint16_t conn_handle, uint8_t reason) {
     writeSerial("=== BLE CLIENT DISCONNECTED ===", true);
     writeSerial("Disconnect reason: " + String(reason), true);
     cleanupDirectWriteState(true);
+    cleanupPartialWriteOnDisconnect();   // 0x76 / pipe-partial session bookkeeping + panel power
     resetPipeWriteState();   // clear any pipe transfer + reorder queue on disconnect
 }
 

--- a/src/device_control.cpp
+++ b/src/device_control.cpp
@@ -88,6 +88,7 @@ void connect_callback(uint16_t conn_handle) {
     updatemsdata();
 #ifdef TARGET_NRF
     ble_nrf_log_link_params(conn_handle, "at connect");  // baseline (pre-negotiation)
+    ble_nrf_request_fast_link(conn_handle);              // request 2M PHY + 251-octet DLE
     ble_nrf_arm_link_diag(conn_handle);                  // re-log once negotiation settles
 #endif
 }

--- a/src/device_control.h
+++ b/src/device_control.h
@@ -13,6 +13,6 @@ void initButtons();
 void handleLedActivate(uint8_t* data, uint16_t len);
 void handleLedStop(uint8_t* data, uint16_t len);
 void enterDFUMode();
-void handleDeepSleepCommand();
+void handleDeepSleepCommand(const uint8_t* payload, uint16_t payloadLen);
 
 #endif

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -2061,8 +2061,10 @@ void handlePipeWriteStart(uint8_t* data, uint16_t len) {
     if (directWriteActive) cleanupDirectWriteState(false);
     resetPipeWriteState();
 
-    // Fixed 12-byte header; tolerate trailing bytes (future fields).
-    if (len < 12) { sendPipeStartNack(0x01); return; }
+    // Fixed 10-byte payload (opcode already stripped by the dispatcher):
+    // ver(1)+flags(1)+req_w(1)+req_n(1)+client_max_frame(2)+total_size(4).
+    // Tolerate trailing bytes (future fields).
+    if (len < 10) { sendPipeStartNack(0x01); return; }
     uint8_t  ver              = data[0];
     uint8_t  flags            = data[1];
     uint8_t  req_w            = data[2];

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -195,7 +195,19 @@ void checkPartialWriteTimeout(void) {
         (millis() - partialCtx.start_time) > 900000UL) {
         writeSerial("ERROR: Partial write timeout - cleaning up stuck state", true);
         cleanup_partial_write_state();
+        // A pipe-partial transfer shares partialCtx: also clear pipeState so a zombie
+        // pipeState.active can't misroute later 0x0081 frames into the dead partialCtx.
+        if (pipeState.partial) resetPipeWriteState();
     }
+}
+
+// Disconnect hook: a partial session (0x76 or pipe-partial) powers the panel via
+// partial_prepare_panel_ram but never sets directWriteActive, so the disconnect
+// handlers' cleanupDirectWriteState gate misses it and the panel would stay
+// powered until the 15-min watchdog. cleanup_partial_write_state is file-static;
+// this wrapper gives the BLE callbacks a safe no-op-when-idle entry point.
+void cleanupPartialWriteOnDisconnect(void) {
+    if (partialCtx.active) cleanup_partial_write_state();
 }
 
 #define AXP2101_SLAVE_ADDRESS 0x34
@@ -1757,6 +1769,11 @@ void handlePartialWriteStart(uint8_t* data, uint16_t len) {
 }
 
 void handleDirectWriteData(uint8_t* data, uint16_t len) {
+    // A pipe transfer (0x0080-0x0082) owns the panel session — and a pipe-partial
+    // one owns partialCtx. A stray legacy 0x71 must not feed that context out of
+    // band from the sliding-window seq accounting. Silent-discard mirrors how the
+    // pipe path treats frames after a fatal error.
+    if (pipeState.active) return;
     if (partialCtx.active) {
         if (len == 0) return;
         imageWriteLogChunk(data, len);
@@ -1810,6 +1827,10 @@ void handleDirectWriteData(uint8_t* data, uint16_t len) {
 }
 
 void handleDirectWriteEnd(uint8_t* data, uint16_t len) {
+    // Same guard as handleDirectWriteData: a stray legacy 0x72 mid-pipe must not
+    // finalize/refresh a pipe-owned session (partial would commit new_etag==0 and
+    // leave pipeState zombied; full-frame would refresh with pipeState still active).
+    if (pipeState.active) return;
     if (partialCtx.active) {
         if (data != nullptr && len > 1) {
             send_direct_write_nack(0x72, ERR_PARTIAL_STREAM, true);
@@ -1935,6 +1956,23 @@ static void directWriteFinishAndRefresh(uint8_t* data, uint16_t len, uint8_t end
 // directWriteActivatePanel / pipeConsumePayload -> bbepWriteData / zlib) so the
 // legacy 0x70/0x71/0x72 path is untouched. Out-of-order frames are held in a
 // 33-slot reorder queue while the controller stream pauses at a hole.
+//
+// PARTIAL-REGION mode (PIPE_FLAG_PARTIAL, flags bit1): a single-rectangle partial
+// update rides the same sliding window. The 0x0080 START gains a 12-byte LE
+// extension appended after total_size (payload len 22 instead of 10):
+//   [old_etag:4 LE][x:2][y:2][w:2][h:2]   (LE, unlike 0x76's big-endian layout).
+// total_size is the decompressed logical stream size = plane_size*2 where
+// plane_size = calc_controller_plane_bytes(w,h) (old plane then new plane, the
+// same stream 0x76 uses). Geometry/etag are validated exactly like the 0x76
+// handler; the ACK sets response flags bit1 to confirm partial acceptance. DATA
+// (0x0081) is routed to partialCtx (two 1bpp controller planes) instead of the
+// full-frame writer, and partial transfers NEVER auto-complete — the explicit
+// 0x0082 END carries the refresh selector (0->FULL,1->FAST,2/absent->PARTIAL) and
+// new_etag [refresh:1][new_etag:4 BE], driving partial_write_to_panel().
+// START NACK codes: 0x01 len/ver, 0x02 unknown flag, 0x03 size mismatch,
+// 0x05 ETAG_MISMATCH (partial), 0x06 PARTIAL_UNSUPPORTED (partial, bpp!=1/seeed),
+// 0x07 RECT_INVALID (partial, zero/OOB/misaligned rect). Any partial START NACK
+// at the geometry/etag stages clears displayed_etag (parity with 0x76).
 // ===========================================================================
 
 static inline uint8_t pipeSlot(uint8_t seq) { return (uint8_t)(seq % PIPE_REORDER_SLOTS); }
@@ -2001,7 +2039,15 @@ static void sendPipeNack(uint8_t err) {
     pipeBuildAckPayload(r + 3);
     sendResponse(r, sizeof(r));
     pipeState.error = true;
-    cleanupDirectWriteState(true);
+    // Partial transfers own partialCtx, not the full-frame direct-write session:
+    // clear the negotiated etag (any partial NACK invalidates it, parity with
+    // send_direct_write_nack) and power the panel down via the partial cleanup.
+    if (pipeState.partial) {
+        displayed_etag = 0;
+        cleanup_partial_write_state();
+    } else {
+        cleanupDirectWriteState(true);
+    }
 }
 
 // {0xFF,0x80, err, 0x00}. Caller owns any session teardown.
@@ -2027,6 +2073,14 @@ static void pipeUpdateHighestSeen(uint8_t seq) {
 static bool pipeConsumePayload(uint8_t* data, uint16_t len) {
     if (len == 0) return true;
     imageWriteLogChunk(data, len);
+    // Partial transfers stream into the two 1bpp controller planes via partialCtx;
+    // partial_consume_bytes handles zlib-vs-raw and plane-at-a-time sub-window
+    // addressing itself, so the full-frame directWrite* writers below are skipped.
+    if (pipeState.partial) {
+        if (!partial_consume_bytes(data, (uint32_t)len)) return false;
+        imageWriteLogProgress(partialCtx.bytes_received, partialCtx.expected_stream_size);
+        return true;
+    }
     if (directWriteCompressed) {
         if (!handleDirectWriteCompressedData(data, len)) return false;
         directWriteCompressedReceived += len;
@@ -2074,18 +2128,60 @@ void handlePipeWriteStart(uint8_t* data, uint16_t len) {
                               | ((uint32_t)data[8] << 16) | ((uint32_t)data[9] << 24);
 
     if (ver != PIPE_VERSION) { sendPipeStartNack(0x01); return; }
-    // Only zlib compression (flags bit0) is defined; any reserved bit set is unsupported.
-    if ((flags & ~PIPE_FLAG_COMPRESSED) != 0) { sendPipeStartNack(0x02); return; }
+    // Defined flags: bit0 zlib compression, bit1 partial-region refresh. Any other bit unsupported.
+    if ((flags & ~(PIPE_FLAG_COMPRESSED | PIPE_FLAG_PARTIAL)) != 0) { sendPipeStartNack(0x02); return; }
 
     bool compressed = (flags & PIPE_FLAG_COMPRESSED) != 0;
+    bool partial    = (flags & PIPE_FLAG_PARTIAL) != 0;
 
-    // Geometry is pure config math (no panel I/O), so total_size can be validated
-    // before any hardware is touched — a NACK here needs no teardown.
-    directWriteComputeGeometry(compressed);
-    // total_size is the decompressed panel byte total for BOTH modes (plan 1.1).
-    if (total_size != directWriteTotalBytes) {
-        sendPipeStartNack(0x03);
-        return;
+    // Partial START appends a 12-byte LE extension after total_size (payload len 22 vs 10):
+    // [old_etag:4][x:2][y:2][w:2][h:2]. LE, unlike 0x76's big-endian layout.
+    if (partial && len < 22) { sendPipeStartNack(0x01); return; }
+    uint32_t old_etag = 0;
+    uint16_t rectX = 0, rectY = 0, rectW = 0, rectH = 0;
+    uint32_t planeBytes = 0;
+    if (partial) {
+        old_etag = (uint32_t)data[10] | ((uint32_t)data[11] << 8)
+                 | ((uint32_t)data[12] << 16) | ((uint32_t)data[13] << 24);
+        rectX = (uint16_t)data[14] | ((uint16_t)data[15] << 8);
+        rectY = (uint16_t)data[16] | ((uint16_t)data[17] << 8);
+        rectW = (uint16_t)data[18] | ((uint16_t)data[19] << 8);
+        rectH = (uint16_t)data[20] | ((uint16_t)data[21] << 8);
+
+        // Partial validations (plan 1.2, order 5-7). All precede any hardware touch; any
+        // failure clears displayed_etag for parity with send_direct_write_nack. These are
+        // the same checks the 0x76 handler runs (bpp, etag, bounds, alignment).
+        uint16_t dispW = globalConfig.displays[0].pixel_width;
+        uint16_t dispH = globalConfig.displays[0].pixel_height;
+        // 5: two 1bpp controller planes are the partial mechanism; seeed/IT8951 has no equivalent.
+        if (getBitsPerPixel() != 1 || seeed_driver_used()) {
+            displayed_etag = 0; sendPipeStartNack(0x06); return;
+        }
+        // 6: etag gate — nonzero and must match what is currently on the panel.
+        if (old_etag == 0 || old_etag != displayed_etag) {
+            displayed_etag = 0; sendPipeStartNack(0x05); return;
+        }
+        // 7: rectangle must be non-empty, in-bounds, and x/width byte-aligned (1bpp packing).
+        if (rectW == 0 || rectH == 0 ||
+            (uint32_t)rectX + rectW > dispW || (uint32_t)rectY + rectH > dispH ||
+            (rectX & 7u) != 0 || (rectW & 7u) != 0) {
+            displayed_etag = 0; sendPipeStartNack(0x07); return;
+        }
+    }
+
+    // total_size validation (plan 1.2, order 8). Pure config/geometry math (no panel I/O),
+    // so a NACK here needs no teardown. Partial: plane_size*2 (flat old+new planes, like
+    // 0x76). Full: directWriteComputeGeometry's decompressed panel byte total.
+    if (partial) {
+        planeBytes = calc_controller_plane_bytes(rectW, rectH);
+        if (planeBytes == 0 || total_size != planeBytes * 2u) {
+            // Plan 1.2: every partial-request NACK at steps 5-8 clears the etag
+            // (parity with send_direct_write_nack).
+            displayed_etag = 0; sendPipeStartNack(0x03); return;
+        }
+    } else {
+        directWriteComputeGeometry(compressed);
+        if (total_size != directWriteTotalBytes) { sendPipeStartNack(0x03); return; }
     }
 
     // Effective values (min-rule, plan 1.1). Floors at 1; N <= W; frame <= 244.
@@ -2113,21 +2209,56 @@ void handlePipeWriteStart(uint8_t* data, uint16_t len) {
     pipeState.total_size = total_size;
     pipeState.queued_count = 0;
     pipeState.queue_high_water = 0;
+    pipeState.partial = partial;
+
+    // Partial transfers own partialCtx (two 1bpp planes); init it exactly as the 0x76
+    // START does, but new_etag stays 0 — it rides the 0x0082 END. Bookkeeping only; the
+    // panel RAM prep (partial_prepare_panel_ram) waits until after the ACK, below.
+    if (partial) {
+        memset(&partialCtx, 0, sizeof(partialCtx));
+        partialCtx.active = true;
+        partialCtx.compressed = compressed;
+        partialCtx.flags = flags;
+        partialCtx.new_etag = 0;
+        partialCtx.x = rectX;
+        partialCtx.y = rectY;
+        partialCtx.width = rectW;
+        partialCtx.height = rectH;
+        partialCtx.expected_stream_size = total_size;
+        partialCtx.plane_size = planeBytes;
+        partialCtx.current_plane = 0xFF;
+        partialCtx.start_time = millis();
+    }
 
     // Respond BEFORE panel bring-up: slow panels (Spectra/ACeP-class init can take
-    // > 2 s) must not blow the client's 2 s pipe probe, which would cache pipe mode
-    // off for the whole connection on exactly the devices that need it most.
+    // seconds) must not starve the client's 0x0080 START wait. Clients gate pipe
+    // attempts on the config pipe bit and wait a normal command timeout (30 s,
+    // sized for the ESP32 response-queue flush landing after bring-up), but
+    // responding first keeps the wait short on nRF and any direct-notify path.
     // Ordering is safe on both targets: on ESP32 this handler runs in the main-loop
     // queue drain, so 0x0081 frames arriving during bring-up park in the 33-slot
     // ingest ring until we return; on nRF the Bluefruit write callback dispatches
     // commands sequentially from its callback task, so activation below completes
     // before any queued 0x0081 write is handed to the dispatcher.
-    // Device maxima; flags bit0 SET (buffers out-of-order / selective repeat).
+    // Device maxima; flags bit0 SET (selective repeat), bit1 = partial accepted (plan 1.2).
     uint8_t resp[8] = {0x00, 0x80, PIPE_VERSION, PIPE_MAX_W, PIPE_MAX_N,
-                       (uint8_t)(PIPE_MAX_FRAME & 0xFF), (uint8_t)((PIPE_MAX_FRAME >> 8) & 0xFF), 0x01};
+                       (uint8_t)(PIPE_MAX_FRAME & 0xFF), (uint8_t)((PIPE_MAX_FRAME >> 8) & 0xFF),
+                       (uint8_t)(0x01 | (partial ? PIPE_FLAG_PARTIAL : 0))};
     sendResponse(resp, sizeof(resp));
 
-    // Bring up the session exactly like legacy START (touch suspend, panel prep).
+    if (partial) {
+        // Partial bring-up (0x76 parity): white-fill both controller planes and reset the
+        // zlib stream if compressed. Deliberately NOT the full-frame path — do not suspend
+        // touch, set directWriteActive, or call directWriteActivatePanel (partial_write_to_panel
+        // powers the panel down on the 0x0082 END; partial_prepare_panel_ram brought it up).
+        imageWriteLogReset();
+        imageWriteLogStart(total_size);
+        partial_prepare_panel_ram();
+        if (compressed) od_zlib_stream_reset(total_size);
+        return;
+    }
+
+    // Bring up the full-frame session exactly like legacy START (touch suspend, panel prep).
     imageWriteLogReset();
     touchSuspendForEpdRefresh();
     directWriteTouchSuspended = true;
@@ -2172,9 +2303,12 @@ void handlePipeWriteData(uint8_t* data, uint16_t len) {
             if (pipeState.frames_since_ack < 0xFF) pipeState.frames_since_ack++;
         }
         if (pipeState.queued_count == 0) pipeState.gap_open = false;
-        // Auto-complete (uncompressed only, mirrors legacy handleDirectWriteData auto-finish).
-        // The shared helper emits the single unsolicited {0x00,0x82} END ack then refreshes.
-        if (!pipeState.compressed && directWriteBytesWritten >= directWriteTotalBytes) {
+        // Auto-complete (uncompressed FULL-FRAME only, mirrors legacy handleDirectWriteData
+        // auto-finish). The shared helper emits the single unsolicited {0x00,0x82} END ack then
+        // refreshes with a FULL waveform. MUST be gated on !partial: a partial transfer never
+        // touches directWrite* (both are 0), so 0>=0 would false-fire a FULL refresh on the very
+        // first frame — partial transfers complete only on the explicit 0x0082 END (plan 1.5).
+        if (!pipeState.partial && !pipeState.compressed && directWriteBytesWritten >= directWriteTotalBytes) {
             sendPipeAck();                                   // final tail flush ({0x00,0x81})
             directWriteFinishAndRefresh(nullptr, 0, 0x82);   // {0x00,0x82} + FULL refresh, no etag
             resetPipeWriteState();
@@ -2238,13 +2372,56 @@ void handlePipeWriteEnd(uint8_t* data, uint16_t len) {
         uint8_t n[2] = {0xFF, 0x82};   // a fatal error already NACKed this transfer
         sendResponse(n, sizeof(n));
         // sendPipeNack already released the panel hardware at NACK time; this
-        // re-run is a defensive no-op (directWriteActive/displayPowerState false).
-        cleanupDirectWriteState(false);
+        // re-run is a defensive no-op (partialCtx / directWriteActive already down).
+        if (pipeState.partial) cleanup_partial_write_state();
+        else cleanupDirectWriteState(false);
         resetPipeWriteState();
         return;
     }
     // Tail-flush ACK precedes the END result (plan 1.3c / 1.5).
     sendPipeAck();
+
+    // Partial transfers never auto-complete (plan 1.5): the 0x0082 END alone carries the
+    // refresh mode + new_etag. Completeness mirrors the 0x76 partial branch.
+    if (pipeState.partial) {
+        bool incomplete = (pipeState.queued_count > 0);
+        if (partialCtx.compressed) {
+            if (partialCtx.bytes_received == 0 || !zlib_stream_to_partial_write(nullptr, 0, true)) incomplete = true;
+        } else if (partialCtx.bytes_written != partialCtx.expected_stream_size) {
+            incomplete = true;
+        }
+        if (incomplete) {
+            uint8_t n[2] = {0xFF, 0x82};
+            sendResponse(n, sizeof(n));
+            displayed_etag = 0;
+            cleanup_partial_write_state();
+            resetPipeWriteState();
+            return;
+        }
+        imageWriteLogFinish(partialCtx.bytes_received, partialCtx.expected_stream_size);
+        uint8_t ackResponse[] = {0x00, 0x82};
+        sendResponse(ackResponse, sizeof(ackResponse));
+        // Refresh selector rides the END tail (plan 1.4): 0->FULL, 1->FAST, 2/absent->PARTIAL.
+        int refreshMode = REFRESH_PARTIAL;
+        if (data != nullptr && len >= 1 && data[0] == REFRESH_FULL) refreshMode = REFRESH_FULL;
+        else if (data != nullptr && len >= 1 && data[0] == REFRESH_FAST) refreshMode = REFRESH_FAST;
+        // new_etag rides the END tail [refresh:1][new_etag:4 BE]; absent => 0.
+        uint32_t newEtag = (len >= 5) ? parse_be_u32(data + 1) : 0;
+        bool refreshSuccess = partial_write_to_panel(refreshMode);
+        if (refreshSuccess) {
+            displayed_etag = newEtag;
+            uint8_t validatedResponse[] = {0x00, 0x73};
+            sendResponse(validatedResponse, sizeof(validatedResponse));
+        } else {
+            displayed_etag = 0;
+            uint8_t timeoutResponse[] = {0x00, 0x74};
+            sendResponse(timeoutResponse, sizeof(timeoutResponse));
+        }
+        cleanup_partial_write_state();
+        resetPipeWriteState();
+        return;
+    }
+
     // The client must not send END before every chunk is acked; a hole or short
     // byte count here is a protocol violation.
     bool incomplete = (pipeState.queued_count > 0);

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -177,6 +177,19 @@ static uint32_t parse_be_u32(const uint8_t* data);
 static void send_direct_write_nack(uint8_t opcode, uint8_t error, bool cleanupState);
 static PartialStreamContext partialCtx = {};
 
+// Direct-write session-setup helpers (shared by legacy 0x70 START and PIPE 0x80 START)
+// and the shared END/refresh tail (shared by legacy 0x72 END, PIPE 0x82 END, and
+// both auto-complete paths). Declared here; defined below near the direct-write handlers.
+static void directWriteComputeGeometry(bool compressed);
+static void directWriteActivatePanel(void);
+static void directWriteFinishAndRefresh(uint8_t* data, uint16_t len, uint8_t endOpcode);
+
+// PIPE_WRITE (0x0080-0x0082) sliding-window receive state + reorder queue. Declared
+// early so the quiet-logging predicates below can consult pipeState.active. The
+// reorder array is a file static (not in the struct) so both targets pay it once.
+static PipeWriteState pipeState = {};
+static PipeReorderSlot pipeReorder[PIPE_REORDER_SLOTS];
+
 void checkPartialWriteTimeout(void) {
     if (partialCtx.active && partialCtx.start_time > 0 &&
         (millis() - partialCtx.start_time) > 900000UL) {
@@ -1448,11 +1461,11 @@ static void imageWriteLogFinish(uint32_t written, uint32_t total) {
 }
 
 bool imageWriteLogQuietCmd(void) {
-    return (directWriteActive || partialCtx.active) && imgLogChunks >= 1;
+    return (directWriteActive || partialCtx.active || pipeState.active) && imgLogChunks >= 1;
 }
 
 bool imageWriteLogQuietAck(void) {
-    return (directWriteActive || partialCtx.active) && imgLogChunks >= 2;
+    return (directWriteActive || partialCtx.active || pipeState.active) && imgLogChunks >= 2;
 }
 
 // True when this raw frame is a mid-stream image-write data chunk (command
@@ -1460,27 +1473,23 @@ bool imageWriteLogQuietAck(void) {
 // be suppressed. Lets the receive callback and queue drain in the other files
 // silence their spam without duplicating the stream-state check.
 bool imageWriteLogQuietFrame(const uint8_t* data, uint16_t len) {
-    return len >= 2 && data[0] == 0x00 && data[1] == 0x71 && imageWriteLogQuietCmd();
+    return len >= 2 && data[0] == 0x00 &&
+           (data[1] == 0x71 || data[1] == 0x81) && imageWriteLogQuietCmd();
 }
 // ---------------------------------------------------------------------------
 
-void handleDirectWriteCompressedData(uint8_t* data, uint16_t len) {
+// Consume one compressed direct-write payload into the panel controller. Returns
+// false on overflow guard or decompress/write failure; the CALLER owns cleanup and
+// ACK/NACK emission (legacy 0x71 caller keeps its byte-identical acks; PIPE reuses
+// the bool core without acking per frame). Does NOT advance directWriteCompressedReceived.
+bool handleDirectWriteCompressedData(uint8_t* data, uint16_t len) {
     if (len > UINT32_MAX - directWriteCompressedReceived) {
-        cleanupDirectWriteState(true);
-        uint8_t errorResponse[] = {0xFF, 0x71};
-        sendResponse(errorResponse, sizeof(errorResponse));
-        return;
+        return false;
     }
     if (!zlib_stream_to_direct_write(data, len, false)) {
-        cleanupDirectWriteState(true);
-        uint8_t errorResponse[] = {0xFF, 0x71};
-        sendResponse(errorResponse, sizeof(errorResponse));
-        return;
+        return false;
     }
-    directWriteCompressedReceived += len;
-    imageWriteLogProgress(directWriteBytesWritten, directWriteTotalBytes);
-    uint8_t ackResponse[] = {0x00, 0x71};
-    sendResponse(ackResponse, sizeof(ackResponse));
+    return true;
 }
 
 // True when the active display uses the bb_epaper 4-gray scheme (two 1-bit
@@ -1556,26 +1565,16 @@ void cleanupDirectWriteState(bool refreshDisplay) {
     }
 }
 
-void handleDirectWriteStart(uint8_t* data, uint16_t len) {
-if (partialCtx.active) cleanup_partial_write_state();
-    if (directWriteActive) {
-        cleanupDirectWriteState(false);
-    }
-    imageWriteLogReset();
-    touchSuspendForEpdRefresh();
-    directWriteTouchSuspended = true;
-#if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
-    if (seeed_driver_used()) {
-        seeed_gfx_prepare_hardware();
-    }
-#endif
+// Computes the panel geometry and total controller byte count for a direct-write
+// session and records the compressed flag. Sets directWrite{Compressed,Bitplanes,
+// Plane2,Width,Height,TotalBytes}. No panel I/O, no acks. Shared by 0x70 and 0x80.
+static void directWriteComputeGeometry(bool compressed) {
     uint8_t colorScheme = globalConfig.displays[0].color_scheme;
     directWriteBitplanes = (colorScheme == COLOR_SCHEME_BWR || colorScheme == COLOR_SCHEME_BWY);
     directWritePlane2 = false;
-    directWriteCompressed = (len >= 4);
+    directWriteCompressed = compressed;
     directWriteWidth = globalConfig.displays[0].pixel_width;
     directWriteHeight = globalConfig.displays[0].pixel_height;
-    uint32_t pixels = (uint32_t)directWriteWidth * (uint32_t)directWriteHeight;
     if (directWriteBitplanes) directWriteTotalBytes = 2u * (((uint32_t)directWriteWidth + 7u) / 8u) * directWriteHeight;
     else {
         // Panel RAM is row-padded: each row occupies ceil(w / pixelsPerByte) bytes, and the
@@ -1594,15 +1593,12 @@ if (partialCtx.active) cleanup_partial_write_state();
     // streamGray4Bytes as chunks arrive.
     const bool gray4 = directWriteIsGray4();
     if (gray4) directWriteTotalBytes = 2u * (((uint32_t)directWriteWidth + 7u) / 8u) * directWriteHeight;
-    if (directWriteCompressed) {
-        memcpy(&directWriteDecompressedTotal, data, 4);
-        if (directWriteDecompressedTotal != directWriteTotalBytes) {
-            cleanupDirectWriteState(false);
-            uint8_t errorResponse[] = {0xFF, 0x70};
-            sendResponse(errorResponse, sizeof(errorResponse));
-            return;
-        }
-    }
+}
+
+// Powers/initializes the panel, opens the full address window, and (compressed)
+// resets the zlib streamer. directWriteDecompressedTotal must already be set for
+// compressed. Shared by 0x70 and 0x80. No header parsing, no inline data, no acks.
+static void directWriteActivatePanel(void) {
     directWriteActive = true;
     directWriteBytesWritten = 0;
     directWriteStartTime = millis();
@@ -1626,16 +1622,44 @@ if (partialCtx.active) cleanup_partial_write_state();
     }
     if (directWriteCompressed) {
         od_zlib_stream_reset(directWriteDecompressedTotal);
-        if (len > 4) {
-            uint32_t compressedDataLen = len - 4;
-            if (!zlib_stream_to_direct_write(data + 4, compressedDataLen, false)) {
-                cleanupDirectWriteState(false);
-                uint8_t errorResponse[] = {0xFF, 0x70};
-                sendResponse(errorResponse, sizeof(errorResponse));
-                return;
-            }
-            directWriteCompressedReceived = compressedDataLen;
+    }
+}
+
+void handleDirectWriteStart(uint8_t* data, uint16_t len) {
+    if (partialCtx.active) cleanup_partial_write_state();
+    if (directWriteActive) {
+        cleanupDirectWriteState(false);
+    }
+    resetPipeWriteState();
+    imageWriteLogReset();
+    touchSuspendForEpdRefresh();
+    directWriteTouchSuspended = true;
+#if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
+    if (seeed_driver_used()) {
+        seeed_gfx_prepare_hardware();
+    }
+#endif
+    bool compressed = (len >= 4);
+    directWriteComputeGeometry(compressed);
+    if (compressed) {
+        memcpy(&directWriteDecompressedTotal, data, 4);
+        if (directWriteDecompressedTotal != directWriteTotalBytes) {
+            cleanupDirectWriteState(false);
+            uint8_t errorResponse[] = {0xFF, 0x70};
+            sendResponse(errorResponse, sizeof(errorResponse));
+            return;
         }
+    }
+    directWriteActivatePanel();
+    if (compressed && len > 4) {
+        uint32_t compressedDataLen = len - 4;
+        if (!zlib_stream_to_direct_write(data + 4, compressedDataLen, false)) {
+            cleanupDirectWriteState(false);
+            uint8_t errorResponse[] = {0xFF, 0x70};
+            sendResponse(errorResponse, sizeof(errorResponse));
+            return;
+        }
+        directWriteCompressedReceived = compressedDataLen;
     }
     uint8_t ackResponse[] = {0x00, 0x70};
     sendResponse(ackResponse, sizeof(ackResponse));
@@ -1644,6 +1668,7 @@ if (partialCtx.active) cleanup_partial_write_state();
 void handlePartialWriteStart(uint8_t* data, uint16_t len) {
     if (directWriteActive) cleanupDirectWriteState(false);
     if (partialCtx.active) cleanup_partial_write_state();
+    resetPipeWriteState();
     imageWriteLogReset();
 
     if (len < 17) {
@@ -1747,7 +1772,16 @@ void handleDirectWriteData(uint8_t* data, uint16_t len) {
     if (!directWriteActive || len == 0) return;
     imageWriteLogChunk(data, len);
     if (directWriteCompressed) {
-        handleDirectWriteCompressedData(data, len);
+        if (!handleDirectWriteCompressedData(data, len)) {
+            cleanupDirectWriteState(true);
+            uint8_t errorResponse[] = {0xFF, 0x71};
+            sendResponse(errorResponse, sizeof(errorResponse));
+        } else {
+            directWriteCompressedReceived += len;
+            imageWriteLogProgress(directWriteBytesWritten, directWriteTotalBytes);
+            uint8_t ackResponse[] = {0x00, 0x71};
+            sendResponse(ackResponse, sizeof(ackResponse));
+        }
         return;
     }
     uint32_t remainingBytes = (directWriteBytesWritten < directWriteTotalBytes) ? (directWriteTotalBytes - directWriteBytesWritten) : 0;
@@ -1810,21 +1844,29 @@ void handleDirectWriteEnd(uint8_t* data, uint16_t len) {
         return;
     }
     if (!directWriteActive) return;
+    directWriteFinishAndRefresh(data, len, 0x72);
+}
+
+// Shared finalize+refresh tail for a full-frame direct-write session. Emits the
+// END success ack {0x00,endOpcode} (0x72 legacy / 0x82 PIPE) or a NACK
+// {0xFF,endOpcode} on compressed-flush/completeness failure, then refreshes the
+// panel and emits {0x00,0x73}/{0x00,0x74}. Caller guarantees directWriteActive.
+static void directWriteFinishAndRefresh(uint8_t* data, uint16_t len, uint8_t endOpcode) {
     directWriteStartTime = 0;
     if (directWriteCompressed && !zlib_stream_to_direct_write(nullptr, 0, true)) {
         cleanupDirectWriteState(true);
-        uint8_t errorResponse[] = {0xFF, 0x72};
+        uint8_t errorResponse[] = {0xFF, endOpcode};
         sendResponse(errorResponse, sizeof(errorResponse));
         return;
     }
     const bool gray4 = directWriteIsGray4();
     if (gray4 || directWriteBitplanes) {
         // Both planes must be present before refresh. Compressed and uncompressed
-        // paths stream live as 0x71 chunks, so confirm the full two-plane payload
+        // paths stream live as chunks, so confirm the full two-plane payload
         // arrived before refreshing stale RAM or committing an etag.
         if (directWriteBytesWritten != directWriteTotalBytes) {
             cleanupDirectWriteState(false);
-            uint8_t errorResponse[] = {0xFF, 0x72};
+            uint8_t errorResponse[] = {0xFF, endOpcode};
             sendResponse(errorResponse, sizeof(errorResponse));
             return;
         }
@@ -1844,7 +1886,7 @@ void handleDirectWriteEnd(uint8_t* data, uint16_t len) {
         writeSerial("none (auto)", false);
     }
     writeSerial(")", true);
-    uint8_t ackResponse[] = {0x00, 0x72};
+    uint8_t ackResponse[] = {0x00, endOpcode};
     sendResponse(ackResponse, sizeof(ackResponse));
     delay(20);
     epdRefreshInProgress = true;
@@ -1885,6 +1927,340 @@ void handleDirectWriteEnd(uint8_t* data, uint16_t len) {
         uint8_t timeoutResponse[] = {0x00, 0x74};
         sendResponse(timeoutResponse, sizeof(timeoutResponse));
     }
+}
+
+// ===========================================================================
+// PIPE_WRITE (0x0080-0x0082): sliding-window image transfer with QUIC-style SACK.
+// Reuses the direct-write session machinery (directWriteComputeGeometry /
+// directWriteActivatePanel / pipeConsumePayload -> bbepWriteData / zlib) so the
+// legacy 0x70/0x71/0x72 path is untouched. Out-of-order frames are held in a
+// 33-slot reorder queue while the controller stream pauses at a hole.
+// ===========================================================================
+
+static inline uint8_t pipeSlot(uint8_t seq) { return (uint8_t)(seq % PIPE_REORDER_SLOTS); }
+
+void resetPipeWriteState(void) {
+    pipeState = PipeWriteState{};
+    for (int i = 0; i < PIPE_REORDER_SLOTS; ++i) pipeReorder[i].occupied = false;
+}
+
+bool pipeWriteActive(void) { return pipeState.active; }
+
+// A chunk c is "received" for ACK purposes if it was accepted in-order (lies just
+// below expected_seq within the mask window) or is currently held in the reorder
+// queue. The accepted-prefix depth is bounded by received_count (chunks actually
+// streamed this transfer, i.e. expected_seq advances): a plain mod-256 distance
+// test would wrap during the first 32 chunks and assert phantom "received" bits
+// for seqs 224-255 that predate the transfer (e.g. expected_seq=8 claiming seq
+// 250). Never marks an in-range unreceived chunk; highest_seen=0 with only chunk
+// 0 accepted yields mask=0.
+static bool pipeChunkReceived(uint8_t c) {
+    uint8_t below = (uint8_t)(pipeState.expected_seq - 1 - c);   // distance below expected
+    uint32_t acceptedDepth = (pipeState.received_count < PIPE_ACK_MASK_BITS)
+                           ? pipeState.received_count : PIPE_ACK_MASK_BITS;
+    if (below < acceptedDepth) return true;                      // accepted (in-order prefix)
+    return pipeReorder[pipeSlot(c)].occupied && pipeReorder[pipeSlot(c)].seq == c;
+}
+
+// Fills out[0]=highest_seen, out[1..4]=32-bit ack_mask LE. Mask bit i (LSB first)
+// = chunk (highest_seen - 1 - i) received. highest_seen implicitly acked.
+static void pipeBuildAckPayload(uint8_t* out) {
+    uint8_t hs = pipeState.has_received ? pipeState.highest_seen
+                                        : (uint8_t)(pipeState.expected_seq - 1);
+    uint32_t mask = 0;
+    for (uint8_t i = 0; i < PIPE_ACK_MASK_BITS; ++i) {
+        if (pipeChunkReceived((uint8_t)(hs - 1 - i))) mask |= (1u << i);
+    }
+    out[0] = hs;
+    out[1] = (uint8_t)(mask & 0xFF);
+    out[2] = (uint8_t)((mask >> 8) & 0xFF);
+    out[3] = (uint8_t)((mask >> 16) & 0xFF);
+    out[4] = (uint8_t)((mask >> 24) & 0xFF);
+}
+
+// {0x00,0x81, highest_seen, ack_mask LE(4)} via sendResponse (auto-encrypts when
+// authenticated). Resets both cadence counters.
+static void sendPipeAck(void) {
+    uint8_t r[7] = {0x00, 0x81, 0, 0, 0, 0, 0};
+    pipeBuildAckPayload(r + 2);
+    sendResponse(r, sizeof(r));
+    pipeState.frames_since_ack = 0;
+    pipeState.ooo_acks_since_gap = 0;
+}
+
+// {0xFF,0x81, err, highest_seen, ack_mask LE(4)}. All 0x81 NACKs are FATAL: the
+// payload is built from pipeState + reorder queue BEFORE any teardown, the error
+// flag makes subsequent 0x0081 frames silently discard until the next 0x0080 /
+// disconnect (pipeState and the reorder queue are deliberately NOT reset so the
+// reported ACK position stays consistent), and the panel hardware is released the
+// same way the legacy mid-stream {0xFF,0x71} failure does (cleanupDirectWriteState
+// with refreshDisplay=true: sleep a powered controller cleanly, cut power, resume
+// touch) instead of leaving the panel powered until the next transfer.
+static void sendPipeNack(uint8_t err) {
+    uint8_t r[8] = {0xFF, 0x81, err, 0, 0, 0, 0, 0};
+    pipeBuildAckPayload(r + 3);
+    sendResponse(r, sizeof(r));
+    pipeState.error = true;
+    cleanupDirectWriteState(true);
+}
+
+// {0xFF,0x80, err, 0x00}. Caller owns any session teardown.
+static void sendPipeStartNack(uint8_t err) {
+    uint8_t r[4] = {0xFF, 0x80, err, 0x00};
+    sendResponse(r, sizeof(r));
+}
+
+// Advance highest_seen only for a genuinely newer seq (forward distance small and
+// nonzero) so duplicates/late frames never move it backward.
+static void pipeUpdateHighestSeen(uint8_t seq) {
+    if (!pipeState.has_received) {
+        pipeState.has_received = true;
+        pipeState.highest_seen = seq;
+        return;
+    }
+    uint8_t fwd = (uint8_t)(seq - pipeState.highest_seen);
+    if (fwd != 0 && fwd <= PIPE_ACK_MASK_BITS) pipeState.highest_seen = seq;
+}
+
+// Feed one DATA payload to the panel controller through the SAME machinery the
+// legacy 0x71 path uses. Returns false on any write/decompress/overflow failure.
+static bool pipeConsumePayload(uint8_t* data, uint16_t len) {
+    if (len == 0) return true;
+    imageWriteLogChunk(data, len);
+    if (directWriteCompressed) {
+        if (!handleDirectWriteCompressedData(data, len)) return false;
+        directWriteCompressedReceived += len;
+        imageWriteLogProgress(directWriteBytesWritten, directWriteTotalBytes);
+        return true;
+    }
+    uint32_t remaining = (directWriteBytesWritten < directWriteTotalBytes)
+                       ? (directWriteTotalBytes - directWriteBytesWritten) : 0;
+    uint16_t toWrite = (len > remaining) ? (uint16_t)remaining : len;
+    if (toWrite > 0) {
+#if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
+        if (seeed_driver_used()) {
+            seeed_gfx_direct_write_chunk(data, toWrite);
+            directWriteBytesWritten += toWrite;
+        } else
+#endif
+        if (directWriteIsGray4() || directWriteBitplanes) {
+            streamGray4Bytes(data, toWrite);  // advances directWriteBytesWritten, splits planes
+        } else {
+            bbepWriteData(&bbep, data, toWrite);
+            directWriteBytesWritten += toWrite;
+        }
+    }
+    imageWriteLogProgress(directWriteBytesWritten, directWriteTotalBytes);
+    return true;
+}
+
+void handlePipeWriteStart(uint8_t* data, uint16_t len) {
+    // A new START aborts any in-flight transfer of any family and resets pipe state
+    // (mirrors legacy START). Reset happens up-front so even a malformed START is safe.
+    if (partialCtx.active) cleanup_partial_write_state();
+    if (directWriteActive) cleanupDirectWriteState(false);
+    resetPipeWriteState();
+
+    // Fixed 12-byte header; tolerate trailing bytes (future fields).
+    if (len < 12) { sendPipeStartNack(0x01); return; }
+    uint8_t  ver              = data[0];
+    uint8_t  flags            = data[1];
+    uint8_t  req_w            = data[2];
+    uint8_t  req_n            = data[3];
+    uint16_t client_max_frame = (uint16_t)data[4] | ((uint16_t)data[5] << 8);
+    uint32_t total_size       = (uint32_t)data[6] | ((uint32_t)data[7] << 8)
+                              | ((uint32_t)data[8] << 16) | ((uint32_t)data[9] << 24);
+
+    if (ver != PIPE_VERSION) { sendPipeStartNack(0x01); return; }
+    // Only zlib compression (flags bit0) is defined; any reserved bit set is unsupported.
+    if ((flags & ~PIPE_FLAG_COMPRESSED) != 0) { sendPipeStartNack(0x02); return; }
+
+    bool compressed = (flags & PIPE_FLAG_COMPRESSED) != 0;
+
+    // Geometry is pure config math (no panel I/O), so total_size can be validated
+    // before any hardware is touched — a NACK here needs no teardown.
+    directWriteComputeGeometry(compressed);
+    // total_size is the decompressed panel byte total for BOTH modes (plan 1.1).
+    if (total_size != directWriteTotalBytes) {
+        sendPipeStartNack(0x03);
+        return;
+    }
+
+    // Effective values (min-rule, plan 1.1). Floors at 1; N <= W; frame <= 244.
+    uint8_t w_eff = req_w > PIPE_MAX_W ? PIPE_MAX_W : req_w;
+    if (w_eff == 0) w_eff = 1;
+    if (isEncryptionEnabled() && isAuthenticated() && w_eff > 32) w_eff = 32;  // defensive (mask width)
+    uint8_t n_eff = req_n > PIPE_MAX_N ? PIPE_MAX_N : req_n;
+    if (n_eff == 0) n_eff = 1;
+    if (n_eff > w_eff) n_eff = w_eff;
+    uint16_t frame_eff = client_max_frame < PIPE_MAX_FRAME ? client_max_frame : PIPE_MAX_FRAME;
+
+    pipeState.active = true;
+    pipeState.error = false;
+    pipeState.compressed = compressed;
+    pipeState.gap_open = false;
+    pipeState.window = w_eff;
+    pipeState.ack_every = n_eff;
+    pipeState.max_frame = frame_eff;
+    pipeState.expected_seq = 0;
+    pipeState.has_received = false;
+    pipeState.highest_seen = 0;
+    pipeState.received_count = 0;
+    pipeState.frames_since_ack = 0;
+    pipeState.ooo_acks_since_gap = 0;
+    pipeState.total_size = total_size;
+    pipeState.queued_count = 0;
+    pipeState.queue_high_water = 0;
+
+    // Respond BEFORE panel bring-up: slow panels (Spectra/ACeP-class init can take
+    // > 2 s) must not blow the client's 2 s pipe probe, which would cache pipe mode
+    // off for the whole connection on exactly the devices that need it most.
+    // Ordering is safe on both targets: on ESP32 this handler runs in the main-loop
+    // queue drain, so 0x0081 frames arriving during bring-up park in the 33-slot
+    // ingest ring until we return; on nRF the Bluefruit write callback dispatches
+    // commands sequentially from its callback task, so activation below completes
+    // before any queued 0x0081 write is handed to the dispatcher.
+    // Device maxima; flags bit0 SET (buffers out-of-order / selective repeat).
+    uint8_t resp[8] = {0x00, 0x80, PIPE_VERSION, PIPE_MAX_W, PIPE_MAX_N,
+                       (uint8_t)(PIPE_MAX_FRAME & 0xFF), (uint8_t)((PIPE_MAX_FRAME >> 8) & 0xFF), 0x01};
+    sendResponse(resp, sizeof(resp));
+
+    // Bring up the session exactly like legacy START (touch suspend, panel prep).
+    imageWriteLogReset();
+    touchSuspendForEpdRefresh();
+    directWriteTouchSuspended = true;
+#if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
+    if (seeed_driver_used()) {
+        seeed_gfx_prepare_hardware();
+    }
+#endif
+    directWriteDecompressedTotal = total_size;   // compressed zlib reset + overflow guard
+    directWriteActivatePanel();
+}
+
+void handlePipeWriteData(uint8_t* data, uint16_t len) {
+    if (!pipeState.active || pipeState.error) return;   // silent discard
+    if (len < 1) return;
+    uint8_t  seq     = data[0];
+    uint8_t* payload = data + 1;
+    uint16_t plen    = (uint16_t)(len - 1);
+    if (plen > PIPE_REORDER_SLOT_SIZE) { sendPipeNack(0x03); return; }  // over-size frame (impossible <=244)
+
+    const uint8_t W   = pipeState.window;
+    uint8_t fwd  = (uint8_t)(seq - pipeState.expected_seq);   // 0 in-order; 1..W-1 ahead
+    uint8_t back = (uint8_t)(pipeState.expected_seq - seq);   // >=1 below expected
+
+    if (fwd == 0) {
+        // In-order accept -> stream to controller, then drain contiguous successors.
+        // Count every accepted frame (trigger + drained) toward the ACK cadence so a
+        // post-gap drain refunds tokens promptly instead of waiting for fresh frames.
+        if (!pipeConsumePayload(payload, plen)) { sendPipeNack(pipeState.compressed ? 0x02 : 0x03); return; }
+        pipeState.expected_seq++;
+        pipeState.received_count++;
+        pipeState.frames_since_ack++;
+        pipeUpdateHighestSeen(seq);
+        while (pipeReorder[pipeSlot(pipeState.expected_seq)].occupied &&
+               pipeReorder[pipeSlot(pipeState.expected_seq)].seq == pipeState.expected_seq) {
+            PipeReorderSlot& s = pipeReorder[pipeSlot(pipeState.expected_seq)];
+            if (!pipeConsumePayload(s.data, s.len)) { sendPipeNack(pipeState.compressed ? 0x02 : 0x03); return; }
+            s.occupied = false;
+            if (pipeState.queued_count > 0) pipeState.queued_count--;
+            pipeState.expected_seq++;
+            pipeState.received_count++;
+            if (pipeState.frames_since_ack < 0xFF) pipeState.frames_since_ack++;
+        }
+        if (pipeState.queued_count == 0) pipeState.gap_open = false;
+        // Auto-complete (uncompressed only, mirrors legacy handleDirectWriteData auto-finish).
+        // The shared helper emits the single unsolicited {0x00,0x82} END ack then refreshes.
+        if (!pipeState.compressed && directWriteBytesWritten >= directWriteTotalBytes) {
+            sendPipeAck();                                   // final tail flush ({0x00,0x81})
+            directWriteFinishAndRefresh(nullptr, 0, 0x82);   // {0x00,0x82} + FULL refresh, no etag
+            resetPipeWriteState();
+            return;
+        }
+        if (pipeState.frames_since_ack >= pipeState.ack_every) sendPipeAck();
+        return;
+    }
+
+    if (fwd < W) {
+        // Ahead within the window -> PAUSE POINT: hold in the reorder queue, nothing
+        // reaches the controller past the hole.
+        PipeReorderSlot& s = pipeReorder[pipeSlot(seq)];
+        bool duplicate = (s.occupied && s.seq == seq);
+        s.occupied = true;
+        s.seq = seq;
+        s.len = plen;
+        memcpy(s.data, payload, plen);
+        if (!duplicate) {
+            pipeState.queued_count++;
+            if (pipeState.queued_count > pipeState.queue_high_water)
+                pipeState.queue_high_water = pipeState.queued_count;
+        }
+        if (pipeState.queued_count >= PIPE_REORDER_SLOTS) { sendPipeNack(0x03); return; }  // overflow guard
+        pipeUpdateHighestSeen(seq);
+        // Gap ACK: immediately when the gap first opens (fast-retransmit), then
+        // rate-limited to one per ack_every subsequent out-of-order arrivals.
+        if (!pipeState.gap_open) {
+            pipeState.gap_open = true;
+            sendPipeAck();                                   // resets ooo_acks_since_gap to 0
+        } else if (++pipeState.ooo_acks_since_gap >= pipeState.ack_every) {
+            sendPipeAck();
+        }
+        return;
+    }
+
+    // fwd >= W: either a duplicate of an already-accepted chunk (seq just below
+    // expected) or a genuinely out-of-window frame.
+    if (back <= W) {
+        // Duplicate/below-expected -> discard, ACK so the sender learns our position
+        // (rate-limited the same way as out-of-order arrivals).
+        if (!pipeState.gap_open) {
+            sendPipeAck();
+        } else if (++pipeState.ooo_acks_since_gap >= pipeState.ack_every) {
+            sendPipeAck();
+        }
+        return;
+    }
+
+    // Out of window on both sides -> protocol violation.
+    sendPipeNack(0x04);
+}
+
+void handlePipeWriteEnd(uint8_t* data, uint16_t len) {
+    if (!pipeState.active) {
+        uint8_t n[2] = {0xFF, 0x82};   // no active pipe transfer
+        sendResponse(n, sizeof(n));
+        return;
+    }
+    if (pipeState.error) {
+        uint8_t n[2] = {0xFF, 0x82};   // a fatal error already NACKed this transfer
+        sendResponse(n, sizeof(n));
+        // sendPipeNack already released the panel hardware at NACK time; this
+        // re-run is a defensive no-op (directWriteActive/displayPowerState false).
+        cleanupDirectWriteState(false);
+        resetPipeWriteState();
+        return;
+    }
+    // Tail-flush ACK precedes the END result (plan 1.3c / 1.5).
+    sendPipeAck();
+    // The client must not send END before every chunk is acked; a hole or short
+    // byte count here is a protocol violation.
+    bool incomplete = (pipeState.queued_count > 0);
+    if (!pipeState.compressed && directWriteBytesWritten < directWriteTotalBytes) incomplete = true;
+    if (incomplete) {
+        uint8_t n[2] = {0xFF, 0x82};
+        sendResponse(n, sizeof(n));
+        // Mid-stream abort with the panel powered: use the legacy mid-stream
+        // variant (refreshDisplay=true → sleep the controller cleanly, cut power,
+        // resume touch), matching the legacy {0xFF,0x71}/zlib-flush failure paths.
+        cleanupDirectWriteState(true);
+        resetPipeWriteState();
+        return;
+    }
+    // Shared END/refresh flow emits {0x00,0x82} then {0x00,0x73}/{0x00,0x74}.
+    // Compressed incompleteness surfaces as a zlib-flush NACK {0xFF,0x82} inside.
+    directWriteFinishAndRefresh(data, len, 0x82);
+    resetPipeWriteState();
 }
 
 static void cleanup_partial_write_state(void) {

--- a/src/display_service.h
+++ b/src/display_service.h
@@ -51,6 +51,7 @@ bool imageWriteLogQuietFrame(const uint8_t* data, uint16_t len);
 extern volatile bool epdRefreshInProgress;
 void handlePartialWriteStart(uint8_t* data, uint16_t len);
 void checkPartialWriteTimeout(void);
+void cleanupPartialWriteOnDisconnect(void);
 int getplane();
 int getBitsPerPixel();
 

--- a/src/display_service.h
+++ b/src/display_service.h
@@ -31,8 +31,17 @@ void initDisplay();
 void writeTextAndFill(const char* text);
 void handleDirectWriteStart(uint8_t* data, uint16_t len);
 void handleDirectWriteData(uint8_t* data, uint16_t len);
-void handleDirectWriteCompressedData(uint8_t* data, uint16_t len);
+// Consumes one direct-write compressed payload into the panel controller. Returns
+// false on overflow/decompress failure; the CALLER owns ACK/NACK emission.
+bool handleDirectWriteCompressedData(uint8_t* data, uint16_t len);
 void cleanupDirectWriteState(bool refreshDisplay);
+// PIPE_WRITE (0x0080-0x0082) sliding-window handlers + state reset.
+void handlePipeWriteStart(uint8_t* data, uint16_t len);
+void handlePipeWriteData(uint8_t* data, uint16_t len);
+void handlePipeWriteEnd(uint8_t* data, uint16_t len);
+void resetPipeWriteState(void);
+// True while a PIPE_WRITE stream is active (mid-transfer log suppression, resets).
+bool pipeWriteActive(void);
 void handleDirectWriteEnd(uint8_t* data, uint16_t len);
 // True while an image push is mid-stream and the per-frame command/ack logging
 // should be suppressed (chunk 1 still logs in full; the meter covers the rest).

--- a/src/esp32_ble_callbacks.h
+++ b/src/esp32_ble_callbacks.h
@@ -14,11 +14,14 @@
 // (0x0071) whose per-frame receive/queue logging should be suppressed.
 bool imageWriteLogQuietFrame(const uint8_t* data, uint16_t len);
 
+// Kept in sync with main.h (included first, so its values win). PIPE_WRITE ingest:
+// 33 slots hold a full W=32 window + END across a 60 s Spectra SPI stall; 256 covers
+// pipe <=244 / legacy <=232 / HA <=244.
 #ifndef COMMAND_QUEUE_SIZE
-#define COMMAND_QUEUE_SIZE 5
+#define COMMAND_QUEUE_SIZE 33
 #endif
 #ifndef MAX_COMMAND_SIZE
-#define MAX_COMMAND_SIZE 512
+#define MAX_COMMAND_SIZE 256
 #endif
 
 struct CommandQueueItem {
@@ -35,6 +38,7 @@ extern volatile bool esp32BleNotifySubscribed;
 
 void updatemsdata();
 void cleanupDirectWriteState(bool refreshDisplay);
+void resetPipeWriteState(void);
 void touchResumeAfterEpdRefresh(void);
 extern volatile bool epdRefreshInProgress;
 extern bool directWriteActive;
@@ -56,6 +60,7 @@ class MyBLEServerCallbacks : public BLEServerCallbacks {
         } else if (directWriteActive) {
             cleanupDirectWriteState(true);
         }
+        resetPipeWriteState();   // clear any pipe transfer + reorder queue on disconnect
         bleRestartAdvertisingPending = true;
     }
 };
@@ -88,12 +93,16 @@ public:
                 }
                 writeSerial(hexDump);
             }
-            uint8_t nextHead = (commandQueueHead + 1) % COMMAND_QUEUE_SIZE;
-            if (nextHead != commandQueueTail) {
-                memcpy(commandQueue[commandQueueHead].data, data, len);
-                commandQueue[commandQueueHead].len = len;
-                commandQueue[commandQueueHead].pending = true;
-                commandQueueHead = nextHead;
+            // SPSC ring: publish head with RELEASE after the payload is fully written
+            // so the consumer (main loop) never observes a slot before its bytes land.
+            uint8_t head = __atomic_load_n(&commandQueueHead, __ATOMIC_RELAXED);
+            uint8_t tail = __atomic_load_n(&commandQueueTail, __ATOMIC_ACQUIRE);
+            uint8_t nextHead = (head + 1) % COMMAND_QUEUE_SIZE;
+            if (nextHead != tail) {
+                memcpy(commandQueue[head].data, data, len);
+                commandQueue[head].len = len;
+                commandQueue[head].pending = true;
+                __atomic_store_n(&commandQueueHead, nextHead, __ATOMIC_RELEASE);
                 if (!quiet) writeSerial("ESP32: Command queued for processing");
             } else {
                 writeSerial("ERROR: Command queue full, dropping command");

--- a/src/esp32_ble_callbacks.h
+++ b/src/esp32_ble_callbacks.h
@@ -38,6 +38,7 @@ extern volatile bool esp32BleNotifySubscribed;
 
 void updatemsdata();
 void cleanupDirectWriteState(bool refreshDisplay);
+void cleanupPartialWriteOnDisconnect(void);
 void resetPipeWriteState(void);
 void touchResumeAfterEpdRefresh(void);
 extern volatile bool epdRefreshInProgress;
@@ -57,8 +58,12 @@ class MyBLEServerCallbacks : public BLEServerCallbacks {
         esp32BleNotifySubscribed = false;
         if (epdRefreshInProgress) {
             writeSerial("EPD refresh in progress — deferring cleanup/advertising to main loop");
-        } else if (directWriteActive) {
-            cleanupDirectWriteState(true);
+        } else {
+            if (directWriteActive) cleanupDirectWriteState(true);
+            // Partial sessions (0x76 or pipe-partial) power the panel without
+            // setting directWriteActive; release it here instead of waiting on
+            // the 15-min partial watchdog.
+            cleanupPartialWriteOnDisconnect();
         }
         resetPipeWriteState();   // clear any pipe transfer + reorder queue on disconnect
         bleRestartAdvertisingPending = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -185,6 +185,35 @@ static void pollActivity() {
     prevLanSession = lanSession;
     memcpy(prevDynamic, dynamicreturndata, sizeof(prevDynamic));
 }
+
+// Flush queued responses to BLE notifications. Called once per loop() pass and —
+// critically — between commands inside the bounded command drain: at small
+// negotiated ack_every (N_eff 1-2) a 33-command drain can emit up to ~32 pipe
+// ACKs, which would overflow the 10-slot response ring (drops the NEWEST entry)
+// and leave only stale ACKs — lagging window refunds and collapsing throughput.
+static void flushResponseQueueToBle() {
+    if (responseQueueTail == responseQueueHead) return;
+    if (esp32_ble_notify_enabled()) {
+        uint8_t bleDrain = 0;
+        while (responseQueueTail != responseQueueHead && bleDrain < 16) {
+            const bool quietAck = imageWriteLogQuietFrame(responseQueue[responseQueueTail].data, responseQueue[responseQueueTail].len);
+            if (!quietAck) writeSerial("ESP32: Sending queued response (" + String(responseQueue[responseQueueTail].len) + " bytes)");
+            pTxCharacteristic->setValue(responseQueue[responseQueueTail].data, responseQueue[responseQueueTail].len);
+            pTxCharacteristic->notify();
+            responseQueue[responseQueueTail].pending = false;
+            responseQueueTail = (responseQueueTail + 1) % RESPONSE_QUEUE_SIZE;
+            if (!quietAck) writeSerial("Response sent successfully");
+            bleDrain++;
+        }
+    } else if (pServer && pServer->getConnectedCount() > 0) {
+        // Connected but CCCD not enabled yet — keep responses queued
+    } else {
+        while (responseQueueTail != responseQueueHead) {
+            responseQueue[responseQueueTail].pending = false;
+            responseQueueTail = (responseQueueTail + 1) % RESPONSE_QUEUE_SIZE;
+        }
+    }
+}
 #endif
 
 void loop() {
@@ -232,38 +261,30 @@ void loop() {
     // THIS IS THE END OF THE MAIN LOOP() FOR DEEP SLEEP ESP32.  Loop starts over.
     // IF CONNECTION OCCURED THEN SET woke_from_deep_sleep=false and escape above on next loop
     // BELOW THIS IS WHERE ESP32 DOES WORK
-    if (commandQueueTail != commandQueueHead) {
-        const bool quietCmd = imageWriteLogQuietFrame(commandQueue[commandQueueTail].data, commandQueue[commandQueueTail].len);
-        if (!quietCmd) writeSerial("ESP32: Processing queued command (" + String(commandQueue[commandQueueTail].len) + " bytes)");
-    // imageDataWritten (misleading name) actually services any BLE command
-    // services up to 1 command per pass
-        imageDataWritten(NULL, NULL, commandQueue[commandQueueTail].data, commandQueue[commandQueueTail].len);
-        commandQueue[commandQueueTail].pending = false;
-        commandQueueTail = (commandQueueTail + 1) % COMMAND_QUEUE_SIZE; // WRAP THE QUEUE
-        if (!quietCmd) writeSerial("Command processed");
-    }
-    if (responseQueueTail != responseQueueHead) {
-        if (esp32_ble_notify_enabled()) {
-            uint8_t bleDrain = 0;
-            while (responseQueueTail != responseQueueHead && bleDrain < 16) {
-                const bool quietAck = imageWriteLogQuietFrame(responseQueue[responseQueueTail].data, responseQueue[responseQueueTail].len);
-                if (!quietAck) writeSerial("ESP32: Sending queued response (" + String(responseQueue[responseQueueTail].len) + " bytes)");
-                pTxCharacteristic->setValue(responseQueue[responseQueueTail].data, responseQueue[responseQueueTail].len);
-                pTxCharacteristic->notify();
-                responseQueue[responseQueueTail].pending = false;
-                responseQueueTail = (responseQueueTail + 1) % RESPONSE_QUEUE_SIZE;
-                if (!quietAck) writeSerial("Response sent successfully");
-                bleDrain++;
-            }
-        } else if (pServer && pServer->getConnectedCount() > 0) {
-            // Connected but CCCD not enabled yet — keep responses queued
-        } else {
-            while (responseQueueTail != responseQueueHead) {
-                responseQueue[responseQueueTail].pending = false;
-                responseQueueTail = (responseQueueTail + 1) % RESPONSE_QUEUE_SIZE;
-            }
+    // Bounded drain: service up to COMMAND_QUEUE_SIZE commands per pass so a sustained
+    // W-deep PIPE_WRITE window burst isn't starved at one-per-loop, while WiFi/refresh
+    // servicing below still runs each pass. ACQUIRE the head so the payload the producer
+    // wrote before its RELEASE store is visible; RELEASE the tail after consuming.
+    {
+        uint8_t drained = 0;
+        while (drained < COMMAND_QUEUE_SIZE) {
+            uint8_t tail = __atomic_load_n(&commandQueueTail, __ATOMIC_RELAXED);
+            uint8_t head = __atomic_load_n(&commandQueueHead, __ATOMIC_ACQUIRE);
+            if (tail == head) break;
+            const bool quietCmd = imageWriteLogQuietFrame(commandQueue[tail].data, commandQueue[tail].len);
+            if (!quietCmd) writeSerial("ESP32: Processing queued command (" + String(commandQueue[tail].len) + " bytes)");
+            // imageDataWritten (misleading name) actually services any BLE command.
+            imageDataWritten(NULL, NULL, commandQueue[tail].data, commandQueue[tail].len);
+            commandQueue[tail].pending = false;
+            __atomic_store_n(&commandQueueTail, (uint8_t)((tail + 1) % COMMAND_QUEUE_SIZE), __ATOMIC_RELEASE);
+            if (!quietCmd) writeSerial("Command processed");
+            drained++;
+            // Flush responses BETWEEN commands so pipe ACKs generated by this drain
+            // never overflow the 10-slot response ring (see flushResponseQueueToBle).
+            flushResponseQueueToBle();
         }
     }
+    flushResponseQueueToBle();
     if (bleRestartAdvertisingPending) {
         esp32_restart_ble_advertising();
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "device_control.h"
 #include "display_service.h"
 #include "power_latch.h"
+#include "wake_button.h"
 #include "touch_input.h"
 #include "encryption.h"
 #include "ble_init.h"
@@ -38,6 +39,10 @@ static const char* resetReasonName(esp_reset_reason_t reason) {
         default:                return "UNKNOWN";
     }
 }
+
+// Defined with the sleep helpers below loop()'s activity poller; setup() logs
+// the window length when arming the button-wake hold.
+static uint32_t minWakeTimeMs();
 #endif
 
 void setup() {
@@ -62,6 +67,7 @@ void setup() {
     }
     // Set only by the ESP32 wake-cause check below; NRF has no deep-sleep wake path.
     bool is_deep_sleep_wake = false;
+    bool woke_by_button = false;
     #ifdef TARGET_ESP32
     esp_reset_reason_t reset_reason = esp_reset_reason();
     writeSerial("Reset reason: " + String(resetReasonName(reset_reason)) + " (" + String((int)reset_reason) + ")");
@@ -71,13 +77,16 @@ void setup() {
         woke_from_deep_sleep = true;
         deep_sleep_count++;
         writeSerial("=== WOKE FROM DEEP SLEEP ===");
-        writeSerial("Wake-up reason: " + String(wakeup_reason));
+        woke_by_button = detectButtonWake(wakeup_reason);  // logs the named cause + pin(s)
         writeSerial("Deep sleep count: " + String(deep_sleep_count));
     } else {
         woke_from_deep_sleep = false;
         writeSerial("=== NORMAL BOOT ===");
-        // RTC memory survives soft resets (panic/WDT/esp_restart) but not power
-        // loss: a non-zero count on a NORMAL BOOT means a hidden mid-cycle reset.
+        // The bootloader reloads RTC memory segments from the app image on every
+        // reset except a deep-sleep wake, so RTC_DATA_ATTR does NOT survive
+        // panic/WDT/SW/brownout resets: a hidden mid-cycle reset lands here with
+        // count 0, indistinguishable from a true first boot (captured on hardware
+        // in docs/FINDINGS_DEEP_SLEEP_WAKE_BOOT_SCREEN_2026-07-07.md).
         writeSerial("Deep sleep count (RTC): " + String(deep_sleep_count));
     }
     #endif
@@ -127,6 +136,19 @@ void setup() {
         writeSerial("Advertising for " + String(globalConfig.power_option.sleep_timeout_ms) + " ms (sleep_timeout_ms), waiting for connection...");
         advertising_timeout_active = true;
         advertising_start_time = millis();
+        if (woke_by_button) {
+            // A button press means a user is present: hold awake for at least
+            // the minimum window so they (or a host) get time to interact.
+            minWakeWindowActive = true;
+            minWakeWindowStartMs = millis();
+            writeSerial("Button wake: holding awake >= " + String(minWakeTimeMs()) + " ms");
+        }
+    } else if (deep_sleep_count == 0) {
+        // First boot — or a hidden mid-cycle reset, which reloads the RTC count
+        // to 0 (see the NORMAL BOOT comment above). Inert on wired devices:
+        // every consumer of the hold is power_mode/deep-sleep gated.
+        minWakeWindowActive = true;
+        minWakeWindowStartMs = millis();
     }
     // Both sleep paths measure quiet time from here, not from power-on.
     lastActivityMs = millis();
@@ -135,6 +157,26 @@ void setup() {
 }
 
 #ifdef TARGET_ESP32
+// Minimum awake window (first boot / button wake). A floor layered UNDER the
+// quiet-window logic, not a replacement: sleep requires both the existing
+// idle/advertising quiet condition AND this hold expired, so interaction keeps
+// extending the quiet window inside and beyond the floor. Timer wakes never
+// arm the hold — their behavior is unchanged.
+static uint32_t minWakeTimeMs() {
+    uint16_t s = globalConfig.power_option.min_wake_time_seconds;
+    return (uint32_t)(s ? s : DEFAULT_MIN_WAKE_TIME_SECONDS) * 1000UL;
+}
+
+static bool minWakeHoldActive() {
+    if (!minWakeWindowActive) return false;
+    if (millis() - minWakeWindowStartMs >= minWakeTimeMs()) {
+        minWakeWindowActive = false;
+        writeSerial("Minimum wake window elapsed, deep sleep permitted");
+        return false;
+    }
+    return true;
+}
+
 // Single point of activity detection. Rather than have every producer (BLE host
 // task, buttons, touch, LAN) stamp a timestamp, sample the state they already
 // mutate and treat any change since the previous pass as activity.
@@ -243,7 +285,9 @@ void loop() {
         // Measured from the last activity, not from window start: a client that
         // connects and drops re-arms the full window instead of inheriting it.
         uint32_t idle_duration = millis() - lastActivityMs;
-        if (idle_duration >= advertising_timeout_ms) {
+        // On a button wake the min-wake hold keeps this window open past the
+        // quiet timeout; idleDelay(50) below services buttons/touch throughout.
+        if (idle_duration >= advertising_timeout_ms && !minWakeHoldActive()) {
             writeSerial("BLE advertising timeout (idle " + String(idle_duration) + " ms of " +
                         String(millis() - advertising_start_time) + " ms window) - no connection, returning to deep sleep");
             advertising_timeout_active = false;
@@ -333,30 +377,15 @@ void loop() {
         processTouchInput();
         delay(1);
     } else {
-        if (!woke_from_deep_sleep && deep_sleep_count == 0 && globalConfig.power_option.power_mode == 1) {
-            if (!firstBootDelayInitialized) {
-                firstBootDelayInitialized = true;
-                firstBootDelayStart = millis();
-                processButtonEvents();
-                writeSerial("First boot: waiting 2 minutes before entering deep sleep");
-            }
-            uint32_t elapsed = millis() - firstBootDelayStart;
-            if (elapsed < FIRST_BOOT_DEEP_SLEEP_DELAY_MS) {
-                idleDelay(5);
-                return;
-            }
-            if (!firstBootDelayElapsed) {
-                firstBootDelayElapsed = true;
-                writeSerial("First boot delay elapsed, deep sleep permitted");
-            }
-        }
         if(globalConfig.power_option.deep_sleep_time_seconds > 0 && globalConfig.power_option.power_mode == 1){
             uint32_t idleHoldMs = globalConfig.power_option.sleep_timeout_ms;
             if (idleHoldMs == 0) {
                 idleHoldMs = DEFAULT_IDLE_HOLD_MS;
             }
             uint32_t idleMs = millis() - lastActivityMs;
-            if (idleMs < idleHoldMs) {
+            // The min-wake hold covers first boot and connect-then-drop during a
+            // button-wake window (woke_from_deep_sleep cleared on connect above).
+            if (idleMs < idleHoldMs || minWakeHoldActive()) {
                 idleDelay(5);
             } else {
                 writeSerial("Idle " + String(idleMs) + " ms (hold " + String(idleHoldMs) + " ms) - entering deep sleep");
@@ -428,7 +457,7 @@ void fullSetupAfterConnection() {
     writeSerial("=== Full setup completed ===");
 }
 
-void enterDeepSleep(bool force) {
+void enterDeepSleep(bool force, uint16_t overrideSleepSeconds) {
     if (globalConfig.power_option.power_mode != 1) {
         writeSerial("Skipping deep sleep - not battery powered (power_mode: " + String(globalConfig.power_option.power_mode) + ")");
         delay(2000);
@@ -446,6 +475,14 @@ void enterDeepSleep(bool force) {
         lastActivityMs = millis();
         return;
     }
+    // Defense in depth for the min-wake hold (first boot / button wake). MUST
+    // stay ahead of the advertising stop below: everything past that point
+    // commits to esp_deep_sleep_start(), so a late abort would leave the device
+    // awake with the radio dark. force (host 0x0052) bypasses the hold.
+    if (!force && minWakeHoldActive()) {
+        writeSerial("Skipping deep sleep - minimum wake window active");
+        return;
+    }
     woke_from_deep_sleep = true; // Will be true on next boot
     if (pServer != nullptr) {
         BLEAdvertising *pAdvertising = pServer->getAdvertising();
@@ -459,10 +496,18 @@ void enterDeepSleep(bool force) {
     esp32_ble_clear_handles();
     delay(100);
     writeSerial("BLE deinitialized");
-    uint64_t sleep_timeout_us = (uint64_t)globalConfig.power_option.deep_sleep_time_seconds * 1000000ULL;
+    // Host override (0x0052 payload) applies to this one cycle only: it is a
+    // parameter, never stored, so an aborted or later sleep reverts to config.
+    uint16_t sleepSeconds = overrideSleepSeconds ? overrideSleepSeconds
+                                                 : globalConfig.power_option.deep_sleep_time_seconds;
+    uint64_t sleep_timeout_us = (uint64_t)sleepSeconds * 1000000ULL;
     esp_sleep_enable_timer_wakeup(sleep_timeout_us);
-    // consider adding code to enable button wake-up from deep sleep
-    writeSerial("Entering deep sleep for " + String(globalConfig.power_option.deep_sleep_time_seconds) + " seconds");
+    // After the timer arm, before powerLatchHoldForSleep(): the latch-hold
+    // manipulation then cannot disturb freshly configured RTC pulls, and its
+    // gpio_hold_en() touches only the latch pin, never the wake pads.
+    armButtonWakeSources();
+    writeSerial("Entering deep sleep for " + String(sleepSeconds) + " seconds" +
+                (overrideSleepSeconds ? " (host override, one cycle)" : " (config)"));
     flushLog(); // Arduino drain UART/Serial prior to deep sleep
     delay(100); // Brief delay to ensure serial output is sent
     powerLatchHoldForSleep();

--- a/src/main.h
+++ b/src/main.h
@@ -45,6 +45,7 @@ using namespace Adafruit_LittleFS_Namespace;
 #define MAX_CONFIG_CHUNKS 20  // Maximum number of chunks allowed
 // Response buffer constants
 #define MAX_RESPONSE_DATA_SIZE 100  // Maximum data size in response buffer
+// PIPE_WRITE grants/constants (PIPE_MAX_*, PIPE_VERSION, PIPE_FLAG_*) live in structs.h.
 
 // BLE response codes (second byte only, first byte is always 0x00 for success, 0xFF for error)
 #define RESP_DIRECT_WRITE_START_ACK  0x70  // Direct write start acknowledgment
@@ -252,7 +253,11 @@ void cleanupDirectWriteState(bool refreshDisplay);
 void handleDirectWriteStart(uint8_t* data, uint16_t len);
 void handleDirectWriteData(uint8_t* data, uint16_t len);
 void handleDirectWriteEnd(uint8_t* data = nullptr, uint16_t len = 0);
-void handleDirectWriteCompressedData(uint8_t* data, uint16_t len);
+bool handleDirectWriteCompressedData(uint8_t* data, uint16_t len);
+void handlePipeWriteStart(uint8_t* data, uint16_t len);
+void handlePipeWriteData(uint8_t* data, uint16_t len);
+void handlePipeWriteEnd(uint8_t* data, uint16_t len);
+void resetPipeWriteState(void);
 void handlePartialWriteStart(uint8_t* data, uint16_t len);
 int mapEpd(int id);
 uint8_t getFirmwareMajor();
@@ -366,8 +371,12 @@ BLECharacteristic imageCharacteristic("2446", BLEWrite | BLEWriteWithoutResponse
 // Define queue sizes and structures first
 #define RESPONSE_QUEUE_SIZE 10
 #define MAX_RESPONSE_SIZE 512
-#define COMMAND_QUEUE_SIZE 5
-#define MAX_COMMAND_SIZE 512
+// PIPE_WRITE ingest sizing: 33 slots hold a full W=32 in-flight window + END across a
+// 60 s Spectra SPI stall (loop blocked in bbepWriteData). 256 covers pipe <=244,
+// legacy <=232, HA <=244. A third-party client writing >256 B on a raw 512-MTU link
+// would regress (none known).
+#define COMMAND_QUEUE_SIZE 33
+#define MAX_COMMAND_SIZE 256
 
 struct ResponseQueueItem {
     uint8_t data[MAX_RESPONSE_SIZE];

--- a/src/main.h
+++ b/src/main.h
@@ -201,7 +201,9 @@ void disconnect_callback(uint16_t conn_handle, uint8_t reason);
 #ifdef TARGET_ESP32
 void fullSetupAfterConnection();
 // force: sleep even with a client connected (explicit host request 0x0052).
-void enterDeepSleep(bool force = false);
+// overrideSleepSeconds: nonzero replaces deep_sleep_time_seconds for this one
+// sleep cycle (0x0052 duration payload); never changes sleep eligibility.
+void enterDeepSleep(bool force = false, uint16_t overrideSleepSeconds = 0);
 extern bool advertising_timeout_active;
 extern uint32_t advertising_start_time;
 #endif
@@ -316,6 +318,13 @@ RTC_DATA_ATTR uint32_t deep_sleep_count = 0;
 bool advertising_timeout_active = false;
 uint32_t advertising_start_time = 0;
 
+// Minimum awake window, armed in setup() on first boot or button wake (never
+// on timer wake). A floor layered under the quiet-window logic: sleep needs
+// both the idle/advertising quiet condition AND this hold expired.
+static constexpr uint16_t DEFAULT_MIN_WAKE_TIME_SECONDS = 120;
+bool minWakeWindowActive = false;
+uint32_t minWakeWindowStartMs = 0;
+
 // Stamped by pollActivity() at the top of every loop() pass. Both sleep paths
 // require a continuous quiet window since this stamp, so a dropped link, an
 // in-flight command, or a pending ack extends the window rather than racing a
@@ -323,12 +332,6 @@ uint32_t advertising_start_time = 0;
 uint32_t lastActivityMs = 0;
 // Quiet window required before deep sleep when sleep_timeout_ms is unset.
 static constexpr uint32_t DEFAULT_IDLE_HOLD_MS = 10000;
-
-// First-boot holdoff before allowing deep sleep (2 minutes)
-static constexpr uint32_t FIRST_BOOT_DEEP_SLEEP_DELAY_MS = 120000;
-static bool firstBootDelayInitialized = false;
-static bool firstBootDelayElapsed = false;
-static uint32_t firstBootDelayStart = 0;
 #endif
 
 #define AXP2101_SLAVE_ADDRESS 0x34

--- a/src/structs.h
+++ b/src/structs.h
@@ -89,7 +89,53 @@ struct PowerOption {
 #define TRANSMISSION_MODE_ZIP            (1u << 1)
 #define TRANSMISSION_MODE_G5             (1u << 2)
 #define TRANSMISSION_MODE_DIRECT_WRITE   (1u << 3)
+#define TRANSMISSION_MODE_PIPE_WRITE     (1u << 4)
 #define TRANSMISSION_MODE_CLEAR_ON_BOOT  (1u << 7)
+
+// PIPE_WRITE (0x0080-0x0082) sliding-window receive state. Out-of-order frames
+// are held in a small reorder queue while the controller stream pauses at a hole;
+// when the missing frame arrives in-order it is written and the contiguous run of
+// queued successors drains. 33 slots = 32 (max window) + 1 safety; the sender's
+// span-based window rule bounds occupancy to <=32 so overflow is a protocol
+// violation, not an expected condition. Indexing by seq % PIPE_REORDER_SLOTS is
+// collision-free because any live window spans <=32 < 33 consecutive seqs.
+#define PIPE_REORDER_SLOTS      33
+#define PIPE_REORDER_SLOT_SIZE  248    // >= max plaintext data payload (241 @ frame 244; 212 encrypted)
+#define PIPE_ACK_MASK_BITS      32
+
+// PIPE_WRITE device grants / protocol constants (plan Part 1 & 3).
+// frame cap = HA ATT write ceiling (244 B); window cap = ACK-mask width (32).
+#define PIPE_MAX_W      32
+#define PIPE_MAX_N      32
+#define PIPE_MAX_FRAME  244
+#define PIPE_VERSION    0x01
+#define PIPE_FLAG_COMPRESSED 0x01
+
+struct PipeReorderSlot {
+    bool     occupied;
+    uint8_t  seq;
+    uint16_t len;
+    uint8_t  data[PIPE_REORDER_SLOT_SIZE];
+};
+
+struct PipeWriteState {
+    bool     active;
+    bool     error;             // fatal: silently discard 0x0081 until next 0x0080 / disconnect
+    bool     compressed;
+    bool     gap_open;          // true while a hole is outstanding (queue non-empty)
+    uint8_t  window;            // W_eff
+    uint8_t  ack_every;         // N_eff
+    uint16_t max_frame;         // frame_eff
+    uint8_t  expected_seq;      // next in-order seq (mod 256)
+    bool     has_received;      // false until first accepted-or-queued frame (highest_seen valid)
+    uint8_t  highest_seen;      // highest received seq (accepted or queued), mod 256
+    uint32_t received_count;    // accepted+queued distinct frames (diagnostics)
+    uint8_t  frames_since_ack;  // cadence counter (in-order accepts)
+    uint8_t  ooo_acks_since_gap;// rate-limit counter for out-of-order / duplicate gap ACKs
+    uint32_t total_size;        // negotiated decompressed panel byte total
+    uint8_t  queued_count;      // reorder-queue occupancy
+    uint8_t  queue_high_water;  // diagnostics: max occupancy seen this transfer
+};
 
 // 0x20: display (repeatable, max 4 instances)
 struct DisplayConfig {

--- a/src/structs.h
+++ b/src/structs.h
@@ -98,15 +98,27 @@ struct PowerOption {
 // queued successors drains. 33 slots = 32 (max window) + 1 safety; the sender's
 // span-based window rule bounds occupancy to <=32 so overflow is a protocol
 // violation, not an expected condition. Indexing by seq % PIPE_REORDER_SLOTS is
-// collision-free because any live window spans <=32 < 33 consecutive seqs.
+// collision-free because any live window spans <=W < PIPE_REORDER_SLOTS seqs.
+//
+// PIPE_SMALL_DRAM_WINDOW is set ONLY by the classic-ESP32 env:esp32-N4 (esp32dev,
+// 320KB RAM). Its static DRAM is far tighter than the S3/C3/C6 parts, so the full
+// 33-slot x 248 B queue (~8.3KB .bss) overflows dram0_0_seg by ~672 B at link.
+// Cap that env to W=16 / 17 slots (~4.2KB); 17 = W+1 keeps seq%SLOTS collision-free
+// (a live window spans <=16 < 17). All other ESP32 envs keep the full 32-deep window.
+#ifdef PIPE_SMALL_DRAM_WINDOW
+#define PIPE_REORDER_SLOTS      17
+#define PIPE_MAX_W      16
+#define PIPE_MAX_N      16
+#else
 #define PIPE_REORDER_SLOTS      33
+#define PIPE_MAX_W      32
+#define PIPE_MAX_N      32
+#endif
 #define PIPE_REORDER_SLOT_SIZE  248    // >= max plaintext data payload (241 @ frame 244; 212 encrypted)
 #define PIPE_ACK_MASK_BITS      32
 
 // PIPE_WRITE device grants / protocol constants (plan Part 1 & 3).
 // frame cap = HA ATT write ceiling (244 B); window cap = ACK-mask width (32).
-#define PIPE_MAX_W      32
-#define PIPE_MAX_N      32
 #define PIPE_MAX_FRAME  244
 #define PIPE_VERSION    0x01
 #define PIPE_FLAG_COMPRESSED 0x01

--- a/src/structs.h
+++ b/src/structs.h
@@ -57,11 +57,16 @@ struct PowerOption {
     uint8_t charge_enable_pin;      // BQ25616 CE (0 or 0xFF = unused)
     uint8_t charge_state_pin;       // BQ25616 charge-state GPIO (0 or 0xFF = unused)
     uint8_t charger_flags;          // bit0 enable active-low; bit1 state active-low when charging
-    uint8_t reserved[7];
+    uint16_t min_wake_time_seconds; // Min awake window after first boot or button wake; 0 = default 120 s
+    uint8_t reserved[5];
 } __attribute__((packed));
 
 #define CHARGER_FLAG_ENABLE_ACTIVE_LOW (1u << 0)
 #define CHARGER_FLAG_STATE_ACTIVE_LOW  (1u << 1)
+
+// sleep_flags (power_option): button wake from timer deep sleep is default-on;
+// bit 0 opts a device out (e.g. buttons sharing pads with wake-hostile hardware).
+#define SLEEP_FLAG_BUTTON_WAKE_DISABLE (1u << 0)
 
 // battery_sense_flags (power_option)
 #define BATTERY_SENSE_FLAG_ENABLE_INVERTED (1 << 0)  // Enable active-low (e.g. XIAO ~READ_BAT on P0.14)

--- a/src/structs.h
+++ b/src/structs.h
@@ -122,6 +122,10 @@ struct PowerOption {
 #define PIPE_MAX_FRAME  244
 #define PIPE_VERSION    0x01
 #define PIPE_FLAG_COMPRESSED 0x01
+// bit1: partial-region refresh. START carries a 12-byte LE extension
+// [old_etag:4][x:2][y:2][w:2][h:2]; geometry/etag validated like 0x76, refresh
+// mode + new_etag ride the 0x0082 END. See PIPE_WRITE section in display_service.cpp.
+#define PIPE_FLAG_PARTIAL 0x02
 
 struct PipeReorderSlot {
     bool     occupied;
@@ -134,6 +138,7 @@ struct PipeWriteState {
     bool     active;
     bool     error;             // fatal: silently discard 0x0081 until next 0x0080 / disconnect
     bool     compressed;
+    bool     partial;           // partial-region transfer: route DATA to partialCtx, END drives REFRESH_PARTIAL
     bool     gap_open;          // true while a hole is outstanding (queue non-empty)
     uint8_t  window;            // W_eff
     uint8_t  ack_every;         // N_eff

--- a/src/wake_button.cpp
+++ b/src/wake_button.cpp
@@ -1,0 +1,272 @@
+#include "wake_button.h"
+
+#if defined(TARGET_ESP32)
+
+#include <Arduino.h>
+#include "esp_sleep.h"
+#include "soc/soc_caps.h"
+#include "driver/gpio.h"
+#if SOC_PM_SUPPORT_EXT1_WAKEUP
+#include "driver/rtc_io.h"  // RTC pull retention for ext0/ext1 pads
+#endif
+#include "structs.h"
+
+#ifndef DEVICE_FLAG_BATTERY_LATCH
+#define DEVICE_FLAG_BATTERY_LATCH (1 << 3)
+#endif
+#ifndef DEVICE_FLAG_PWR_LATCH_DFF
+#define DEVICE_FLAG_PWR_LATCH_DFF (1 << 4)
+#endif
+
+extern struct GlobalConfig globalConfig;
+extern ButtonState buttonStates[MAX_BUTTONS];
+extern uint8_t buttonStateCount;
+void writeSerial(String message, bool newLine = true);
+
+// There is no ext0 status register, so the armed pin is remembered across the
+// sleep for detectButtonWake() to name. 0xFF = ext0 not armed this cycle.
+RTC_DATA_ATTR static uint8_t s_ext0WakePin = 0xFF;
+
+namespace {
+
+bool validPin(uint8_t pin) { return pin != 0 && pin != 0xFF; }
+
+struct WakeCandidate {
+    uint8_t pin;
+    bool wakeHigh;   // wake level == pressed level
+    bool pullup;     // configured internal pulls (retained across sleep)
+    bool pulldown;
+};
+
+String maskToHex(uint64_t mask) {
+    String s = "";
+    bool started = false;
+    for (int shift = 60; shift >= 0; shift -= 4) {
+        uint8_t nib = (mask >> shift) & 0xF;
+        if (!started && nib == 0 && shift != 0) continue;
+        started = true;
+        s += (char)(nib < 10 ? ('0' + nib) : ('A' + nib - 10));
+    }
+    return s;
+}
+
+#if !SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP && SOC_PM_SUPPORT_EXT1_WAKEUP
+// With RTC_PERIPH powered down, IDF maintains pulls configured through the RTC
+// IO registers via the HOLD feature — the digital-domain pinMode pulls do not
+// survive, so re-assert them here for every armed pad. A pad with no internal
+// pull depends on external hardware to idle at the released level.
+void retainWakePull(const WakeCandidate& c) {
+    const gpio_num_t gpio = (gpio_num_t)c.pin;
+    if (c.pullup) {
+        rtc_gpio_pullup_en(gpio);
+        rtc_gpio_pulldown_dis(gpio);
+    } else if (c.pulldown) {
+        rtc_gpio_pulldown_en(gpio);
+        rtc_gpio_pullup_dis(gpio);
+    } else {
+        writeSerial("Wake: pin " + String(c.pin) + " has no internal pull - floating wake pin may cause spurious wakes");
+    }
+}
+
+void warnUnarmedPins(uint64_t mask, const char* reason) {
+    for (uint8_t pin = 0; pin < 64; pin++) {
+        if (mask & (1ULL << pin)) {
+            writeSerial("Wake: pin " + String(pin) + " not armed (" + String(reason) + ") - timer-only for this button");
+        }
+    }
+}
+#endif
+
+}  // namespace
+
+void armButtonWakeSources() {
+    if (globalConfig.power_option.sleep_flags & SLEEP_FLAG_BUTTON_WAKE_DISABLE) {
+        writeSerial("Button wake disabled (sleep_flags) - timer-only deep sleep");
+        return;
+    }
+    const uint8_t deviceFlags = globalConfig.system_config.device_flags;
+    const uint8_t pwrPin2 = globalConfig.system_config.pwr_pin_2;
+    const uint8_t pwrPin3 = globalConfig.system_config.pwr_pin_3;
+
+    // Candidates: every initialized button (initButtons() already excluded 0xFF
+    // and the GT911 INT pin), plus the MOSFET-latch power button so it wakes
+    // from timer sleep the same way it wakes from powerOff().
+    WakeCandidate candidates[MAX_BUTTONS + 1];
+    uint8_t candidateCount = 0;
+    for (uint8_t i = 0; i < buttonStateCount && i < MAX_BUTTONS; i++) {
+        const ButtonState& btn = buttonStates[i];
+        if (!btn.initialized || btn.instance_index >= 4) continue;
+        const BinaryInputs& input = globalConfig.binary_inputs[btn.instance_index];
+        WakeCandidate& c = candidates[candidateCount++];
+        c.pin = btn.pin;
+        c.wakeHigh = !btn.inverted;
+        c.pullup = (input.pullups & (1 << btn.pin_offset)) != 0;
+        c.pulldown = (input.pulldowns & (1 << btn.pin_offset)) != 0;
+    }
+    if ((deviceFlags & DEVICE_FLAG_BATTERY_LATCH) && validPin(pwrPin3)) {
+        WakeCandidate& c = candidates[candidateCount++];
+        c.pin = pwrPin3;
+        c.wakeHigh = false;      // shutdown button is active-low
+        c.pullup = true;         // powerLatchBegin() keeps it INPUT_PULLUP
+        c.pulldown = false;
+    }
+
+    uint64_t lowMask = 0;
+    uint64_t highMask = 0;
+    WakeCandidate eligible[MAX_BUTTONS + 1];
+    uint8_t eligibleCount = 0;
+    s_ext0WakePin = 0xFF;
+    for (uint8_t i = 0; i < candidateCount; i++) {
+        const WakeCandidate& c = candidates[i];
+        if (validPin(pwrPin2) && c.pin == pwrPin2) {
+            // pwr_pin_2 is the latch hold pin (MOSFET enable / D-FF D input);
+            // it is an output, never a wake button.
+            writeSerial("Wake: pin " + String(c.pin) + " is the power latch pin - not armed");
+            continue;
+        }
+        if ((deviceFlags & DEVICE_FLAG_PWR_LATCH_DFF) && validPin(pwrPin3) && c.pin == pwrPin3) {
+            // On D-FF boards pwr_pin_3 is the 74AHC1G79 CP clock: a wake-armed
+            // pull or level change could clock the latch off and cut power.
+            writeSerial("Wake: pin " + String(c.pin) + " is the D-FF latch clock - not armed");
+            continue;
+        }
+        if (!esp_sleep_is_valid_wakeup_gpio((gpio_num_t)c.pin)) {
+            writeSerial("Wake: pin " + String(c.pin) + " not wake-capable on this chip - timer-only for this button");
+            continue;
+        }
+        if (digitalRead(c.pin) == (c.wakeHigh ? HIGH : LOW)) {
+            // Already at its wake level: arming would wake instantly and
+            // ping-pong. The pin re-qualifies next sleep entry after release.
+            writeSerial("Wake: pin " + String(c.pin) + " held at sleep entry - skipped this cycle");
+            continue;
+        }
+        if (c.wakeHigh) highMask |= 1ULL << c.pin;
+        else lowMask |= 1ULL << c.pin;
+        eligible[eligibleCount++] = c;
+    }
+
+    if (lowMask == 0 && highMask == 0) {
+        writeSerial("No wake-capable buttons - timer-only deep sleep");
+        return;
+    }
+
+#if SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP
+    // C3/C6: LP GPIO wake; esp_deep_sleep_start() auto-enables the pull
+    // opposite each wake level (CONFIG_ESP_SLEEP_GPIO_ENABLE_INTERNAL_RESISTORS).
+    if (lowMask) {
+        esp_err_t err = esp_deep_sleep_enable_gpio_wakeup(lowMask, ESP_GPIO_WAKEUP_GPIO_LOW);
+        if (err != ESP_OK) {
+            writeSerial("Wake: gpio LOW arm failed (err " + String(err) + ") - timer-only for mask 0x" + maskToHex(lowMask));
+        } else {
+            writeSerial("Wake: gpio LOW armed, mask 0x" + maskToHex(lowMask));
+        }
+    }
+    if (highMask) {
+        // Mixed polarity needs the second call to accumulate per-pin; on error
+        // keep the LOW group and never abort the sleep.
+        esp_err_t err = esp_deep_sleep_enable_gpio_wakeup(highMask, ESP_GPIO_WAKEUP_GPIO_HIGH);
+        if (err != ESP_OK) {
+            writeSerial("Wake: gpio HIGH arm failed (err " + String(err) + ") - timer-only for mask 0x" + maskToHex(highMask));
+        } else {
+            writeSerial("Wake: gpio HIGH armed, mask 0x" + maskToHex(highMask));
+        }
+    }
+#elif SOC_PM_SUPPORT_EXT1_WAKEUP
+    uint64_t armedMask = 0;
+#if CONFIG_IDF_TARGET_ESP32
+    // Classic ESP32 ext1 has no ANY_LOW mode: the HIGH group rides ext1
+    // ANY_HIGH; ext0 covers exactly one LOW pin (the lowest-numbered).
+    if (highMask) {
+        esp_sleep_enable_ext1_wakeup(highMask, ESP_EXT1_WAKEUP_ANY_HIGH);
+        armedMask |= highMask;
+        writeSerial("Wake: ext1 ANY_HIGH armed, mask 0x" + maskToHex(highMask));
+    }
+    if (lowMask) {
+        const uint8_t firstLowPin = (uint8_t)__builtin_ctzll(lowMask);
+        esp_sleep_enable_ext0_wakeup((gpio_num_t)firstLowPin, 0);
+        s_ext0WakePin = firstLowPin;
+        armedMask |= 1ULL << firstLowPin;
+        writeSerial("Wake: ext0 LOW armed on pin " + String(firstLowPin));
+        warnUnarmedPins(lowMask & ~(1ULL << firstLowPin), "classic ESP32 ext0 takes one LOW pin");
+    }
+#else
+    // S2/S3: one ext1 call only (a second replaces the first), so the larger
+    // polarity group takes ext1 and the other group's first pin takes ext0.
+    if (__builtin_popcountll(highMask) >= __builtin_popcountll(lowMask)) {
+        if (highMask) {
+            esp_sleep_enable_ext1_wakeup(highMask, ESP_EXT1_WAKEUP_ANY_HIGH);
+            armedMask |= highMask;
+            writeSerial("Wake: ext1 ANY_HIGH armed, mask 0x" + maskToHex(highMask));
+        }
+        if (lowMask) {
+            const uint8_t firstLowPin = (uint8_t)__builtin_ctzll(lowMask);
+            esp_sleep_enable_ext0_wakeup((gpio_num_t)firstLowPin, 0);
+            s_ext0WakePin = firstLowPin;
+            armedMask |= 1ULL << firstLowPin;
+            writeSerial("Wake: ext0 LOW armed on pin " + String(firstLowPin));
+            warnUnarmedPins(lowMask & ~(1ULL << firstLowPin), "ext1 taken by HIGH group, ext0 takes one pin");
+        }
+    } else {
+        esp_sleep_enable_ext1_wakeup(lowMask, ESP_EXT1_WAKEUP_ANY_LOW);
+        armedMask |= lowMask;
+        writeSerial("Wake: ext1 ANY_LOW armed, mask 0x" + maskToHex(lowMask));
+        if (highMask) {
+            const uint8_t firstHighPin = (uint8_t)__builtin_ctzll(highMask);
+            esp_sleep_enable_ext0_wakeup((gpio_num_t)firstHighPin, 1);
+            s_ext0WakePin = firstHighPin;
+            armedMask |= 1ULL << firstHighPin;
+            writeSerial("Wake: ext0 HIGH armed on pin " + String(firstHighPin));
+            warnUnarmedPins(highMask & ~(1ULL << firstHighPin), "ext1 taken by LOW group, ext0 takes one pin");
+        }
+    }
+#endif
+    // Re-assert configured pulls through the RTC IO registers on every armed
+    // pad so each pin idles at its released level through the sleep.
+    for (uint8_t i = 0; i < eligibleCount; i++) {
+        if (armedMask & (1ULL << eligible[i].pin)) {
+            retainWakePull(eligible[i]);
+        }
+    }
+#endif
+}
+
+bool detectButtonWake(int wakeupCause) {
+    switch ((esp_sleep_wakeup_cause_t)wakeupCause) {
+        // The EXT0/EXT1 causes are guarded by hardware capability: the enum
+        // values exist on every chip, but the status symbol does not link on
+        // chips without ext1 (C3), and neither cause can occur where the
+        // hardware is absent — the default case covers them defensively.
+#if SOC_PM_SUPPORT_EXT0_WAKEUP
+        case ESP_SLEEP_WAKEUP_EXT0:
+            writeSerial("Wake-up reason: EXT0 button (pin " + String(s_ext0WakePin) + ")");
+            return true;
+#endif
+#if SOC_PM_SUPPORT_EXT1_WAKEUP
+        case ESP_SLEEP_WAKEUP_EXT1:
+            writeSerial("Wake-up reason: EXT1 button (pin mask 0x" + maskToHex(esp_sleep_get_ext1_wakeup_status()) + ")");
+            return true;
+#endif
+#if SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP
+        case ESP_SLEEP_WAKEUP_GPIO:
+            writeSerial("Wake-up reason: GPIO button (pin mask 0x" + maskToHex(esp_sleep_get_gpio_wakeup_status()) + ")");
+            return true;
+#endif
+        case ESP_SLEEP_WAKEUP_TIMER:
+            writeSerial("Wake-up reason: timer");
+            return false;
+        default:
+            writeSerial("Wake-up reason: " + String(wakeupCause) + " (not a button)");
+            return false;
+    }
+}
+
+#else  // not ESP32
+
+void armButtonWakeSources() {}
+
+bool detectButtonWake(int wakeupCause) {
+    (void)wakeupCause;
+    return false;
+}
+
+#endif

--- a/src/wake_button.h
+++ b/src/wake_button.h
@@ -1,0 +1,22 @@
+#pragma once
+
+// Button wake from timer deep sleep (ESP32). Arms every wake-capable configured
+// button — plus the MOSFET-latch power button on DEVICE_FLAG_BATTERY_LATCH
+// boards — as a deep-sleep wake source alongside the timer, and classifies the
+// wake cause on the next boot. Default-on; SLEEP_FLAG_BUTTON_WAKE_DISABLE
+// (power_option.sleep_flags bit 0) opts a device out.
+//
+// Both functions are no-ops / false on non-ESP32 targets, so callers in shared
+// code need no guards.
+
+// Arm all eligible button-wake sources for the upcoming timer deep sleep.
+// Never fails; logs each pin's disposition. Call from enterDeepSleep() after
+// esp_sleep_enable_timer_wakeup() — the timer stays armed alongside — and
+// before powerLatchHoldForSleep().
+void armButtonWakeSources();
+
+// Classify the wake cause and log it with the waking pin(s). Call once, early
+// in setup(); safe pre-config (reads sleep registers only). Returns true for
+// the button causes (EXT0/EXT1/GPIO). Takes esp_sleep_wakeup_cause_t as int so
+// this header also compiles on targets without esp_sleep.h.
+bool detectButtonWake(int wakeupCause);


### PR DESCRIPTION
## Summary
Adds wake-on-button-press from deep sleep, plus a `0x0052` duration payload command.

> **Stacked on [#96](https://github.com/OpenDisplay/Firmware/pull/96).** This PR currently shows the full PIPE_WRITE stack because #96 (`feat/pipe-partial`) isn't merged yet. Once #96 lands in `main`, this collapses to the single wake-on-button commit (`a9795c8`). Keeping it as a draft until then.

## Changes (the wake-on-button commit)
- New `wake_button.cpp` / `wake_button.h` — button-wake handling out of deep sleep.
- `main.cpp` / `main.h` — deep-sleep wake integration.
- `device_control`, `communication`, `config_parser`, `structs` — supporting wiring and the `0x0052` duration payload.
- Docs: wake-on-button plan, implementation notes, and deep-sleep power/button architecture.