### PR TITLE
fix(esp32): deinit BLE before esp_restart() to stop reboot boot-loop

### DIFF
--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -256,7 +256,6 @@ void sendResponse(uint8_t* response, uint16_t len) {
 }
 
 void handleReadMSD() {
-    writeSerial("=== READ MSD COMMAND (0x0044) ===", true);
     uint8_t response[2 + 16];
     uint16_t responseLen = 0;
     response[responseLen++] = RESP_ACK;

--- a/src/device_control.cpp
+++ b/src/device_control.cpp
@@ -21,6 +21,8 @@ extern "C" void bootloader_util_app_start(uint32_t start_addr);
 #include <esp_system.h>
 #include "driver/gpio.h"
 #include "esp32-hal-gpio.h"
+#include "ble_init.h"          // BLEDevice/BLEServer/BLEAdvertising aliases + esp32_ble_clear_handles()
+extern BLEServer* pServer;     // defined in main.cpp
 #endif
 
 extern uint8_t rebootFlag;
@@ -108,6 +110,25 @@ void disconnect_callback(uint16_t conn_handle, uint8_t reason) {
     resetPipeWriteState();   // clear any pipe transfer + reorder queue on disconnect
 }
 
+#ifdef TARGET_ESP32
+// Tear NimBLE down before esp_restart(): esp_restart() resets the CPU but NOT the
+// BT controller hardware, so on the next (software-reset) boot BLEDevice::init()
+// tries to enable an already-enabled controller and aborts -> PANIC boot loop that
+// only a physical power cycle clears. Mirrors the deep-sleep teardown in
+// enterDeepSleep() (main.cpp), which is why sleep->wake re-inits cleanly.
+static void esp32_ble_deinit_before_restart() {
+    if (pServer != nullptr) {
+        BLEAdvertising* pAdvertising = pServer->getAdvertising();
+        if (pAdvertising != nullptr) pAdvertising->stop();
+    }
+    delay(200);
+    BLEDevice::deinit(true);      // clearAll: disables + releases the BT controller
+    esp32_ble_clear_handles();
+    delay(100);
+    writeSerial("BLE deinitialized before restart", true);
+}
+#endif
+
 void reboot(){
     writeSerial("=== REBOOT COMMAND (0x000F) ===", true);
     delay(100);
@@ -115,6 +136,7 @@ void reboot(){
     NVIC_SystemReset();
 #endif
 #ifdef TARGET_ESP32
+    esp32_ble_deinit_before_restart();
     esp_restart();
 #endif
 }
@@ -702,6 +724,7 @@ void enterDFUMode() {
 #ifdef TARGET_ESP32
     writeSerial("ESP32: Rebooting (OTA typically handled via WiFi)", true);
     delay(100);
+    esp32_ble_deinit_before_restart();
     esp_restart();
 #endif
 }


### PR DESCRIPTION
## Problem

Sending `CMD_REBOOT` (0x000F) to an ESP32 tag causes a **PANIC boot loop** that only a physical power cycle clears.

`reboot()` (and `enterDFUMode()`) call `esp_restart()` while NimBLE is still initialized. `esp_restart()` resets the CPU but **not** the BT controller hardware, so on the next (software-reset) boot `BLEDevice::init()` (`ble_init.cpp:255`) tries to enable an already-enabled controller and aborts → PANIC. The panic is itself a software reset, so the device loops. Only `POWERON` (a physical power cycle) fully resets the controller and lets `init()` succeed.

Observed on `esp32-s3-N16R8` (Seeed reTerminal E1003) after Home Assistant issued `0x000F` following a config write. Serial capture shows the crash consistently just after `Device name will be: …` and before `Setting BLE MTU`, repeating until power-cycled.

This is a pre-existing latent bug (prior `main` had the identical `reboot()`); it is triggered by issuing a reboot/DFU command.

## Fix

Add `esp32_ble_deinit_before_restart()`, mirroring the deep-sleep teardown in `enterDeepSleep()` (`main.cpp`) — stop advertising → `delay(200)` → `BLEDevice::deinit(true)` (clearAll: disables + releases the controller) → `esp32_ble_clear_handles()` → `delay(100)` — and call it before both `esp_restart()` sites (`reboot()` and `enterDFUMode()`). That clean controller shutdown is exactly why sleep→wake already re-inits fine; reboot now does the same.

All new code is under `#ifdef TARGET_ESP32`; NRF reset paths are untouched. Confined to a single file (`src/device_control.cpp`).

Also includes a small cosmetic follow-up: `CMD_READ_MSD` logged its banner twice (dispatch case + handler); the duplicate inside `handleReadMSD()` is removed.

## Testing

- Builds green: `esp32-s3-N16R8`, `esp32-c3-N16`, `nrf52840custom`.
- On-device: connect over BLE, send `0x000F`; expect `BLE deinitialized before restart` → clean reboot → `BLEDevice::init()` succeeds → `=== BLE advertising started successfully ===`, with **no PANIC and no power cycle**. Repeat several reboots to confirm the loop is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)