### PR TITLE
chore: remove dead boot .bss buffers (staticWhiteRow, staticLineBuffer)

### DIFF
--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -595,9 +595,7 @@ void cleanupPartialWriteOnDisconnect(void) {
 #define FONT_SMALL_THRESHOLD 264
 
 extern const uint8_t writelineFont[] PROGMEM;
-extern uint8_t staticWhiteRow[680];
 extern uint8_t staticRowBuffer[BOOT_ROW_BUFFER_SIZE];
-extern char staticLineBuffer[256];
 
 int bbepSetPanelType(BBEPDISP *pBBEP, int iPanel);
 void bbepSetRotation(BBEPDISP *pBBEP, int iRotation);

--- a/src/main.h
+++ b/src/main.h
@@ -131,9 +131,7 @@ uint8_t ledFlashPosition = 0;  // Current position in LED flash pattern group
 uint8_t activeLedInstance = 0xFF;  // LED instance index for flashing (0xFF = none configured)
 bool ledFlashActive = false;  // Flag to indicate if LED flashing is active (set by command)
 
-uint8_t staticWhiteRow[680];
 uint8_t staticRowBuffer[BOOT_ROW_BUFFER_SIZE];
-char staticLineBuffer[256];
 
 char wifiSsid[33] = {0};  // 32 bytes + null terminator
 char wifiPassword[33] = {0};  // 32 bytes + null terminator


### PR DESCRIPTION
## Summary

Removes two global buffers that are defined and `extern`'d but never read or written on any build path:

- `uint8_t staticWhiteRow[680];` (`src/main.h`)
- `char staticLineBuffer[256];` (`src/main.h`)

Together these reserve **936 bytes** of internal-DRAM `.bss`. The matching dead `extern` declarations in `src/display_service.cpp` are removed as well.

`staticRowBuffer[BOOT_ROW_BUFFER_SIZE]` is **not** touched — it is genuinely used by the boot-screen renderer (`src/boot_screen.cpp`).

## Validation

Checked repo-wide (all `.c/.cpp/.h/.ino/.inc`, plus `variants/`, `lib/`, `tools/`, `scripts/`, and non-source files) for both identifiers:

- No reads, writes, `sizeof`, address-of, or function-argument uses anywhere.
- No indirect references: no macro/token-paste, no stringized names, no partial-token matches.
- Nothing under any platform `#ifdef` (`TARGET_NRF`, `TARGET_ESP32`, `OPENDISPLAY_ENABLE_WIFI`, `OPENDISPLAY_SEEED_GFX`, `OPENDISPLAY_HAS_WIFI`, `PIPE_SMALL_DRAM_WINDOW`, etc.).
- Only occurrences were the definitions, the two dead `extern`s, and a comment in `FINDINGS.md` already flagging them as dead.

`main.h` is included by exactly one translation unit (`src/main.cpp`), so these non-static globals have no duplicate definitions and removal is safe.

## Notes

Depending on whether the platform build enables `-fdata-sections`/`--gc-sections`, the linker may already have been dropping these unreferenced globals — in which case the runtime saving is smaller and this is a source-hygiene cleanup. Either way the code is dead and safe to remove.