### PR TITLE
fix(esp32): drain response ring between config-read chunks (audit S5)

### DIFF
--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -72,6 +72,9 @@ extern bool wifiServerConnected;
 extern ResponseQueueItem responseQueue[10];
 extern uint8_t responseQueueHead;
 extern uint8_t responseQueueTail;
+// Drains the response ring to BLE (defined in main.cpp). handleReadConfig() calls
+// this between chunks so a multi-chunk config read never overflows the ring.
+extern void flushResponseQueueToBle();
 static constexpr uint8_t RESPONSE_QUEUE_SIZE_LOCAL = 10;
 static constexpr uint16_t MAX_RESPONSE_SIZE_LOCAL = 512;
 
@@ -381,7 +384,11 @@ void handleReadConfig() {
             remaining -= chunkSize;
             chunkNumber++;
 #ifdef TARGET_ESP32
-            delay(1);
+            // Drain THIS chunk to BLE before enqueuing the next: this handler runs
+            // synchronously on the loop task, so the ring's only drainer cannot run
+            // until we return. Without this, chunk 9+ overflows the 10-slot ring and
+            // is silently dropped, truncating configs > ~864 B on read-back.
+            flushResponseQueueToBle();
 #else
             delay(50);
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -234,7 +234,10 @@ static void pollActivity() {
 // negotiated ack_every (N_eff 1-2) a 33-command drain can emit up to ~32 pipe
 // ACKs, which would overflow the 10-slot response ring (drops the NEWEST entry)
 // and leave only stale ACKs — lagging window refunds and collapsing throughput.
-static void flushResponseQueueToBle() {
+// Non-static: handleReadConfig() (communication.cpp) calls this between config
+// chunks so a single multi-chunk read never overflows the 10-slot response ring,
+// mirroring how the loop() command drain flushes between commands.
+void flushResponseQueueToBle() {
     if (responseQueueTail == responseQueueHead) return;
     if (esp32_ble_notify_enabled()) {
         uint8_t bleDrain = 0;


### PR DESCRIPTION
## Problem

On ESP32, reading the device config over BLE (`CMD_CONFIG_READ`) **silently truncates any config larger than ~864 bytes**.

`handleReadConfig()` runs synchronously on the loop task and emits up to 44 chunks in a tight loop via `sendResponse()`. On ESP32 each `sendResponse()` only *enqueues* into the 10-slot `responseQueue` ring; the ring's only drainer, `flushResponseQueueToBle()`, runs on the **same loop task** and therefore cannot run until `handleReadConfig()` returns. After ~9 chunks the ring fills and every further chunk logs `"Response queue full, dropping response"`.

A realistically provisioned device (displays + LEDs + sensors + wifi + security + `data_extended`) easily exceeds ~864 B, so the host reassembles a truncated config and parse/CRC fails. LAN transport is unaffected (it writes synchronously). This is a regression from the NimBLE queue-based response model, which replaced the pre-NimBLE direct-notify path that drained each chunk before producing the next.

## Fix

Mirror the `loop()` command drain, which already flushes the ring **between commands** so pipe ACKs never overflow it. `handleReadConfig()` now flushes **between chunks**, so this multi-response handler honors the same invariant. The ESP32 `delay(1)` is replaced by `flushResponseQueueToBle()`; the non-ESP32 path keeps `delay(50)`. `flushResponseQueueToBle()` drops its `static` linkage and is `extern`-declared alongside the existing ring externs in `communication.cpp`.

The response queue's single-loop-task producer/consumer invariant is preserved — the flush is called from the command-drain path, still on the loop task.

## Testing

- Builds green: `esp32-s3-N16R8`, `esp32-c3-N16`, `nrf52840custom`.
- On-device: read back a config with `data_extended` populated (> ~864 B) via py-opendisplay/HA and confirm all chunks arrive (previously chunk 9+ was dropped).

Ref: opendisplay-protocol `AUDIT_2026-07-19` finding **S5** / Firmware H1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)