### PR TITLE
feat(wifi/lan): WiFi/LAN transport + tinfl inflate; pin pioarduino 55.03.39

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,21 @@ pio run -e <env> -t upload       # build + flash
 pio run                          # build every environment
 ```
 
-Common envs: `nrf52840custom`, `esp32-s3-N16R8`, `esp32-s3-N8R8`, `esp32-c3-N16`, `esp32-c6-N4`. CI (`.github/workflows/main.yaml`) builds `nrf52840custom`, `esp32-s3-N16R8`, and `esp32-c3-N16` on every push — keep those three green.
+Common envs: `nrf52840custom`, `esp32-s3-N16R8`, `esp32-s3-N8R8`, `esp32-c3-N16`, `esp32-c6-N4`. CI (`.github/workflows/main.yaml`) builds **all eleven** environments on every push — keep them all green.
 
 Factory provisioning: `OPENDISPLAY_FACTORY_CONFIG_HEX="..." pio run -e <env>` (or `tools/provision_firmware.py`). `scripts/factory_config_gen.py` runs as a pre-build step.
+
+### Do NOT bump the ESP platform past IDF 5.5.4 (C6 / NimBLE-Arduino)
+
+Every ESP env pins pioarduino **`55.03.39`** (Arduino 3.3.9 / **IDF 5.5.4**) by exact version, never the floating `stable` URL. **Do not move to `55.03.311` (IDF 5.5.5) or later until NimBLE-Arduino ships a release built against it.**
+
+**NimBLE-Arduino 2.5.0 depends on IDF ≤ 5.5.4.** IDF 5.5.5 dropped the `r_` prefix on the C6 BLE controller's mempool exports and moved them from `libble_app.a` to `libbt.a` (`r_os_mempool_init` → `os_mempool_init`, same for `os_memblock_get`/`_put`). NimBLE-Arduino 2.5.0 — the latest release, 2026-04-02 — still calls the `r_` names, so `esp32-c6-N4` fails to link with a wall of `undefined reference to r_os_mempool_init`. There is no library-side fix; it has to land upstream in NimBLE-Arduino.
+
+Only C6 is affected: it is the sole target whose BLE controller ships as a precompiled blob carrying its own NimBLE porting layer (`CONFIG_BT_LE_CONTROLLER_NPL_OS_PORTING_SUPPORT=y`). ESP32/S3/C3 compile that layer from source and build fine on IDF 5.5.5.
+
+`scripts/esp32c6_nimble_mempool_link.py` force-links the mempool object for C6 and **warns-and-skips on every failure path** — never abort the build from it, or a future platform change hides the real linker error behind a missing-member message. Full analysis, including a `--defsym` workaround that links but is unvalidated on hardware: `docs/FINDINGS_C6_NIMBLE_IDF555_MEMPOOL_ABI_2026-07-25.md`.
+
+Note for whenever the bump does happen: `55.03.311` also requires PlatformIO Core ≥ 6.1.19 (it silently uninstalls itself on older Core with an `IncompatiblePlatform` error). The pinned `.39` has no such requirement.
 
 ## The vendored protocol header (critical invariant)
 

--- a/docs/FINDINGS_C6_NIMBLE_IDF555_MEMPOOL_ABI_2026-07-25.md
+++ b/docs/FINDINGS_C6_NIMBLE_IDF555_MEMPOOL_ABI_2026-07-25.md
@@ -1,0 +1,110 @@
+# Do not move past IDF 5.5.4 until NimBLE-Arduino catches up (ESP32-C6)
+
+**Date:** 2026-07-25
+**Applies to:** `esp32-c6-N4` (and any future C6/H2/C2 target)
+**Short version:** pin pioarduino **55.03.39** (Arduino 3.3.9 / IDF 5.5.4) or older.
+**55.03.311** (Arduino 3.3.11 / IDF 5.5.5) does not link on C6 with
+NimBLE-Arduino 2.5.0. Do not bump the pin until NimBLE-Arduino ships a release
+built against IDF 5.5.5.
+
+## The break
+
+IDF 5.5.5 renamed the NimBLE OS-porting mempool exports for the C6 BLE
+controller. They **lost their `r_` prefix and moved archives**:
+
+| Symbol NimBLE-Arduino 2.5.0 calls | IDF 5.5.4 (`55.03.39`) | IDF 5.5.5 (`55.03.311`) |
+|---|---|---|
+| `r_os_mempool_init` | `libble_app.a(os_mempool.c.o)` | **not defined anywhere** |
+| `r_os_memblock_get`  | `libble_app.a(os_mempool.c.o)` | **not defined anywhere** |
+| `r_os_memblock_put`  | `libble_app.a(os_mempool.c.o)` | **not defined anywhere** |
+
+Under 5.5.5 the same functions exist as `os_mempool_init` / `os_memblock_get` /
+`os_memblock_put` in `libbt.a`. Neighbouring families (`r_os_mbuf_*`,
+`r_os_cputime_*`) kept their prefix, so this is a targeted rename, not a
+blanket one.
+
+NimBLE-Arduino 2.5.0 (2026-04-02, the latest release as of this writing) still
+emits calls to the `r_`-prefixed names, so the C6 link fails with a wall of:
+
+```
+ble_att_svr.c:3287: undefined reference to `r_os_mempool_init'
+ble_gap.c:9045:     undefined reference to `r_os_mempool_init'
+ble_hs.c:784:       undefined reference to `r_os_mempool_init'
+... (ble_gatts, ble_gattc, ble_hs_conn, ble_l2cap, ble_l2cap_sig, ble_sm)
+collect2: error: ld returned 1 exit status
+```
+
+There is no library-side fix available: 2.5.0 *is* current. This has to be
+resolved upstream in NimBLE-Arduino.
+
+## Why only C6
+
+C6 is the only target in this repo whose BLE controller ships as a
+**precompiled blob** (`libble_app.a`) carrying its own copy of the NimBLE
+OS-porting layer. Its sdkconfig therefore sets
+`CONFIG_BT_LE_CONTROLLER_NPL_OS_PORTING_SUPPORT=y`, which tells the NimBLE host
+*not* to compile mempool/mbuf/cputime itself and to call the blob's exports
+instead. Measured across `framework-arduinoespressif32-libs`:
+
+| Chip | `..._NPL_OS_PORTING_SUPPORT` | `libble_app.a` |
+|---|---|---|
+| esp32 | 0 | absent |
+| esp32s3 | 0 | absent |
+| esp32c3 | 0 | absent |
+| **esp32c6** | **1** | **present** |
+
+ESP32/S3/C3 compile the porting layer from source, reference plain
+`os_mempool_init`, and are unaffected by the rename. All ten non-C6
+environments build clean on `55.03.311`.
+
+## What was verified (2026-07-25)
+
+All eleven environments, built locally:
+
+| Platform | C6 without the script | C6 with the script | Other 10 envs |
+|---|---|---|---|
+| 55.03.32 (Arduino 3.3.2 / IDF 5.5.1) | links | links (no-op, +28 B) | OK |
+| **55.03.39 (3.3.9 / IDF 5.5.4)** — current pin | links | links (no-op, +148 B) | OK |
+| 55.03.311 (3.3.11 / IDF 5.5.5) | **link fails** | **link fails** | OK |
+
+A linker-alias workaround does link:
+
+```ini
+-Wl,--defsym,r_os_mempool_init=os_mempool_init
+-Wl,--defsym,r_os_memblock_get=os_memblock_get
+-Wl,--defsym,r_os_memblock_put=os_memblock_put
+```
+
+It is **not applied**, and should not be without on-device validation: it
+aliases BLE memory-pool allocation to symbols assumed ABI-identical from their
+names alone. A signature mismatch corrupts the BLE heap at runtime rather than
+failing at link time.
+
+## `scripts/esp32c6_nimble_mempool_link.py`
+
+The script extracts `os_mempool.c.o` from `libble_app.a` and links it as a
+plain object, because CI's `--as-needed` plus single-pass archive scan was
+reported to drop the member. On both `.32` and `.39` the ordinary link resolves
+`r_os_mempool_init` unaided, so locally the script is belt-and-braces; it is
+kept for CI, which is where the ordering problem was observed.
+
+Its failure paths were changed on 2026-07-25 from `sys.exit(1)` to
+**warn-and-skip**. Under `.311` the hard exit aborted with
+`no entry os_mempool.c.o in archive`, which hid the actual cause (the rename)
+behind a missing-member error. Skipping lets the link proceed and report the
+genuine `undefined reference to r_os_mempool_init`, which names the real
+problem.
+
+## Before bumping the pin
+
+1. Confirm NimBLE-Arduino has a release built against IDF 5.5.5 — i.e. one
+   that calls the unprefixed `os_mempool_*` names on C6.
+2. Build `esp32-c6-N4` both with and without the script; both should link.
+3. Flash a real C6 and confirm BLE advertises, connects, and completes an
+   image transfer. A mempool ABI problem will not show up at build time.
+
+## Related
+
+- `platformio.ini` — the pin and a condensed version of this warning.
+- Upstream commit `0d95b37` — introduced the version pin (at `55.03.32`) and
+  the current form of the C6 force-link script.

--- a/docs/FINDINGS_EP75_PARTIAL_REFRESH_WHITE_BLANK_2026-07-17.md
+++ b/docs/FINDINGS_EP75_PARTIAL_REFRESH_WHITE_BLANK_2026-07-17.md
@@ -1,0 +1,136 @@
+# Findings — EP75 (7.5" 800×480) partial refresh blanks the surround to white
+
+**Repo:** `Firmware` (branch `debug/v2.2-audit`)
+**Date:** 2026-07-17
+**Panel:** EP75 7.5" 800×480 **mono B/W** — UC8179-class controller (`BBEP_CHIP_UC81xx`). Reproducing SKU is almost certainly `EP75_800x480_GEN2` (config id `0x003B`), **not** plain `EP75_800x480` (`0x0014`) — see [§6](#6-which-ep75-sku-are-you-on).
+**Symptom (confirmed on hardware):** sending a PARTIAL RECTANGLE update repaints the entire display **outside** the rectangle to **white**. Only the rectangle should change.
+**Status:** Root cause confirmed at register level. **No code changed** — this is an investigation/decision doc. Fix options in [§5](#5-fix-options).
+**Method:** Read of `src/display_service.cpp` partial paths + the vendored `bb_epaper` library under `.pio/libdeps/nrf52840custom/bb_epaper/src/` (`bb_ep.inl`, `bb_epaper.h`). Every claim cites `file:line`.
+
+---
+
+## 1. TL;DR
+
+On this panel, the firmware's "partial refresh" is not a differential, region-limited partial — it is a **whole-panel drive-to-target** refresh:
+
+- `bbepRefresh(&bbep, REFRESH_PARTIAL)` for the GEN2 EP75 either uses the OTP **full**-refresh LUT (when `pInitPart == NULL`) or a **non-hold** "partial" LUT (GEN2), both of which drive **every** pixel to the value in the NEW/DTM2 bank.
+- The DRF (display refresh) is **never region-limited**: bb_epaper programs the UC8179 partial window (`PTL 0x90`) with "refresh whole screen" and issues `PTOU` (partial-out) *before* `DRF`, so the panel scans the whole gate/source range.
+- The firmware white-fills **both** RAM banks outside the rectangle (`partial_prepare_panel_ram`), so the NEW/DTM2 bank outside the rect is **white**.
+
+Whole-panel drive-to-target × white NEW bank outside the rect ⇒ **the entire surround is actively driven white.** That is the symptom.
+
+The white-fill is only *exposed* here; it is harmless on a panel with a genuine differential-hold LUT (only `EP75_800x480` 0x0014 qualifies). The prior belief that "the generic `bbepRefresh` partial path is a true differential and is unaffected" is **false for this hardware**.
+
+---
+
+## 2. Controller and plane wiring (this part is correct)
+
+**Controller family.** The EP75 panelDefs are `BBEP_CHIP_UC81xx` (UC8179-class) — `bb_ep.inl:3762-3766, 3780-3781, 3785, 3812`. UC8179 command set (`bb_epaper.h:413-447`): `PSR=0x00`, `PWR=0x01`, `PON=0x04`, **`DTM1=0x10` (old bank)**, `DRF=0x12`, **`DTM2=0x13` (new bank)**, LUT registers `VCOM=0x20 / WW=0x21 / BW=0x22 / WB=0x23 / BB=0x24 / VCOM2=0x25`, `CDI=0x50` (border), `TCON=0x60`, `TRES=0x61`, **`PTL=0x90` (partial window)**, **`PTIN=0x91` (partial-in)**, **`PTOU=0x92` (partial-out)**.
+
+**Plane→command mapping.** For 1bpp EP75, `bbepStartWrite` / `bbepFill` map `PLANE_1 → DTM1 (0x10, OLD)` and `PLANE_0 → DTM2 (0x13, NEW)` — `bb_ep.inl:4145-4156, 4333-4360`. The firmware streams `PLANE_1` then `PLANE_0` into the rect window (`src/display_service.cpp:2808-2829`). So the two-bank/old-new wiring is right; the defect is entirely in the refresh waveform + window handling.
+
+---
+
+## 3. Root cause (register-level)
+
+### 3.1 The refresh drives the whole panel to the NEW bank (no differential hold)
+
+`bbepRefresh(&bbep, REFRESH_PARTIAL)` — `bb_ep.inl:4390-4416`:
+
+- **`pInitPart == NULL` variants silently degrade to full/fast.** For `EP75_800x480_4GRAY` (0x0015), `_4GRAY_V2` (0x0016), `_4GRAY_GEN2` (0x003C), `EP73_800x480` (0x0022), `EP73_SPECTRA` (0x0023), `EP75R_800x480` (0x0026), `EP75YR` (0x0040), the panelDef `pInitPart` field is `NULL` (`bb_ep.inl:3764-3766, 3780-3781, 3785, 3812`). `bb_ep.inl:4391-4396` then falls back to `pInitFast` / `pInitFull` — the **OTP full-refresh LUT**, which drives every pixel to its NEW (DTM2) value.
+- **`EP75_800x480_GEN2` (0x003B) has a `pInitPart`, but it is a drive-to-target LUT, not a hold LUT.** `epd75_init_partial_gen2` — `bb_ep.inl:859-890` — has `WW=0x80`, `BW=0x80`, `WB=0x40`, `BB=0x40`; **every** source/target combination applies drive voltage. It also begins with `EPD_RESET` (`bb_ep.inl:838`) → `bbepWakeUp` (`bb_ep.inl:4216-4217`), a hardware controller reset.
+
+Contrast — a genuine differential-hold LUT (only plain `EP75_800x480` 0x0014): `epd75_init_sequence_partial` — `bb_ep.inl:702-762`, with `WW=0x00` and `BB=0x00` (unchanged pixels get **no** movement, `bb_ep.inl:720-751`) and `PSR=0x3f` (LUT-from-register). There, unchanged pixels physically hold and the white-fill is harmless.
+
+### 3.2 The DRF is never region-limited
+
+Even though UC8179 *can* limit the refresh to a window, bb_epaper defeats it:
+
+- `bbepSetAddrWindow` emits `PTIN (0x91)` + `PTL (0x90)` but sets `PTL`'s last parameter byte to `1` = **"refresh whole screen"** — `bb_ep.inl:4054`.
+- `bbepRefresh` sends `PTOU (0x92, partial-out)` **immediately before** `DRF (0x12)` — `bb_ep.inl:4414-4415` — with the literal source comment "update the entire panel, not just the last memory window."
+
+So the gate/source scan covers the **whole panel** regardless of the RAM address window. (On SSD16xx this region-limiting is impossible; on UC8179 it *is* possible but is being switched off here.)
+
+### 3.3 The firmware supplies the white
+
+`partial_prepare_panel_ram` (`src/display_service.cpp:2848-2872`) white-fills both banks over the full panel at partial START (`bbepFill(&bbep, BBEP_WHITE, PLANE_1)` then `PLANE_0`, `:2866-2867`), skipped only for a full-frame rect. The subsequent stream overwrites only the rect window. So outside the rect, DTM2/NEW = white.
+
+### 3.4 Composition
+
+whole-panel scan (3.2) × drive-to-target LUT (3.1) × white NEW bank outside the rect (3.3) ⇒ **every pixel outside the rect is driven to white.** Inside the rect the client's real content lands correctly; outside, the panel is repainted white. Exactly the observed symptom.
+
+---
+
+## 4. Why the two earlier conclusions were wrong
+
+1. **"The white-fill is correct because OLD==NEW==white ⇒ differential drives nothing."** This assumes a differential-hold waveform is active. On GEN2 EP75 it is not (3.1) — the LUT drives to target — so equal banks do **not** produce a hold; they produce a drive to the (white) target.
+2. **"The generic `bbepRefresh(REFRESH_PARTIAL)` path is a true differential and is unaffected (only EP397/EP426 are broken)."** The generic UC81xx path is differential **only** when `pInitPart` is a hold-LUT, which across the entire EP75 family is true for **exactly one SKU** (`EP75_800x480` 0x0014). Every other EP75 variant is broken the way this doc describes. The EP397/EP426 blank documented in `FIRMWARE_NIMBLE_PORT_CODE_REVIEW`-adjacent notes has a *different* root cause (SSD16xx DISP_CTRL1 `0x21` left in OLD-plane-bypass); this EP75 case is a distinct bug in a distinct controller family.
+
+### Related: the partial gate is too permissive
+
+`handlePartialWriteStart` only rejects `getBitsPerPixel() != 1` (`src/display_service.cpp:1864-1870`); it does not check whether the panel actually has a differential-hold partial LUT. So GEN2 mono (1bpp, no hold LUT) slips through and reaches the broken refresh.
+
+---
+
+## 5. Fix options
+
+UC8179 **can** do a real region-limited partial, so unlike the SSD16xx panels a proper fix exists — bb_epaper's refresh/window helpers just have to be bypassed.
+
+### Option A — Real region-scan partial (correct, higher effort, needs hardware validation)
+
+After streaming `DTM1 (old)` + `DTM2 (new)` for the rect, drive a **windowed** refresh with raw commands instead of `bbepRefresh`:
+
+```
+PTIN (0x91)                              // partial-in
+PTL  (0x90)  x_start,x_end, y_start,y_end, 0x00   // last byte = 0x00 → scan WINDOW ONLY (not 0x01)
+DRF  (0x12)                              // display refresh; then wait BUSY
+PTOU (0x92)                              // partial-out
+```
+
+Key deltas vs current behavior:
+- Do **not** call `bbepRefresh` (it sends `PTOU` before `DRF`, `bb_ep.inl:4414-4415`).
+- Do **not** use `bbepSetAddrWindow`'s `PTL` last-byte=1 (`bb_ep.inl:4054`); use `0x00` so only the window is scanned.
+- With window-scan, pixels outside the rect receive **no voltage** and physically hold — so this works even with the OTP full LUT, and the `bbepFill` white-fill at `display_service.cpp:2866-2867` becomes unnecessary and should be **removed** (it is only needed to make the full-panel drive "safe," which we are eliminating).
+
+Caveats: requires per-SKU validation that the panel honors `PT_SCAN=0`; the in-window waveform may still flash (drive-to-target within the rect) unless a differential LUT is also loaded — acceptable, since the reported bug is the *surround*, not in-rect flashing. This touches flashable panel-drive code and must be eyeballed on hardware.
+
+### Option B — Reject partial for non-differential EP75 variants (safe, minimal)
+
+Mirror the existing Seeed / `getBitsPerPixel()!=1` guard in `handlePartialWriteStart`: reject partial (e.g. NACK `ERR_PARTIAL_UNSUPPORTED`) for `bbep.type` in `{EP75_800x480_GEN2, EP75_800x480_4GRAY, EP75_800x480_4GRAY_V2, EP75_800x480_4GRAY_GEN2, EP73_800x480, EP73_SPECTRA_800x480, EP75R_800x480, EP75YR_800x480}`, allowing partial only for panels with a differential-hold `pInitPart` (currently just `EP75_800x480` 0x0014). The client then falls back to a full-frame update. Low risk, no glitch, but loses the partial-update speed/flicker benefit.
+
+### Option C — Sequence: B now, A later
+
+Land the safe reject/fallback first so the display is correct immediately, then implement and validate the raw UC8179 region-scan (Option A) as a follow-up when hardware test time is available.
+
+---
+
+## 6. Which EP75 SKU are you on?
+
+Plain `EP75_800x480` (`0x0014`) has a true differential-hold LUT (`bb_ep.inl:702-762`) and is **immune** to this bug. Because the symptom reproduces on your "mono B/W" panel, the configured `panel_ic_type` is almost certainly **`0x003B` (`EP75_800x480_GEN2`)**, whose GEN2 partial LUT drives-to-target (`bb_ep.inl:859-890`). Worth confirming the exact `globalConfig.displays[0].panel_ic_type` on the device (mapping table at `src/display_service.cpp:433-473`) before applying a SKU-scoped fix — if it *were* `0x0014` the bug would point somewhere else entirely.
+
+---
+
+## 7. Does bb_epaper support partial on EP75 at all?
+
+Effectively **no**, except plain `EP75_800x480` (0x0014). Every other EP75/EP73 variant either has `pInitPart == NULL` (silently full/fast refresh) or a drive-to-target "partial" LUT (GEN2). So region/differential partial is unsupported across the family bar that one SKU; the firmware must either implement raw UC8179 region-scan (Option A) or reject partial for the rest (Option B).
+
+---
+
+## 8. Key references
+
+Firmware — `src/display_service.cpp`:
+- `partial_trigger_refresh` — `:2831-2846` (EP75 falls through to `bbepRefresh` at `:2844`)
+- `partial_prepare_panel_ram` (white-fill) — `:2848-2872` (fills at `:2866-2867`)
+- `partial_write_stream_bytes` (PLANE_1 then PLANE_0) — `:2808-2829`
+- `panel_skips_reinit_on_partial_refresh` predicate (EP397/EP426 only) — `:2609-2626`
+- `handlePartialWriteStart` bpp-only gate — `:1864-1870`
+- panel id → type map — `:433-473`
+
+bb_epaper — `.pio/libdeps/nrf52840custom/bb_epaper/src/`:
+- `bbepRefresh` (pInitPart fallback + PTOU-before-DRF) — `bb_ep.inl:4390-4416` (fallback `:4391-4396`, `PTOU`/`DRF` `:4414-4415`)
+- `bbepSetAddrWindow` (PTL last byte = 1) — `bb_ep.inl:4054`
+- `bbepStartWrite` / `bbepFill` plane→command mapping — `bb_ep.inl:4145-4156, 4333-4360`
+- EP75 0x0014 differential-hold partial LUT — `bb_ep.inl:702-762`
+- EP75 GEN2 (0x003B) drive-to-target partial LUT + `EPD_RESET` — `bb_ep.inl:838, 859-890`
+- EP75 panelDefs (`pInitPart == NULL` variants) — `bb_ep.inl:3762-3766, 3780-3781, 3785, 3812`
+- UC8179 command constants — `bb_epaper.h:413-447`

--- a/docs/PLAN_TINFL_INFLATE_SWAP_2026-07-23.md
+++ b/docs/PLAN_TINFL_INFLATE_SWAP_2026-07-23.md
@@ -1,0 +1,153 @@
+# Plan: Transparent swap to ROM `tinfl` for the ESP32-WiFi inflate path
+
+## Context
+
+On the WiFi/LAN transport, compressed image uploads are **slower** than uncompressed
+despite a ~4:1 wire saving. Root cause (traced this session): the transfer is
+**consumer-bound on software inflate**, not wire-bound. The active inflater is a
+hand-rolled, fully bit-serial, resumable DEFLATE state machine
+([lib/uzlib/src/od_zlib_stream.c](../lib/uzlib/src/od_zlib_stream.c), from PR #26):
+per-bit reads, per-symbol Huffman walk, one-byte-at-a-time output, and a `% 65521`
+Adler-32 reduction on *every* byte. It was designed BLE-first — where wire speed is far
+below inflate speed, so decode was never the bottleneck. WiFi is ~10–100× faster, so
+inflate becomes the limiter. Crossover: compression only wins when
+`inflate_rate > ~1.33 × wire_rate`; the current engine fails that on LAN.
+
+The three WiFi chips (ESP32-S3 / C3 / C6) carry **miniz `tinfl_decompress` in mask ROM**
+(fixed addresses in `<chip>.rom.ld`; `esp_rom/include/miniz.h` ships with the framework)
+— a word-at-a-time, table-driven inflater. Using it costs **0 bytes of flash**. The S3
+framebuffer is in **PSRAM**, so the design keeps the 32 KB history/output ring in
+**internal SRAM** (fast match reads) and flushes decoded bursts **sequentially** to the
+PSRAM framebuffer — never decoding directly into PSRAM.
+
+Intended outcome: on ESP32-WiFi builds, compressed transfers decode several× faster,
+flipping compression back to a net win on LAN — with **no protocol/wire change** and no
+flash growth. nRF52840 and classic ESP32 (no WiFi) keep uzlib.
+
+## Hard constraint
+
+**`lib/uzlib/` must not be modified at all** — no edits to `od_zlib_stream.c`, `uzlib.h`,
+or any file under it, and no new files added there. The swap therefore happens **one level
+up**, in the firmware's own adapter layer in `src/`. uzlib stays compiled and byte-for-byte
+intact; it is simply not *called* on WiFi builds (unused `od_zlib_stream_*` get dropped by
+`--gc-sections`). All firmware callers of the inflater live in **one file**,
+[src/display_service.cpp](../src/display_service.cpp) (`od_zlib_stream_reset` ×3, and
+`push`/`poll`/`error` inside `zlib_stream_to_direct_write` / `zlib_stream_to_partial_write`) —
+confirmed the only call sites in `src/`.
+
+## Approach: src-level tinfl implementation + compile-time remap in display_service.cpp
+
+Provide a tinfl-backed implementation of the same streaming contract under new names in
+`src/`, then bind the existing call sites to it on WiFi builds via a small `#define` remap —
+so the ~11 existing call sites in `display_service.cpp` are **not edited**. The swap is
+invisible above the adapter layer; the wire protocol, `communication.cpp` dispatch, framing,
+and py-opendisplay are untouched. Because the gate is per-build (chip family), on WiFi-capable
+ESP32 builds *all* compressed transfers (BLE + LAN) use tinfl — a superset of uzlib's behavior.
+
+### The gate
+
+Reuse the exact condition that already defines `OPENDISPLAY_HAS_WIFI`
+([wifi_service.h:13](../src/wifi_service.h#L13)): `TARGET_ESP32 && OPENDISPLAY_ENABLE_WIFI`.
+Covers all S3/C6/C3 WiFi envs (incl. `esp32-s3-E1004`, which extends `…-N32R8-extuart`) and
+excludes `nrf52840custom` and `esp32-N4`. No `platformio.ini` change — `src/` files compile
+automatically and the flag already exists.
+
+## Files to change (2 new in `src/`, 1 edited; zero uzlib/platformio changes)
+
+1. **`src/od_inflate_tinfl.h`** (new) — declares the 5 functions
+   (`od_inflate_tinfl_reset/push/poll/error/output_count`) and the `OPENDISPLAY_USE_TINFL`
+   gate macro. Reuses `od_zlib_status_t` / `OD_ZLIB_STATUS_*` by `#include "uzlib.h"` (include
+   only — no modification), so the tinfl path returns the identical status type the callers
+   already switch on.
+
+2. **`src/od_inflate_tinfl.cpp`** (new) — body wrapped in `#if OPENDISPLAY_USE_TINFL`.
+   `#include "miniz.h"`. Implements the tinfl wrapper over ROM `tinfl_decompress`.
+
+3. **[src/display_service.cpp](../src/display_service.cpp)** — add, right after the includes
+   block (after line 18), ~8 lines:
+   ```c
+   #include "od_inflate_tinfl.h"
+   #if OPENDISPLAY_USE_TINFL
+   // Route the inflate adapter to the ROM-tinfl engine on ESP32-WiFi builds; uzlib
+   // (lib/uzlib) is left untouched and unused here. See od_inflate_tinfl.h.
+   #define od_zlib_stream_reset        od_inflate_tinfl_reset
+   #define od_zlib_stream_push         od_inflate_tinfl_push
+   #define od_zlib_stream_poll         od_inflate_tinfl_poll
+   #define od_zlib_stream_error        od_inflate_tinfl_error
+   #endif
+   ```
+   The macro is placed *after* `#include "uzlib.h"` (line 15) so the existing
+   `od_zlib_stream_*` call sites (2076, 2245, 2778, 3120–3177) bind to the tinfl impl with **no
+   edits to those lines**. `od_zlib_status_t` and `OD_ZLIB_STATUS_*` stay as-is (shared type).
+   Gate off (nRF / classic ESP32): the macros vanish and everything calls uzlib exactly as today.
+
+### tinfl wrapper design (`od_inflate_tinfl.cpp`; static BSS — chosen)
+
+File-scope `static` state (plain arrays land in internal `.bss`/DRAM automatically, satisfying
+"dict must be internal SRAM" with zero effort; ~43 KB permanent on gated builds):
+- `tinfl_decompressor s_decomp;` (~11 KB)
+- `uint8_t s_dict[TINFL_LZ_DICT_SIZE];` (32768 — history + output ring)
+- ring/delivery cursors `s_dict_ofs`, `s_deliver_ofs`, `s_pending`; input staging
+  `s_in`, `s_in_remaining`, `s_more_input`; bookkeeping `s_expected`, `s_produced`,
+  `s_done`, `s_initialized`, `s_error`.
+
+- **`od_inflate_tinfl_reset(expected)`**: `tinfl_init(&s_decomp)`; zero cursors/counters;
+  store `s_expected`; clear error/done; `s_initialized=true`.
+- **`od_inflate_tinfl_push(input,len,final)`**: mirror uzlib semantics (error if not
+  initialized / previous input unconsumed); stash input; `s_more_input = !final` → maps the
+  `final` flag to clearing `TINFL_FLAG_HAS_MORE_INPUT` so tinfl finalizes + verifies Adler-32
+  on the last frame (the empty `push(NULL,0,true)` at
+  [display_service.cpp:2368](../src/display_service.cpp#L2368) resolves to DONE).
+- **`od_inflate_tinfl_poll(output,capacity,produced)`** — rate-matching core:
+  - **Deliver first, decode only when drained.** While `s_pending>0`, `memcpy` a contiguous run
+    from `s_dict+s_deliver_ofs` into `output` (bounded by `capacity`); advance cursors; return
+    `OD_ZLIB_STATUS_OUTPUT_READY` when `output` fills.
+  - When `s_pending==0`, call `tinfl_decompress(&s_decomp, s_in, &in_bytes, s_dict,
+    s_dict+s_dict_ofs, &out_bytes, TINFL_FLAG_PARSE_ZLIB_HEADER | (s_more_input ?
+    TINFL_FLAG_HAS_MORE_INPUT : 0))` with `out_bytes` bounded to **contiguous room to ring end**
+    (`32768 - s_dict_ofs`). One contiguous burst per decode, fully delivered before the next
+    decode → tinfl never overwrites undelivered bytes and delivery stays a simple contiguous copy.
+  - Advance `s_in`, add to `s_produced`/`s_pending`, wrap `s_dict_ofs &= 32767`.
+  - Status map: `<0` → `OD_ZLIB_STATUS_ERROR` (set `s_error`); `TINFL_STATUS_DONE(0)` → mark done,
+    return DONE when drained; `NEEDS_MORE_INPUT(1)` drained → `OD_ZLIB_STATUS_NEEDS_INPUT`;
+    `HAS_MORE_OUTPUT(2)` → loop to deliver.
+- **`od_inflate_tinfl_error()` / `_output_count()`**: return `s_error` / `s_produced`.
+
+tinfl API confirmed present in the ROM header: `tinfl_init` macro (miniz.h:587), status enum
+`DONE=0 / NEEDS_MORE_INPUT=1 / HAS_MORE_OUTPUT=2 / negatives` (miniz.h:578–583),
+`TINFL_LZ_DICT_SIZE 32768`, `TINFL_FLAG_*`, full `tinfl_decompressor` struct.
+
+### Intended, documented behavior differences (benign / desirable)
+- **Window ceiling relaxed.** tinfl always supports up to a 32 KB window, so it accepts any
+  standard zlib stream regardless of `OPENDISPLAY_ZLIB_WINDOW_BITS`. Today's sender emits
+  `wbits=9`, which still decodes; this additionally *unlocks* a future `wbits=15` sender change
+  for a better ratio (py-opendisplay, out of scope).
+- **Adler-32 handled by tinfl** via `TINFL_FLAG_PARSE_ZLIB_HEADER` (no per-byte modulo).
+
+## Out of scope
+- No changes to `lib/uzlib/` (hard constraint), `communication.cpp`, the wire protocol, framing,
+  `platformio.ini`, or py-opendisplay.
+- No BLE-only carve-out — the build gate naturally includes BLE on WiFi builds (superset; no regress).
+
+## Verification
+
+1. **Include-path smoke test (first).** Confirm `#include "miniz.h"` resolves for a `src/`
+   `.cpp` on the S3 env (ROM header at `.../esp32s3/include/esp_rom/include/miniz.h`; symbol
+   guaranteed by `<chip>.rom.ld`). If bare include fails, add the `esp_rom/include` dir to the
+   env `build_flags` `-I`, or include via its resolvable path.
+2. **Builds (keep CI green).**
+   - `pio run -e esp32-s3-N16R8` and `pio run -e esp32-c3-N16` → compile with tinfl remap;
+     `.bss` grows ~43 KB, flash does **not** grow for inflate code.
+   - `pio run -e nrf52840custom` → gate off; compiles/links against uzlib exactly as today.
+3. **uzlib untouched.** `git diff` shows zero changes under `lib/uzlib/`. Host unit test
+   `tools/test_zlib_stream.c` (uzlib impl, gate off on host) still builds/passes.
+4. **Functional on hardware (S3, PSRAM framebuffer).** Flash `esp32-s3-N16R8`; send a compressed
+   LAN direct-write image via py-opendisplay. Confirm correct render (Adler-32 passes;
+   `directWriteBytesWritten == directWriteDecompressedTotal`) and that the
+   `DW complete … zlib <N> B on wire (<x>x)` log ([display_service.cpp:1884](../src/display_service.cpp#L1884))
+   shows the expected ratio. Also exercise the **partial** (0x76) and **pipe** (0x80) compressed
+   paths, and a plain **BLE** compressed transfer (now also tinfl on this build).
+5. **Perf confirmation (no new instrumentation).** Use the existing `DW complete … chunks …
+   <rate> KB/s` log ([display_service.cpp:1873](../src/display_service.cpp#L1873)): send the same
+   image on a tinfl build vs a uzlib build and confirm the compressed-LAN rate rises and now
+   beats the uncompressed-LAN rate (`inflate_rate > ~1.33 × wire_rate`).

--- a/platformio.ini
+++ b/platformio.ini
@@ -44,6 +44,7 @@ lib_deps =
   bitbank2/FastEPD@^2.2.0
 build_flags = 
   -DTARGET_ESP32
+  -DOPENDISPLAY_ENABLE_WIFI  ; WiFi/LAN transport: S3 + C6 + C3 (classic ESP32 excluded)
   #-DOPENDISPLAY_ZLIB_WINDOW_BITS=15
   -DOPENDISPLAY_ZLIB_USE_HEAP_WINDOW=1
   -DBOARD_HAS_PSRAM
@@ -73,6 +74,7 @@ lib_deps =
   bitbank2/FastEPD@^2.2.0
 build_flags = 
   -DTARGET_ESP32
+  -DOPENDISPLAY_ENABLE_WIFI  ; WiFi/LAN transport: S3 + C6 + C3 (classic ESP32 excluded)
   #-DOPENDISPLAY_ZLIB_WINDOW_BITS=15
   -DOPENDISPLAY_ZLIB_USE_HEAP_WINDOW=1
   -DBOARD_HAS_PSRAM
@@ -101,6 +103,7 @@ lib_deps =
   bitbank2/FastEPD@^2.2.0
 build_flags = 
   -DTARGET_ESP32
+  -DOPENDISPLAY_ENABLE_WIFI  ; WiFi/LAN transport: S3 + C6 + C3 (classic ESP32 excluded)
   #-DOPENDISPLAY_ZLIB_WINDOW_BITS=15
   -DOPENDISPLAY_ZLIB_USE_HEAP_WINDOW=1
   -DBOARD_HAS_PSRAM
@@ -129,6 +132,7 @@ platform = https://github.com/pioarduino/platform-espressif32/releases/download/
 framework = arduino
 build_flags =
   -DTARGET_ESP32
+  -DOPENDISPLAY_ENABLE_WIFI  ; WiFi/LAN transport: S3 + C6 + C3 (classic ESP32 excluded)
   -DOPENDISPLAY_ZLIB_USE_HEAP_WINDOW=1
   -DBOARD_HAS_PSRAM
   -DARDUINO_USB_MODE=0
@@ -165,8 +169,9 @@ build_flags =
 [env:esp32-c3-N4]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.32/platform-espressif32.zip
 framework = arduino
-build_flags = 
+build_flags =
   -DTARGET_ESP32
+  -DOPENDISPLAY_ENABLE_WIFI  ; WiFi/LAN transport: S3 + C6 + C3 (classic ESP32 excluded)
   #-DOPENDISPLAY_ZLIB_WINDOW_BITS=15
   -DOPENDISPLAY_ZLIB_USE_HEAP_WINDOW=1
   -DARDUINO_USB_MODE=1
@@ -186,6 +191,7 @@ extra_scripts =
   post:scripts/esp32c6_nimble_mempool_link.py
 build_flags =
   -DTARGET_ESP32
+  -DOPENDISPLAY_ENABLE_WIFI  ; WiFi/LAN transport: S3 + C6 + C3 (classic ESP32 excluded)
   #-DOPENDISPLAY_ZLIB_WINDOW_BITS=15
   -DOPENDISPLAY_ZLIB_USE_HEAP_WINDOW=1
   -DARDUINO_USB_MODE=1
@@ -205,6 +211,7 @@ platform = https://github.com/pioarduino/platform-espressif32/releases/download/
 framework = arduino
 build_flags =
   -DTARGET_ESP32
+  -DOPENDISPLAY_ENABLE_WIFI  ; WiFi/LAN transport: S3 + C6 + C3 (classic ESP32 excluded)
   #-DOPENDISPLAY_ZLIB_WINDOW_BITS=15
   -DOPENDISPLAY_ZLIB_USE_HEAP_WINDOW=1
   -DARDUINO_USB_MODE=1
@@ -228,6 +235,7 @@ lib_deps =
   bitbank2/FastEPD@^2.2.0
 build_flags = 
   -DTARGET_ESP32
+  -DOPENDISPLAY_ENABLE_WIFI  ; WiFi/LAN transport: S3 + C6 + C3 (classic ESP32 excluded)
   -DOPENDISPLAY_ZLIB_USE_HEAP_WINDOW=1
   -DBOARD_HAS_PSRAM
   -DARDUINO_USB_MODE=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -37,7 +37,7 @@ lib_ignore = NimBLE-Arduino
 
 
 [env:esp32-s3-N16R8]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.32/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 framework = arduino
 lib_deps =
   ${env.lib_deps}
@@ -67,7 +67,7 @@ board_upload.flash_size = 16MB
 monitor_speed = 115200
 
 [env:esp32-s3-N8R8]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.32/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 framework = arduino
 lib_deps =
   ${env.lib_deps}
@@ -96,7 +96,7 @@ board_upload.flash_size = 8MB
 monitor_speed = 115200
 
 [env:esp32-s3-N32R8]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.32/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 framework = arduino
 lib_deps =
   ${env.lib_deps}
@@ -128,7 +128,7 @@ monitor_speed = 115200
 ; Console/debug via onboard CH343P USB-UART (U0TXD=GPIO43, U0RXD=GPIO44), not native USB-CDC.
 ; Panel/bus pins come from runtime device config (bb_epaper path).
 [env:esp32-s3-N32R8-extuart]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.32/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 framework = arduino
 build_flags =
   -DTARGET_ESP32
@@ -163,11 +163,21 @@ build_flags =
 	${env:esp32-s3-N32R8-extuart.build_flags}
 	-DOPENDISPLAY_ZLIB_WINDOW_BITS=15
 
-; ESP targets pin pioarduino 55.03.32 (Arduino 3.x / IDF 5). Floating `stable` drifts
-; CI vs local. Stock PlatformIO `espressif32` (Arduino 2.x) lacks mbedtls CMAC and C6
-; NPL r_os_mem* wiring for NimBLE-Arduino.
+; ESP targets pin pioarduino 55.03.39 (Arduino 3.3.9 / IDF 5.5.4), by exact version
+; so it cannot drift CI vs local.
+;
+; DO NOT BUMP PAST IDF 5.5.4 until NimBLE-Arduino ships a release built against the
+; newer IDF. NimBLE-Arduino 2.5.0 (latest, 2026-04-02) depends on IDF <= 5.5.4: IDF
+; 5.5.5 drops the r_ prefix on the C6 mempool exports and moves them to libbt.a
+; (r_os_mempool_init -> os_mempool_init, same for os_memblock_get/_put), while 2.5.0
+; still calls the r_ names -- so esp32-c6-N4 fails to link on 55.03.311. Only C6 is
+; affected (it alone uses the precompiled controller blob with its own NimBLE porting
+; layer). See docs/FINDINGS_C6_NIMBLE_IDF555_MEMPOOL_ABI_2026-07-25.md.
+;
+; Stock PlatformIO `espressif32` (Arduino 2.x) lacks mbedtls CMAC and C6 NPL
+; r_os_mem* wiring for NimBLE-Arduino.
 [env:esp32-c3-N4]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.32/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 framework = arduino
 build_flags =
   -DTARGET_ESP32
@@ -183,7 +193,7 @@ board = esp32-c3-devkitm-1
 monitor_speed = 115200
 
 [env:esp32-c6-N4]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.32/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 framework = arduino
 ; C6 + NimBLE: pull r_os_mem* from libble_app (see script header).
 extra_scripts =
@@ -207,7 +217,7 @@ monitor_speed = 115200
 ; device config. DIO flash mode leaves GPIO12/13 free for general GPIO use
 ; (e.g. a battery-latch MOSFET).
 [env:esp32-c3-N16]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.32/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 framework = arduino
 build_flags =
   -DTARGET_ESP32
@@ -228,7 +238,7 @@ monitor_speed = 115200
 
 ; esp32-s3-N16R8 + UART log; FastEPD IT8951 path when panel_ic_type is 3000 (1bpp) or 3001 (4bpp gray).
 [env:esp32-s3-N16R8-extuart]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.32/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 framework = arduino
 lib_deps =
   ${env.lib_deps}
@@ -259,7 +269,7 @@ board_upload.flash_size = 16MB
 monitor_speed = 115200
 
 [env:esp32-N4]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.32/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 framework = arduino
 build_flags =
   -DTARGET_ESP32

--- a/platformio.ini
+++ b/platformio.ini
@@ -268,6 +268,19 @@ board_upload.maximum_ram_size = 327680
 board_upload.flash_size = 16MB
 monitor_speed = 115200
 
+; esp32-s3-N16R8-extuart with DEBUG-level logging compiled in. OD_LOG_LEVEL defaults
+; to INFO, which compiles every od_log_debug() away -- so the config parse dump and
+; summary, the BLE RX/TX hex lines with [BLE][Q:n] queue depth, and the DIRECT_WRITE
+; progress/throughput lines ("DW complete: ... KB/s") are ABSENT from a normal build.
+; This env turns them on; costs ~13 KB flash and real serial time, so it is a debug
+; build, not a shipping one. Logs over the onboard CH343P UART (GPIO43/44) at 115200,
+; inherited from the parent -- not USB CDC.
+[env:esp32-s3-N16R8-extuart-debug]
+extends = env:esp32-s3-N16R8-extuart
+build_flags =
+  ${env:esp32-s3-N16R8-extuart.build_flags}
+  -DOD_LOG_LEVEL=OD_LOG_DEBUG
+
 [env:esp32-N4]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 framework = arduino

--- a/scripts/esp32c6_nimble_mempool_link.py
+++ b/scripts/esp32c6_nimble_mempool_link.py
@@ -6,6 +6,21 @@ Those symbols live in libble_app.a(os_mempool.c.o). Archive scan order on
 CI often never pulls that member; extract it and link as a plain object.
 
 Must run as post: (after framework sets _LIBFLAGS), not pre:.
+
+EVERY failure here warns and skips rather than aborting the build. What this
+script does is force linkage that the ordinary archive scan usually manages on
+its own -- so when its assumptions stop holding, the right outcome is to let
+the link proceed and report what it actually finds. Aborting instead buries the
+real error: on pioarduino 55.03.311 (IDF 5.5.5) the mempool exports lost their
+r_ prefix and moved to libbt.a, and this script's hard exit reported only
+"no entry os_mempool.c.o in archive" -- hiding the rename behind a missing
+member. Warn-and-skip surfaces the genuine `undefined reference to
+r_os_mempool_init' instead, which names the actual problem.
+
+Measured against the archive this repo pins (55.03.39) the force-link is
+belt-and-braces: C6 links without it locally. It is kept for CI, where
+--as-needed plus single-pass archive scan order was reported to drop the
+member.
 """
 
 from __future__ import annotations
@@ -20,9 +35,12 @@ MEMBER = "os_mempool.c.o"
 NEEDED_SYM = "r_os_mempool_init"
 
 
-def _die(msg: str) -> None:
-    sys.stderr.write(f"esp32c6_nimble_mempool_link: {msg}\n")
-    sys.exit(1)
+class _Skip(Exception):
+    """Force-linking is not possible or not needed; leave the link untouched."""
+
+
+def _warn(msg: str) -> None:
+    sys.stderr.write(f"esp32c6_nimble_mempool_link: SKIPPED -- {msg}\n")
 
 
 def _defines_sym(nm_out: str, sym: str) -> bool:
@@ -34,43 +52,55 @@ def _defines_sym(nm_out: str, sym: str) -> bool:
     return False
 
 
-libs_dir = env.PioPlatform().get_package_dir("framework-arduinoespressif32-libs")
-if not libs_dir:
-    _die("package framework-arduinoespressif32-libs not found")
+def _force_link() -> None:
+    libs_dir = env.PioPlatform().get_package_dir("framework-arduinoespressif32-libs")
+    if not libs_dir:
+        raise _Skip("package framework-arduinoespressif32-libs not found")
 
-archive = Path(libs_dir) / "esp32c6" / "lib" / "libble_app.a"
-if not archive.is_file():
-    _die(f"missing {archive}")
+    archive = Path(libs_dir) / "esp32c6" / "lib" / "libble_app.a"
+    if not archive.is_file():
+        raise _Skip(f"missing {archive}")
 
-build_dir = Path(env.subst("$BUILD_DIR"))
-build_dir.mkdir(parents=True, exist_ok=True)
+    build_dir = Path(env.subst("$BUILD_DIR"))
+    build_dir.mkdir(parents=True, exist_ok=True)
 
-ar = env.subst("$AR") or "ar"
-subprocess.check_call([ar, "x", str(archive), MEMBER], cwd=build_dir)
+    ar = env.subst("$AR") or "ar"
+    try:
+        subprocess.check_call([ar, "x", str(archive), MEMBER], cwd=build_dir)
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        # The member was renamed or dropped, or the toolchain moved. Either way
+        # the linker's own diagnostics beat anything guessed from here.
+        raise _Skip(f"ar x {MEMBER} from {archive.name} failed: {exc}") from exc
 
-extracted = build_dir / MEMBER
-if not extracted.is_file():
-    _die(f"ar x did not produce {extracted}")
+    extracted = build_dir / MEMBER
+    if not extracted.is_file():
+        raise _Skip(f"ar x did not produce {extracted}")
 
-forced = build_dir / "forced_r_os_mempool.c.o"
-if forced.exists():
-    forced.unlink()
-extracted.replace(forced)
+    forced = build_dir / "forced_r_os_mempool.c.o"
+    if forced.exists():
+        forced.unlink()
+    extracted.replace(forced)
 
-nm = env.subst("$NM") or "nm"
+    nm = env.subst("$NM") or "nm"
+    try:
+        nm_out = subprocess.check_output([nm, str(forced)], text=True, stderr=subprocess.STDOUT)
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        raise _Skip(f"nm failed on {forced}: {exc}") from exc
+
+    if not _defines_sym(nm_out, NEEDED_SYM):
+        raise _Skip(f"{forced.name} does not define {NEEDED_SYM}")
+
+    # Inject into the lib-flags region (after objects), not early LINKFLAGS.
+    # Plain .o is always fully linked; follow with libble_app for r_ble_log_*/r_npl_funcs.
+    if "_LIBFLAGS" not in env:
+        raise _Skip("_LIBFLAGS not set; use post: script after framework init")
+
+    prefix = f" {forced} -Wl,--start-group {archive} -Wl,--end-group "
+    env["_LIBFLAGS"] = prefix + str(env["_LIBFLAGS"])
+    print(f"esp32c6_nimble_mempool_link: force-linking {forced.name} from {archive.name}")
+
+
 try:
-    nm_out = subprocess.check_output([nm, str(forced)], text=True, stderr=subprocess.STDOUT)
-except (subprocess.CalledProcessError, FileNotFoundError) as exc:
-    _die(f"nm failed on {forced}: {exc}")
-
-if not _defines_sym(nm_out, NEEDED_SYM):
-    _die(f"{forced} does not define {NEEDED_SYM}")
-
-# Inject into the lib-flags region (after objects), not early LINKFLAGS.
-# Plain .o is always fully linked; follow with libble_app for r_ble_log_*/r_npl_funcs.
-if "_LIBFLAGS" not in env:
-    _die("_LIBFLAGS not set; use post: script after framework init")
-
-prefix = f" {forced} -Wl,--start-group {archive} -Wl,--end-group "
-env["_LIBFLAGS"] = prefix + str(env["_LIBFLAGS"])
-print(f"esp32c6_nimble_mempool_link: force-linking {forced.name} from {archive.name}")
+    _force_link()
+except _Skip as skip:
+    _warn(f"{skip}; letting the linker resolve {NEEDED_SYM} on its own")

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -24,6 +24,34 @@ extern BLEServer* pServer;
 bool isAuthenticated();
 extern struct GlobalConfig globalConfig;
 
+// F4 -- command origin marker. The shared dispatcher (imageDataWritten) and the
+// response senders read this to (a) BYPASS the app-layer AES-CCM envelope for
+// TLS-secured LAN frames (SECTION 9 rule 4: origin-gated decrypt) and (b) route
+// each response back over ONLY its origin transport (no BLE/LAN dual-delivery).
+// Everything runs on the single loop() task (BLE queue drain + handleWiFiServer),
+// so this plain global needs no locking: it is set immediately before each
+// imageDataWritten() call and restored to ORIGIN_BLE after. On non-LAN builds it
+// stays ORIGIN_BLE for the whole lifetime (LAN never sets it).
+// enum CommandOrigin lives in communication.h so display_service.cpp / main.cpp can
+// name the values instead of comparing against a bare 0.
+volatile uint8_t g_commandOrigin = ORIGIN_BLE;
+
+// Transport tag for the RX banner and TX dump. Three transports share this
+// dispatcher (nRF BLE, ESP32 BLE via commandQueue, ESP32 LAN), and without a tag
+// the log cannot show which one a frame took -- in particular whether a frame used
+// the TLS CCM-bypass path. Accurate at every call site below because the LAN
+// listener sets g_commandOrigin immediately around its dispatch. Always "BLE" on
+// nRF and on ESP32 builds without the LAN transport.
+uint8_t commandOrigin(void) { return g_commandOrigin; }
+
+static const char* originTag(void) {
+    switch (g_commandOrigin) {
+        case ORIGIN_LAN_TLS:   return "LAN-TLS";
+        case ORIGIN_LAN_PLAIN: return "LAN";
+        default:               return "BLE";
+    }
+}
+
 static void reloadConfigAfterSave(void) {
     if (!loadGlobalConfig()) {
         od_log_warn("WARNING: Config was saved but reload from storage failed (see errors above). "
@@ -37,8 +65,11 @@ static void reloadConfigAfterSave(void) {
         epdSessionForceOff();
     }
     clearEncryptionSession();
-#ifdef TARGET_ESP32
-    initWiFi();
+#ifdef OPENDISPLAY_HAS_WIFI
+    // Non-blocking: a config write arrives over a live BLE link, and the blocking
+    // form stalls the loop task for up to 36 s of connect retries, freezing BLE
+    // command processing. handleWiFiServer() starts the LAN server on association.
+    initWiFi(false);
 #endif
 }
 bool encryptResponse(uint8_t* plaintext, uint16_t plaintext_len, uint8_t* ciphertext,
@@ -69,17 +100,7 @@ extern uint8_t responseQueueTail;
 // this between chunks so a multi-chunk config read never overflows the ring.
 extern void flushResponseQueueToBle();
 
-static void send_wifi_lan_frame(const uint8_t* payload, uint16_t len) {
-    if (!wifiServerConnected || !wifiClient.connected() || len == 0) {
-        return;
-    }
-    uint8_t hdr[2] = { (uint8_t)(len & 0xFF), (uint8_t)((len >> 8) & 0xFF) };
-    if (wifiClient.write(hdr, 2) != 2 || wifiClient.write(payload, len) != len) {
-        od_log_error("ERROR: LAN response write incomplete");
-    }
-}
-
-/** Mirror responses to BLE only when a central is connected; LAN already got send_wifi_lan_frame. */
+/** Mirror responses to BLE only when a central is connected; LAN responses go via opendisplay_lan_send_frame. */
 static void esp32_queue_ble_notify_copy(const uint8_t* response, uint16_t len, bool quiet = false) {
     if (len > MAX_RESPONSE_SIZE) {
         od_log_error("ERROR: Response too large for queue (%u > %u)", len, MAX_RESPONSE_SIZE);
@@ -97,10 +118,12 @@ static void esp32_queue_ble_notify_copy(const uint8_t* response, uint16_t len, b
     responseQueue[responseQueueHead].len = len;
     responseQueue[responseQueueHead].pending = true;
     responseQueueHead = nextHead;
-    if (!quiet) {
-        uint8_t queueSize = (responseQueueHead - responseQueueTail + RESPONSE_QUEUE_SIZE) % RESPONSE_QUEUE_SIZE;
-        od_log_debug("ESP32: Response queued (queue size: %u)", queueSize);
-    }
+    // The "[BLE][Q:n] TX ..." line above already reports every response and its
+    // queue depth, so the nominal enqueue (depth 1, drained next loop pass) is
+    // pure noise. Log only when a backlog is forming and the 10-slot ring is at
+    // risk of dropping responses.
+    const uint8_t depth = (responseQueueHead - responseQueueTail + RESPONSE_QUEUE_SIZE) % RESPONSE_QUEUE_SIZE;
+    if (!quiet && depth >= 2) od_log_debug("BLE: response queue backlog (queue size: %u)", depth);
 }
 #endif
 
@@ -191,8 +214,14 @@ void sendResponseUnencrypted(uint8_t* response, uint16_t len) {
     buildHexDump(hexDump, sizeof(hexDump), "  Full command: ", response, len);
     od_log_debug("%s", hexDump);
 #ifdef TARGET_ESP32
-    send_wifi_lan_frame(response, len);
-    esp32_queue_ble_notify_copy(response, len);
+    // F4 de-fan-out: reply over the origin transport only.
+    if (g_commandOrigin == ORIGIN_BLE) {
+        esp32_queue_ble_notify_copy(response, len);
+    } else {
+#ifdef OPENDISPLAY_HAS_WIFI
+        opendisplay_lan_send_frame(response, len);
+#endif
+    }
 #endif
 #ifdef TARGET_NRF
     if (Bluefruit.connected() && imageCharacteristic.notifyEnabled()) {
@@ -220,7 +249,9 @@ void sendResponse(uint8_t* response, uint16_t len) {
     // Length test uses the plaintext ACK (encryption happens after this check).
     const bool quietAck = (len == 2 && response[0] == 0x00 && response[1] == 0x71 && imageWriteLogQuietAck())
                        || (len == 7 && response[0] == 0x00 && response[1] == 0x81 && imageWriteLogQuietAck());
-    if (isAuthenticated() && len >= 2) {
+    // TLS-origin responses are already secured by the TLS record layer; never wrap
+    // them in the app-layer CCM envelope (no double-encrypt; SECTION 9 rule 4).
+    if (isAuthenticated() && len >= 2 && g_commandOrigin != ORIGIN_LAN_TLS) {
         uint16_t command = (response[0] << 8) | response[1];
         // The 7-byte PIPE data ACK {0x00,0x81,highest_seen,mask:4} carries a rolling
         // seq at byte[2]; a highest_seen of 0xFE/0xFF (any image >= 255 chunks) must
@@ -238,7 +269,7 @@ void sendResponse(uint8_t* response, uint16_t len) {
             uint16_t encrypted_len = 0;
             if (encryptResponse(response, len, encrypted_response, &encrypted_len, nonce, auth_tag)) {
                 if (!quietAck) {
-                    od_log_debug("Sending encrypted response:");
+                    od_log_debug("[%s] Sending encrypted response:", originTag());
                     od_log_debug("  Original length: %u bytes", len);
                     od_log_debug("  Encrypted length: %u bytes", encrypted_len);
                 }
@@ -253,7 +284,7 @@ void sendResponse(uint8_t* response, uint16_t len) {
                 len = sizeof(errorResponse);
             }
         } else if (!quietAck) {
-            od_log_debug("Sending unencrypted response (authentication/firmware version/error)");
+            od_log_debug("[%s] Sending unencrypted response (authentication/firmware version/error)", originTag());
         }
     }
 
@@ -262,7 +293,17 @@ void sendResponse(uint8_t* response, uint16_t len) {
         // is also the first two bytes of the dump). Replaces the old 4-line block.
         uint16_t cmd = (response[0] << 8) | response[1];
         char line[160];
-        int pos = snprintf(line, sizeof(line), "BLE: TX 0x%04X (%u B):", cmd, (unsigned)len);
+        int pos;
+#ifdef TARGET_ESP32
+        // Queue depth *before* this response is enqueued, so a healthy path reads
+        // [BLE][Q:0] and a rising Q flags the drain falling behind the producer.
+        if (g_commandOrigin == ORIGIN_BLE) {
+            const uint8_t qdepth = (responseQueueHead - responseQueueTail + RESPONSE_QUEUE_SIZE) % RESPONSE_QUEUE_SIZE;
+            pos = snprintf(line, sizeof(line), "[%s][Q:%u] TX 0x%04X (%u B):",
+                           originTag(), (unsigned)qdepth, cmd, (unsigned)len);
+        } else
+#endif
+        pos = snprintf(line, sizeof(line), "[%s] TX 0x%04X (%u B):", originTag(), cmd, (unsigned)len);
         if (pos < 0) {
             pos = 0;
             line[0] = '\0';
@@ -281,8 +322,14 @@ void sendResponse(uint8_t* response, uint16_t len) {
         od_log_debug("%s", line);
     }
 #ifdef TARGET_ESP32
-    send_wifi_lan_frame(response, len);
-    esp32_queue_ble_notify_copy(response, len, quietAck);
+    // F4 de-fan-out: reply over the origin transport only.
+    if (g_commandOrigin == ORIGIN_BLE) {
+        esp32_queue_ble_notify_copy(response, len, quietAck);
+    } else {
+#ifdef OPENDISPLAY_HAS_WIFI
+        opendisplay_lan_send_frame(response, len);
+#endif
+    }
 #endif
 #ifdef TARGET_NRF
     if (Bluefruit.connected() && imageCharacteristic.notifyEnabled()) {
@@ -593,7 +640,7 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
     if (!quietCmd) {
         const char* name = commandName(command);
         if (name != nullptr) {
-            od_log_info("=== %s COMMAND (0x%04X) ===", name, command);
+            od_log_info("=== [%s] %s COMMAND (0x%04X) ===", originTag(), name, command);
         }
     }
 
@@ -609,16 +656,20 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
         return;
     }
 
-    if (isEncryptionEnabled()) {
+    // SECTION 9 rule 4 (origin-gated decrypt): a frame arriving on the TLS-PSK LAN
+    // channel is already confidential + authenticated by TLS, so the app-layer
+    // AES-CCM envelope MUST NOT be required/applied — dispatch its plaintext
+    // command directly. BLE and plaintext-LAN frames still honor the CCM gate.
+    if (isEncryptionEnabled() && g_commandOrigin != ORIGIN_LAN_TLS) {
         if (!isAuthenticated()) {
-            od_log_error("ERROR: Command requires authentication (encryption enabled)");
+            od_log_error("ERROR: [%s] Command requires authentication (encryption enabled)", originTag());
             uint8_t response[] = {RESP_ACK, (uint8_t)(command & 0xFF), RESP_AUTH_REQUIRED};
             sendResponseUnencrypted(response, sizeof(response));
             return;
         }
 
         if (len < BLE_CMD_HEADER_SIZE + ENCRYPTION_NONCE_SIZE + ENCRYPTION_TAG_SIZE) {
-            od_log_error("ERROR: Unencrypted command received when encryption is enabled");
+            od_log_error("ERROR: [%s] Unencrypted command received when encryption is enabled", originTag());
             uint8_t response[] = {RESP_ACK, (uint8_t)(command & 0xFF), RESP_AUTH_REQUIRED};
             sendResponseUnencrypted(response, sizeof(response));
             return;

--- a/src/communication.h
+++ b/src/communication.h
@@ -16,4 +16,14 @@ void handleReadConfig();
 void handleWriteConfig(uint8_t* data, uint16_t len);
 void handleWriteConfigChunk(uint8_t* data, uint16_t len);
 
+// Transport a command arrived on. Set by the LAN listener around each dispatch and
+// ORIGIN_BLE at all other times. Multi-frame transfers use it to reject frames from
+// a transport that does not own the in-flight session, and to scope transport-only
+// behaviour (LAN power-save suspension) to the transport that opened the session.
+// Values are part of no wire format -- they are firmware-local bookkeeping.
+enum CommandOrigin { ORIGIN_BLE = 0, ORIGIN_LAN_PLAIN = 1, ORIGIN_LAN_TLS = 2 };
+
+/// Origin of the command currently being dispatched (a CommandOrigin value).
+uint8_t commandOrigin(void);
+
 #endif

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -5,6 +5,7 @@
 #include "encryption_state.h"
 #include "encryption.h"
 #include "power_latch.h"
+#include "wifi_service.h"  // OPENDISPLAY_HAS_WIFI + lanActivePort()/lanTlsEnabled()
 #include <Arduino.h>
 #include <string.h>
 
@@ -31,6 +32,10 @@ using namespace Adafruit_LittleFS_Namespace;
 #define DEVICE_FLAG_PWR_LATCH_DFF (1 << 4)
 #endif
 
+// The parse-time dumps and printConfigSummary() are od_log_debug, which the
+// default OD_LOG_LEVEL (INFO) compiles out entirely -- so they no longer cost
+// serial time in the deep-sleep wake window and need no runtime quiet flag.
+
 extern struct GlobalConfig globalConfig;
 extern uint8_t activeLedInstance;
 extern char wifiSsid[33];
@@ -40,7 +45,7 @@ extern bool wifiConfigured;
 #ifdef TARGET_ESP32
 extern char wifiServerUrl[65];
 extern uint16_t wifiServerPort;
-extern bool wifiServerConfigured;
+// extern bool wifiServerConfigured;  // dead -- see the 0x26 wifi_config parse
 extern bool wifiConnected;
 extern bool wifiInitialized;
 #endif
@@ -545,29 +550,28 @@ bool loadGlobalConfig(){
                         wifiServerPort = 2446;
                     }
 
-                    wifiServerConfigured = (wifiServerUrl[0] != '\0' &&
-                                           strcmp(wifiServerUrl, "0.0.0.0") != 0);
-                    if (wifiServerConfigured) {
-                        od_log_debug("Server configured: YES");
-                        od_log_debug("Server URL: \"%s\"", wifiServerUrl);
-                        od_log_debug("Server Port: %u", wifiServerPort);
-                    } else {
-                        od_log_debug("Server configured: NO");
-                        if (wifiServerUrl[0] == '\0') {
-                            od_log_debug("Reason: URL is empty");
-                        } else if (strcmp(wifiServerUrl, "0.0.0.0") == 0) {
-                            od_log_debug("Reason: URL is \"0.0.0.0\"");
-                        }
-                    }
+                    // wifiServerConfigured is dead: it was only ever read by the log
+                    // lines that used to sit here. It described the old "tag pushes to
+                    // an upload server" model, but the LAN transport inverted that --
+                    // the device listens and the host connects to it, so server_host
+                    // gates nothing. server_host stays part of the 0x26 wire format.
+                    //
+                    // Report the endpoint the LAN listener will actually bind, not just
+                    // the raw config field: the TLS-PSK channel runs on server_port + 1
+                    // and there is no config entry for it.
+#ifdef OPENDISPLAY_HAS_WIFI
+                    od_log_debug("LAN: %s on port %u (server_port %u)",
+                                 lanTlsEnabled() ? "TLS-PSK" : "plaintext",
+                                 (unsigned)lanActivePort(), (unsigned)wifiServerPort);
+#else
+                    od_log_debug("LAN: transport not compiled in (server_port %u)", (unsigned)wifiServerPort);
+#endif
 #endif
                     wifiConfigured = true;
                     od_log_info("=== WiFi Configuration Loaded ===");
-                    od_log_debug("SSID: \"%s\"", wifiSsid);
-                    if (passwordLen > 0) {
-                        od_log_debug("Password: \"%s\"", wifiPassword);
-                    } else {
-                        od_log_debug("Password: (empty)");
-                    }
+                    // Do NOT log the SSID or password (credentials). Presence/length only.
+                    od_log_debug("SSID: (set, %u chars)", ssidLen);
+                    od_log_debug("Password: %s", passwordLen > 0 ? "(set)" : "(empty)");
                     const char* encTypeStr = "Unknown";
                     switch (wifiEncryptionType) {
                         case 0x00: encTypeStr = "None (Open)"; break;
@@ -664,7 +668,7 @@ void printConfigSummary(){
     #ifdef TARGET_ESP32
     if (globalConfig.system_config.communication_modes & COMM_MODE_WIFI) {
         if (wifiConfigured) {
-            od_log_debug("  WiFi SSID: \"%s\"", wifiSsid);
+            od_log_debug("  WiFi SSID: (configured)");  // credential; not logged verbatim
             if (wifiInitialized) {
                 if (wifiConnected) {
                     String localIp = WiFi.localIP().toString();

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -55,6 +55,8 @@ bool hasValidStoredConfig(void);
 uint32_t calculateConfigCRC(uint8_t* data, uint32_t len);
 bool loadGlobalConfig();
 void printConfigSummary();
+// Suppress the informational config dumps (parse-time detail + printConfigSummary)
+// without touching ERROR/WARNING output. Used to keep a deep-sleep wake quiet.
 void full_config_init();
 
 // The one 4 KB config staging buffer, shared by every consumer that needs a

--- a/src/device_control.cpp
+++ b/src/device_control.cpp
@@ -23,6 +23,7 @@ extern "C" void bootloader_util_app_start(uint32_t start_addr);
 #include "driver/gpio.h"
 #include "esp32-hal-gpio.h"
 #include "ble_init.h"          // BLEDevice/BLEServer/BLEAdvertising aliases + esp32_ble_clear_handles()
+#include "wifi_service.h"      // OPENDISPLAY_HAS_WIFI + opendisplay_lan_teardown()
 extern BLEServer* pServer;     // defined in main.cpp
 #endif
 
@@ -245,6 +246,12 @@ void disconnect_callback(uint16_t conn_handle, uint8_t reason) {
 // only a physical power cycle clears. Mirrors the deep-sleep teardown in
 // enterDeepSleep() (main.cpp), which is why sleep->wake re-inits cleanly.
 static void esp32_ble_deinit_before_restart() {
+#ifdef OPENDISPLAY_HAS_WIFI
+    // F5 (extends PR #114): esp_restart() resets the CPU but not the WiFi radio or
+    // open sockets/TLS context. Tear the LAN listener + mbedTLS state down first so
+    // the next boot re-inits WiFi cleanly (mirrors the BLE deinit below).
+    opendisplay_lan_teardown();
+#endif
     if (pServer != nullptr) {
         BLEAdvertising* pAdvertising = pServer->getAdvertising();
         if (pAdvertising != nullptr) pAdvertising->stop();

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -18,6 +18,28 @@
 #include "display_fastepd.h"
 #endif
 
+// On ESP32-WiFi BUILDS, route this file's streaming-inflate calls to the ROM `tinfl`
+// engine (src/od_inflate_tinfl.*) instead of the uzlib bit-serial inflater. uzlib
+// (lib/uzlib) is left completely untouched — it is simply not called here, so the
+// linker drops it. The od_zlib_stream_* call sites below are unchanged; the macros
+// rebind them at compile time. od_zlib_status_t / OD_ZLIB_STATUS_* stay shared
+// (from uzlib.h).
+//
+// This remap is UNCONDITIONAL within such a build — it is not gated per transport, so
+// it rebinds EVERY compressed path in this file: direct-write (0x70/0x71), partial
+// region (0x76), and PIPE_WRITE (0x80-0x82). PIPE_WRITE is BLE-only, so BLE transfers
+// decode through tinfl here too. The WiFi keying of OPENDISPLAY_USE_TINFL selects
+// which builds opt in (the LAN wire is what makes software inflate the bottleneck and
+// justifies tinfl's ~11 KB of DRAM tables); it does NOT restrict the engine to LAN
+// traffic. See od_inflate_tinfl.h for the full rationale and RAM cost.
+#include "od_inflate_tinfl.h"
+#if OPENDISPLAY_USE_TINFL
+#define od_zlib_stream_reset  od_inflate_tinfl_reset
+#define od_zlib_stream_push   od_inflate_tinfl_push
+#define od_zlib_stream_poll   od_inflate_tinfl_poll
+#define od_zlib_stream_error  od_inflate_tinfl_error
+#endif
+
 #ifdef TARGET_NRF
 extern "C" {
 #include "nrf_soc.h"
@@ -539,6 +561,13 @@ static PartialStreamContext partialCtx = {};
 static void directWriteComputeGeometry(bool compressed);
 static void directWriteActivatePanel(void);
 static void directWriteFinishAndRefresh(uint8_t* data, uint16_t len, uint8_t endOpcode);
+
+#ifdef TARGET_ESP32
+// Defined in main.cpp. The response ring's only drainer is the loop task, which is
+// the same task running these handlers — so anything queued here stays queued until
+// we return. Call it before any multi-second blocking work (see the refresh tail).
+extern void flushResponseQueueToBle();
+#endif
 
 // PIPE_WRITE (0x0080-0x0082) sliding-window receive state + reorder queue. Declared
 // early so the quiet-logging predicates below can consult pipeState.active. The
@@ -1703,7 +1732,7 @@ float readChipTemperature() {
 }
 
 void updatemsdata(){
-    // writeSerial("updatemsdata() called (mloopcounter: " + String(mloopcounter) + ")", true);
+    // od_log_debug("updatemsdata() called (mloopcounter: %u)", mloopcounter);
     pollSht40SensorsForMsd();
     pollBq27220ForMsd();
     float batteryVoltage = readBatteryVoltage();
@@ -1783,7 +1812,9 @@ void updatemsdata(){
             pAdvertising->start();
         }
     }
+#ifdef OPENDISPLAY_HAS_WIFI
     opendisplay_mdns_update_msd_txt();
+#endif
 #endif
     mloopcounter++;
     mloopcounter &= 0x0F;
@@ -1829,7 +1860,12 @@ static void imageWriteLogReset(void) {
 static void imageWriteLogStart(uint32_t totalBytes) {
     imgLogTotalBytes = totalBytes;
     imgLogStartMs = millis();
-    od_log_debug("DW start: %u bytes expected", (unsigned)totalBytes);
+    // Whether the sender compressed is decided per transfer (START header flag), not
+    // by config, so the transmission_modes dump at boot does not answer it. State the
+    // active mode here: without it a slow push is ambiguous between "sent raw" and
+    // "compressed but the link is the bottleneck".
+    od_log_debug("DW start: %u bytes expected, %s", (unsigned)totalBytes,
+                 directWriteCompressed ? "zlib streaming" : "raw (uncompressed)");
 }
 
 static void imageWriteLogChunk(const uint8_t* data, uint16_t len) {
@@ -1863,13 +1899,26 @@ static void imageWriteLogFinish(uint32_t written, uint32_t total) {
     imgLogHex(hex, sizeof(hex), imgLogLastHead, imgLogLastHeadLen);
     od_log_debug("DW final frame %u: %u bytes: %s", (unsigned)imgLogChunks, imgLogLastLen, hex);
     uint32_t elapsedMs = millis() - imgLogStartMs;   // unsigned wrap-safe over one stream
+    char mode[48] = " raw";
+    if (directWriteCompressed) {
+        // On-wire bytes vs bytes handed to the panel: the ratio is the only direct
+        // evidence the stream actually inflated, and it makes a mis-sized or
+        // already-compressed payload obvious.
+        if (directWriteCompressedReceived > 0 && written > 0) {
+            snprintf(mode, sizeof(mode), " zlib %u B on wire (%.2fx)",
+                     (unsigned)directWriteCompressedReceived,
+                     (float)written / (float)directWriteCompressedReceived);
+        } else {
+            snprintf(mode, sizeof(mode), " zlib %u B on wire", (unsigned)directWriteCompressedReceived);
+        }
+    }
     if (elapsedMs > 0) {
         float rate = (float)written / 1.024f / (float)elapsedMs;  // bytes/ms /1.024 = KB/s
-        od_log_debug("DW complete: %u chunks, %u/%u bytes, %.2f s, %.1f KB/s",
-                    (unsigned)imgLogChunks, (unsigned)written, (unsigned)total, elapsedMs / 1000.0f, rate);
+        od_log_debug("DW complete: %u chunks, %u/%u bytes,%s, %.2f s, %.1f KB/s",
+                    (unsigned)imgLogChunks, (unsigned)written, (unsigned)total, mode, elapsedMs / 1000.0f, rate);
     } else {
-        od_log_debug("DW complete: %u chunks, %u/%u bytes, %.2f s, n/a KB/s",
-                    (unsigned)imgLogChunks, (unsigned)written, (unsigned)total, elapsedMs / 1000.0f);
+        od_log_debug("DW complete: %u chunks, %u/%u bytes,%s, %.2f s, n/a KB/s",
+                    (unsigned)imgLogChunks, (unsigned)written, (unsigned)total, mode, elapsedMs / 1000.0f);
     }
 }
 
@@ -1959,6 +2008,11 @@ static void directWriteSinkBytes(uint8_t* data, uint32_t len) {
 static bool directWriteTouchSuspended = false;
 
 void cleanupDirectWriteState(bool refreshDisplay) {
+#ifdef OPENDISPLAY_HAS_WIFI
+    // Sole clearer of directWriteActive, so this is the one place that reliably
+    // re-arms modem sleep after a full-frame transfer. No-op when nothing suspended it.
+    lanPowerSaveRestore();
+#endif
     directWriteActive = false;
     directWriteCompressed = false;
     directWriteBitplanes = false;
@@ -2054,7 +2108,30 @@ static void directWriteActivatePanel(void) {
     }
 }
 
+// ------------------------------------------------------- session ownership ---
+// Transfer state (directWriteActive, the zlib window, pipeState, partialCtx, panel
+// power) is a single global set, while g_commandOrigin is per-FRAME. Without an
+// owner recorded at START, a frame from the other transport joins the in-flight
+// session -- feeding a BLE chunk into a LAN transfer's zlib stream corrupts it
+// silently, and its ack goes back to the injector rather than the owning client.
+// The same gap lets a BLE disconnect tear down a live LAN transfer (see
+// transferSessionOrigin() use in main.cpp's serviceBleDisconnectCleanup).
+static uint8_t sessionOrigin = 0;   // ORIGIN_BLE
+
+uint8_t transferSessionOrigin(void) { return sessionOrigin; }
+
+// True when the frame being dispatched belongs to the transport that opened the
+// session. Logs once per rejected frame: silent discard is what made this class of
+// corruption invisible in the first place.
+static bool frameOwnsSession(const char* what) {
+    if (commandOrigin() == sessionOrigin) return true;
+    od_log_warn("WARNING: %s frame from origin %d dropped; session owned by origin %d",
+                what, (int)commandOrigin(), (int)sessionOrigin);
+    return false;
+}
+
 void handleDirectWriteStart(uint8_t* data, uint16_t len) {
+    sessionOrigin = commandOrigin();
     if (partialCtx.active) cleanup_partial_write_state();
     if (directWriteActive) {
         cleanupDirectWriteState(false);
@@ -2079,6 +2156,15 @@ void handleDirectWriteStart(uint8_t* data, uint16_t len) {
             return;
         }
     }
+#ifdef OPENDISPLAY_HAS_WIFI
+    // Modem sleep only wakes the radio at each DTIM beacon, so the per-chunk 0x71 ack
+    // ladder that follows can stall up to DTIM x 102.4 ms on every inbound frame.
+    // Position is load-bearing: the prior-session cleanups at the head of this function
+    // each call lanPowerSaveRestore(), so a suspend above them is undone. Below them
+    // every exit funnels through cleanupDirectWriteState(), which re-arms modem sleep --
+    // including the zlib-failure return just after this call.
+    if (sessionOrigin != ORIGIN_BLE) lanPowerSaveSuspend();
+#endif
     directWriteActivatePanel();
     if (compressed && len > 4) {
         uint32_t compressedDataLen = len - 4;
@@ -2095,6 +2181,7 @@ void handleDirectWriteStart(uint8_t* data, uint16_t len) {
 }
 
 void handlePartialWriteStart(uint8_t* data, uint16_t len) {
+    sessionOrigin = commandOrigin();
     if (directWriteActive) cleanupDirectWriteState(false);
     if (partialCtx.active) cleanup_partial_write_state();
     resetPipeWriteState();
@@ -2163,6 +2250,14 @@ void handlePartialWriteStart(uint8_t* data, uint16_t len) {
 
     memset(&partialCtx, 0, sizeof(partialCtx));
     partialCtx.active = true;
+#ifdef OPENDISPLAY_HAS_WIFI
+    // Same per-chunk 0x71 ack ladder as a full-frame write. Must go AFTER active=true,
+    // not earlier in this function: every validation return above passes
+    // cleanupState=false to send_direct_write_nack, so none reaches a restore and a
+    // malformed header would strand the radio at full power. From here on,
+    // cleanup_partial_write_state() covers every exit.
+    if (sessionOrigin != ORIGIN_BLE) lanPowerSaveSuspend();
+#endif
     partialCtx.compressed = (flags & PARTIAL_FLAG_COMPRESSED) != 0;
     partialCtx.flags = flags;
     partialCtx.new_etag = newEtag;
@@ -2200,6 +2295,7 @@ void handleDirectWriteData(uint8_t* data, uint16_t len) {
     if (pipeState.active) return;
     if (partialCtx.active) {
         if (len == 0) return;
+        if (!frameOwnsSession("0x0071 (partial)")) return;
         imageWriteLogChunk(data, len);
         if (!partial_consume_bytes(data, (uint32_t)len)) {
             send_direct_write_nack(RESP_DIRECT_WRITE_DATA_ACK, OD_ERR_PARTIAL_STREAM, true);
@@ -2211,6 +2307,7 @@ void handleDirectWriteData(uint8_t* data, uint16_t len) {
         return;
     }
     if (!directWriteActive || len == 0) return;
+    if (!frameOwnsSession("0x0071")) return;
     imageWriteLogChunk(data, len);
     if (directWriteCompressed) {
         if (!handleDirectWriteCompressedData(data, len)) {
@@ -2254,6 +2351,7 @@ void handleDirectWriteEnd(uint8_t* data, uint16_t len) {
     // finalize/refresh a pipe-owned session (partial would commit new_etag==0 and
     // leave pipeState zombied; full-frame would refresh with pipeState still active).
     if (pipeState.active) return;
+    if ((directWriteActive || partialCtx.active) && !frameOwnsSession("0x0072")) return;
     if (partialCtx.active) {
         if (data != nullptr && len > 1) {
             send_direct_write_nack(RESP_DIRECT_WRITE_END_ACK, OD_ERR_PARTIAL_STREAM, true);
@@ -2327,6 +2425,14 @@ static void directWriteFinishAndRefresh(uint8_t* data, uint16_t len, uint8_t end
     }
     uint8_t ackResponse[] = {0x00, endOpcode};
     sendResponse(ackResponse, sizeof(ackResponse));
+#ifdef TARGET_ESP32
+    // Push the END ack — and the final tail ACK the auto-complete path queued just
+    // before calling us — onto the air BEFORE the blocking refresh below. bbepRefresh
+    // + waitforrefresh occupy the loop task for seconds on a big panel, and the loop
+    // task is the response ring's only drainer, so without this the client sits in its
+    // tail-flush probe loop and aborts the (already complete) transfer on PTO.
+    flushResponseQueueToBle();
+#endif
     delay(20);
     epdRefreshInProgress = true;
     bool refreshSuccess = false;
@@ -2404,6 +2510,8 @@ void resetPipeWriteState(void) {
 }
 
 bool pipeWriteActive(void) { return pipeState.active; }
+
+bool partialWriteActive(void) { return partialCtx.active; }
 
 // A chunk c is "received" for ACK purposes if it was accepted in-order (lies just
 // below expected_seq within the mask window) or is currently held in the reorder
@@ -2537,6 +2645,7 @@ static bool pipeConsumePayload(uint8_t* data, uint16_t len) {
 }
 
 void handlePipeWriteStart(uint8_t* data, uint16_t len) {
+    sessionOrigin = commandOrigin();
     // A new START aborts any in-flight transfer of any family and resets pipe state
     // (mirrors legacy START). Reset happens up-front so even a malformed START is safe.
     if (partialCtx.active) cleanup_partial_write_state();
@@ -2711,6 +2820,7 @@ void handlePipeWriteStart(uint8_t* data, uint16_t len) {
 void handlePipeWriteData(uint8_t* data, uint16_t len) {
     if (!pipeState.active || pipeState.error) return;   // silent discard
     if (len < 1) return;
+    if (!frameOwnsSession("0x0081")) return;
     uint8_t  seq     = data[0];
     uint8_t* payload = data + 1;
     uint16_t plen    = (uint16_t)(len - 1);
@@ -2800,6 +2910,7 @@ void handlePipeWriteData(uint8_t* data, uint16_t len) {
 }
 
 void handlePipeWriteEnd(uint8_t* data, uint16_t len) {
+    if (pipeState.active && !frameOwnsSession("0x0082")) return;
     if (!pipeState.active) {
         uint8_t n[2] = {RESP_NACK, 0x82};   // no active pipe transfer
         sendResponse(n, sizeof(n));
@@ -2880,6 +2991,11 @@ void handlePipeWriteEnd(uint8_t* data, uint16_t len) {
 }
 
 static void cleanup_partial_write_state(void) {
+#ifdef OPENDISPLAY_HAS_WIFI
+    // Sole clearer of partialCtx.active, so this is the one place that reliably
+    // re-arms modem sleep for a partial transfer. No-op when nothing suspended it.
+    lanPowerSaveRestore();
+#endif
     // Tear the panel down only when a transfer/refresh is actually in flight
     // (PWR_ACTIVE) — i.e. on error / NACK / disconnect-mid-stream / watchdog. After
     // a successful refresh, epdSessionRelease already moved to PWR_WARM, so

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -1914,10 +1914,10 @@ static void imageWriteLogFinish(uint32_t written, uint32_t total) {
     }
     if (elapsedMs > 0) {
         float rate = (float)written / 1.024f / (float)elapsedMs;  // bytes/ms /1.024 = KB/s
-        od_log_debug("DW complete: %u chunks, %u/%u bytes,%s, %.2f s, %.1f KB/s",
+        od_log_info("DW complete: %u chunks, %u/%u bytes,%s, %.2f s, %.1f KB/s",
                     (unsigned)imgLogChunks, (unsigned)written, (unsigned)total, mode, elapsedMs / 1000.0f, rate);
     } else {
-        od_log_debug("DW complete: %u chunks, %u/%u bytes,%s, %.2f s, n/a KB/s",
+        od_log_info("DW complete: %u chunks, %u/%u bytes,%s, %.2f s, n/a KB/s",
                     (unsigned)imgLogChunks, (unsigned)written, (unsigned)total, mode, elapsedMs / 1000.0f);
     }
 }
@@ -2008,11 +2008,6 @@ static void directWriteSinkBytes(uint8_t* data, uint32_t len) {
 static bool directWriteTouchSuspended = false;
 
 void cleanupDirectWriteState(bool refreshDisplay) {
-#ifdef OPENDISPLAY_HAS_WIFI
-    // Sole clearer of directWriteActive, so this is the one place that reliably
-    // re-arms modem sleep after a full-frame transfer. No-op when nothing suspended it.
-    lanPowerSaveRestore();
-#endif
     directWriteActive = false;
     directWriteCompressed = false;
     directWriteBitplanes = false;
@@ -2156,15 +2151,6 @@ void handleDirectWriteStart(uint8_t* data, uint16_t len) {
             return;
         }
     }
-#ifdef OPENDISPLAY_HAS_WIFI
-    // Modem sleep only wakes the radio at each DTIM beacon, so the per-chunk 0x71 ack
-    // ladder that follows can stall up to DTIM x 102.4 ms on every inbound frame.
-    // Position is load-bearing: the prior-session cleanups at the head of this function
-    // each call lanPowerSaveRestore(), so a suspend above them is undone. Below them
-    // every exit funnels through cleanupDirectWriteState(), which re-arms modem sleep --
-    // including the zlib-failure return just after this call.
-    if (sessionOrigin != ORIGIN_BLE) lanPowerSaveSuspend();
-#endif
     directWriteActivatePanel();
     if (compressed && len > 4) {
         uint32_t compressedDataLen = len - 4;
@@ -2250,14 +2236,6 @@ void handlePartialWriteStart(uint8_t* data, uint16_t len) {
 
     memset(&partialCtx, 0, sizeof(partialCtx));
     partialCtx.active = true;
-#ifdef OPENDISPLAY_HAS_WIFI
-    // Same per-chunk 0x71 ack ladder as a full-frame write. Must go AFTER active=true,
-    // not earlier in this function: every validation return above passes
-    // cleanupState=false to send_direct_write_nack, so none reaches a restore and a
-    // malformed header would strand the radio at full power. From here on,
-    // cleanup_partial_write_state() covers every exit.
-    if (sessionOrigin != ORIGIN_BLE) lanPowerSaveSuspend();
-#endif
     partialCtx.compressed = (flags & PARTIAL_FLAG_COMPRESSED) != 0;
     partialCtx.flags = flags;
     partialCtx.new_etag = newEtag;
@@ -2991,11 +2969,6 @@ void handlePipeWriteEnd(uint8_t* data, uint16_t len) {
 }
 
 static void cleanup_partial_write_state(void) {
-#ifdef OPENDISPLAY_HAS_WIFI
-    // Sole clearer of partialCtx.active, so this is the one place that reliably
-    // re-arms modem sleep for a partial transfer. No-op when nothing suspended it.
-    lanPowerSaveRestore();
-#endif
     // Tear the panel down only when a transfer/refresh is actually in flight
     // (PWR_ACTIVE) — i.e. on error / NACK / disconnect-mid-stream / watchdog. After
     // a successful refresh, epdSessionRelease already moved to PWR_WARM, so

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -1923,11 +1923,11 @@ static void imageWriteLogFinish(uint32_t written, uint32_t total) {
 }
 
 bool imageWriteLogQuietCmd(void) {
-    return (directWriteActive || partialCtx.active || pipeState.active) && imgLogChunks >= 1;
+    return transferActive() && imgLogChunks >= 1;
 }
 
 bool imageWriteLogQuietAck(void) {
-    return (directWriteActive || partialCtx.active || pipeState.active) && imgLogChunks >= 2;
+    return transferActive() && imgLogChunks >= 2;
 }
 
 // True when this raw frame is a mid-stream image-write data chunk (command
@@ -2489,7 +2489,19 @@ void resetPipeWriteState(void) {
 
 bool pipeWriteActive(void) { return pipeState.active; }
 
-bool partialWriteActive(void) { return partialCtx.active; }
+// True while ANY of the three transfer types is streaming. The three flags live in
+// three different places (directWriteActive is a global; pipeState/partialCtx are
+// file-static here), so every caller that just means "a transfer is in flight" used
+// to spell the disjunction out itself -- and drifted: the WiFi roam gate checked
+// direct+pipe but not partial, so a BLE-origin partial write with no LAN client
+// attached could be interrupted by a full-channel scan. Add a fourth transfer type
+// here, not in each caller.
+//
+// Callers wanting ONE specific transfer keep testing that flag directly (the
+// direct-write watchdog and its teardown, the 0x0072 session-ownership check).
+bool transferActive(void) {
+    return directWriteActive || pipeState.active || partialCtx.active;
+}
 
 // A chunk c is "received" for ACK purposes if it was accepted in-order (lies just
 // below expected_seq within the mask window) or is currently held in the reorder

--- a/src/display_service.h
+++ b/src/display_service.h
@@ -72,8 +72,14 @@ bool imageWriteLogQuietAck(void);
 bool imageWriteLogQuietFrame(const uint8_t* data, uint16_t len);
 extern volatile bool epdRefreshInProgress;
 void handlePartialWriteStart(uint8_t* data, uint16_t len);
+// True while a PARTIAL_WRITE stream is active. partialCtx is file-static, so the
+// dispatcher and loop() read the flag through here.
+bool partialWriteActive(void);
 void checkPartialWriteTimeout(void);
 void cleanupPartialWriteOnDisconnect(void);
+// Origin (see commandOrigin()) of the transport that opened the in-flight transfer.
+// A disconnect must only tear down a session its own transport owns.
+uint8_t transferSessionOrigin(void);
 int getplane();
 int getBitsPerPixel();
 

--- a/src/display_service.h
+++ b/src/display_service.h
@@ -64,6 +64,10 @@ void handlePipeWriteEnd(uint8_t* data, uint16_t len);
 void resetPipeWriteState(void);
 // True while a PIPE_WRITE stream is active (mid-transfer log suppression, resets).
 bool pipeWriteActive(void);
+// True while ANY transfer (DIRECT / PIPE / PARTIAL) is streaming. Use this for
+// "is the device busy" gates; test an individual flag only when the logic is
+// genuinely specific to that one transfer type.
+bool transferActive(void);
 void handleDirectWriteEnd(uint8_t* data, uint16_t len);
 // True while an image push is mid-stream and the per-frame command/ack logging
 // should be suppressed (chunk 1 still logs in full; the meter covers the rest).
@@ -72,9 +76,6 @@ bool imageWriteLogQuietAck(void);
 bool imageWriteLogQuietFrame(const uint8_t* data, uint16_t len);
 extern volatile bool epdRefreshInProgress;
 void handlePartialWriteStart(uint8_t* data, uint16_t len);
-// True while a PARTIAL_WRITE stream is active. partialCtx is file-static, so the
-// dispatcher and loop() read the flag through here.
-bool partialWriteActive(void);
 void checkPartialWriteTimeout(void);
 void cleanupPartialWriteOnDisconnect(void);
 // Origin (see commandOrigin()) of the transport that opened the in-flight transfer.

--- a/src/encryption.cpp
+++ b/src/encryption.cpp
@@ -173,6 +173,19 @@ void incrementNonceCounter() {
     }
 }
 
+// Derive the LAN TLS-PSK from the master key with AES-CMAC over a fixed label.
+// Mirrors the KDF-label convention used by deriveSessionKey ("OpenDisplay
+// session"); here the label is "opendisplay-tls-psk". The 16-byte CMAC output is
+// the PSK; the PSK identity presented on the wire is the fixed string
+// "opendisplay" (must match the py-opendisplay TcpTransport client).
+bool deriveTlsPsk(uint8_t* psk_out16) {
+    if (psk_out16 == nullptr) return false;
+    if (!isEncryptionEnabled()) return false;
+    const char* label = "opendisplay-tls-psk";
+    return aes_cmac(securityConfig.encryption_key,
+                    reinterpret_cast<const uint8_t*>(label), strlen(label), psk_out16);
+}
+
 bool isEncryptionEnabled() {
     return (securityConfig.encryption_enabled == 1) &&
            (securityConfig.encryption_key[0] != 0 ||

--- a/src/encryption.h
+++ b/src/encryption.h
@@ -22,6 +22,10 @@ bool decryptCommand(uint8_t* ciphertext, uint16_t ciphertext_len, uint8_t* plain
                     uint16_t* plaintext_len, uint8_t* nonce, uint8_t* auth_tag, uint16_t command_header);
 bool encryptResponse(uint8_t* plaintext, uint16_t plaintext_len, uint8_t* ciphertext,
                      uint16_t* ciphertext_len, uint8_t* nonce, uint8_t* auth_tag);
+/// Derive the 16-byte TLS-PSK for the LAN TLS channel from the configured master
+/// key via AES-CMAC over a fixed KDF label. Returns false if encryption is not
+/// configured (no usable master key). The matching PSK IDENTITY is "opendisplay".
+bool deriveTlsPsk(uint8_t* psk_out16);
 
 String getChipIdHex();
 void secureEraseConfig();

--- a/src/esp32_ble_callbacks.h
+++ b/src/esp32_ble_callbacks.h
@@ -90,7 +90,10 @@ public:
             uint8_t* data = (uint8_t*)value.c_str();
             uint16_t len = value.length();
             if (!quiet) {
-                // One-line RX log, mirroring the "BLE: TX ..." response log.
+                // One-line RX log, mirroring the "[BLE] TX ..." response log. This
+                // callback is the BLE write path only, so the tag is always [BLE];
+                // LAN frames are identified by the dispatch banner in
+                // imageDataWritten(), which reads g_commandOrigin.
                 uint16_t cmd = (len >= 2) ? ((data[0] << 8) | data[1]) : data[0];
                 char line[160] = {0};
                 int pos = snprintf(line, sizeof(line), "BLE: RX 0x%04X (%u B):", cmd, (unsigned)len);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -104,6 +104,15 @@ void setup() {
     od_log_info("Starting setup...");
     if (is_deep_sleep_wake) { od_log_info("[wake] >> full_config_init"); od_log_flush(); }
     full_config_init();
+#ifdef OPENDISPLAY_HAS_WIFI
+    // Reserve mbedTLS's two ~16.7 KB record buffers HERE and nowhere else: config is
+    // loaded (so we know whether TLS is even used) but ble_init() and initWiFi() have not
+    // yet taken their ~100 KB, so internal DRAM is still contiguous. mbedtls_ssl_setup()
+    // needs both buffers contiguous and cannot be satisfied later on a churned heap --
+    // observed failing with -0x7f00 at 51 KB free / 31.7 KB largest block. No-op when
+    // encryption is disabled.
+    od_tls_reserve_records();
+#endif
     if (is_deep_sleep_wake) { od_log_info("[wake] << full_config_init >> initio"); od_log_flush(); }
     initio();
 #ifdef TARGET_NRF
@@ -129,7 +138,7 @@ void setup() {
 #elif defined(TARGET_NRF)
     ble_nrf_advertising_start();
 #endif
-    #ifdef TARGET_ESP32
+    #ifdef OPENDISPLAY_HAS_WIFI
     if (!is_deep_sleep_wake) {
         initWiFi(false);  // wake: WiFi stays deferred to fullSetupAfterConnection()
     }
@@ -223,7 +232,11 @@ static void pollActivity() {
     // Covers connect and disconnect. The disconnect edge is what re-arms the
     // window so a dropped client gets a full reconnect opportunity.
     const uint8_t connCount = (pServer != nullptr) ? (uint8_t)pServer->getConnectedCount() : 0;
+#ifdef OPENDISPLAY_HAS_WIFI
     const bool lanSession = wifiInitialized && wifiServerConnected && wifiClient.connected();
+#else
+    const bool lanSession = false;
+#endif
 
     if (!activityPrimed) {
         activityPrimed = true;
@@ -277,11 +290,15 @@ void flushResponseQueueToBle() {
             }
             responseQueue[responseQueueTail].pending = false;
             responseQueueTail = (responseQueueTail + 1) % RESPONSE_QUEUE_SIZE;
-            // One line per drained response, reporting the remaining queue depth
-            // (replaces the old "Sending queued response" + "Response sent successfully").
+            // The "[BLE][Q:n] TX ..." line in sendResponse() already logs every
+            // response with its queue depth, so the nominal drain (depth back to
+            // 0) is redundant. Report only the interesting case: entries still
+            // queued after this notify, i.e. the drain is behind the producer.
             if (!quietAck) {
                 uint8_t depth = (responseQueueHead - responseQueueTail + RESPONSE_QUEUE_SIZE) % RESPONSE_QUEUE_SIZE;
-                od_log_debug("BLE Response Sent (queue size: %u)", depth);
+                // Only when a backlog actually forms -- a depth-0 line on every
+                // response is noise that hides the interesting case.
+                if (depth > 0) od_log_debug("BLE Response Sent (queue size: %u)", depth);
             }
             bleDrain++;
         }
@@ -304,6 +321,21 @@ void flushResponseQueueToBle() {
 static void serviceBleDisconnectCleanup() {
     if (!bleDisconnectCleanupPending || epdRefreshInProgress) return;
     bleDisconnectCleanupPending = false;
+    // BLE and LAN both raise this flag, so tear down only when the transport that
+    // OWNS the in-flight transfer is the one that went away. Otherwise a BLE
+    // disconnect kills a live LAN push (and a LAN disconnect kills a BLE push)
+    // purely because the other link dropped. Owner is recorded at START.
+#ifdef OPENDISPLAY_HAS_WIFI
+    const bool lanOwnsSession = (transferSessionOrigin() != 0);   // != ORIGIN_BLE
+    const bool ownerStillUp = lanOwnsSession
+                                  ? wifiLanClientConnected()
+                                  : (pServer != nullptr && pServer->getConnectedCount() > 0);
+    if (ownerStillUp) {
+        od_log_info("Disconnect cleanup skipped: transfer still owned by a live %s session",
+                    lanOwnsSession ? "LAN" : "BLE");
+        return;
+    }
+#endif
     // ACTIVE-only-teardown invariant: a WARM (post-successful-refresh) panel
     // SURVIVES disconnect and keeps its keep-alive window, so the cleanups below
     // no-op on power when WARM and only tear down a mid-transfer (PWR_ACTIVE)
@@ -409,6 +441,25 @@ void loop() {
         }
     }
     checkPartialWriteTimeout();
+    #ifdef OPENDISPLAY_HAS_WIFI
+    // Belt-and-braces for the transfer-scoped WIFI_PS_NONE. The suspend/restore pair is
+    // already closed by construction (restore lives in the sole clearer of each active
+    // flag), so this should never fire -- but a stuck WIFI_PS_NONE is a silent battery
+    // drain with no user-visible symptom, and a future fourth way to end a transfer
+    // would leak it. Re-arm only after the state has been quiet for a while, so a brief
+    // gap between two back-to-back pushes does not thrash the radio.
+    static uint32_t psIdleSinceMs = 0;
+    if (lanPowerSaveSuspended() && !directWriteActive && !partialWriteActive()) {
+        if (psIdleSinceMs == 0) {
+            psIdleSinceMs = millis();
+        } else if ((millis() - psIdleSinceMs) > 5000UL) {
+            od_log_warn("WARNING: WiFi power save left suspended with no transfer active - restoring");
+            lanPowerSaveRestore();
+            psIdleSinceMs = 0;
+        }
+    } else {
+        psIdleSinceMs = 0;
+    }
     // WiFi handling runs after BLE queue processing to avoid blocking
     // BLE command responses (moved from top of loop in v1.6 fix).
     handleWiFiServer();
@@ -429,7 +480,8 @@ void loop() {
             restartWiFiLanAfterReconnect();
         }
     }
-    #ifdef TARGET_ESP32
+    #endif
+    #ifdef OPENDISPLAY_HAS_WIFI
     const bool wifiLanSession = wifiInitialized && wifiServerConnected && wifiClient.connected();
     #else
     const bool wifiLanSession = false;
@@ -520,7 +572,9 @@ void idleDelay(uint32_t delayMs) {
 #ifdef TARGET_ESP32
 void fullSetupAfterConnection() {
     od_log_info("=== Full Setup After Connection ===");
+#ifdef OPENDISPLAY_HAS_WIFI
     initWiFi(false);
+#endif
 #if defined(TARGET_ESP32) && defined(OPENDISPLAY_FASTEPD)
     if (globalConfig.display_count > 0 && fastepd_driver_used()) {
         od_log_info("Panel: FastEPD ED103/IT8951 (bb_epaper not used)");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -442,24 +442,6 @@ void loop() {
     }
     checkPartialWriteTimeout();
     #ifdef OPENDISPLAY_HAS_WIFI
-    // Belt-and-braces for the transfer-scoped WIFI_PS_NONE. The suspend/restore pair is
-    // already closed by construction (restore lives in the sole clearer of each active
-    // flag), so this should never fire -- but a stuck WIFI_PS_NONE is a silent battery
-    // drain with no user-visible symptom, and a future fourth way to end a transfer
-    // would leak it. Re-arm only after the state has been quiet for a while, so a brief
-    // gap between two back-to-back pushes does not thrash the radio.
-    static uint32_t psIdleSinceMs = 0;
-    if (lanPowerSaveSuspended() && !directWriteActive && !partialWriteActive()) {
-        if (psIdleSinceMs == 0) {
-            psIdleSinceMs = millis();
-        } else if ((millis() - psIdleSinceMs) > 5000UL) {
-            od_log_warn("WARNING: WiFi power save left suspended with no transfer active - restoring");
-            lanPowerSaveRestore();
-            psIdleSinceMs = 0;
-        }
-    } else {
-        psIdleSinceMs = 0;
-    }
     // WiFi handling runs after BLE queue processing to avoid blocking
     // BLE command responses (moved from top of loop in v1.6 fix).
     handleWiFiServer();

--- a/src/main.h
+++ b/src/main.h
@@ -222,7 +222,6 @@ void enterDFUMode();
 void initio();
 void initDataBuses();
 void initButtons();
-void handleButtonPress(uint8_t buttonIndex);
 void processButtonEvents();  // Process button events and update BLE data
 void idleDelay(uint32_t delayMs);  // Non-blocking delay that processes buttons at 100ms intervals
 void flashLed(uint8_t color, uint8_t brightness);  // Flash LED with color and brightness

--- a/src/main.h
+++ b/src/main.h
@@ -139,15 +139,25 @@ uint8_t wifiEncryptionType = 0;  // 0x00=none, 0x01=WEP, 0x02=WPA, 0x03=WPA2, 0x
 bool wifiConfigured = false;  // True if WiFi config packet (0x26) was received and parsed
 #ifdef TARGET_ESP32
 #include <WiFi.h>
+// Small config-storage / status globals: kept on all ESP32 targets (config_parser
+// and the config-dump report reference them regardless of whether the WiFi
+// transport is compiled in). Trivial RAM cost.
 bool wifiConnected = false;
 bool wifiInitialized = false;
 char wifiServerUrl[65] = {0};
 uint16_t wifiServerPort = 2446;
-bool wifiServerConfigured = false;
+// bool wifiServerConfigured = false;  // dead -- nothing reads it (config_parser.cpp)
+#endif
+#ifdef OPENDISPLAY_HAS_WIFI
+// Heavy WiFi-transport surface: the TCP server/client objects and the 16 KB RX
+// reassembly buffer exist ONLY when the WiFi transport is compiled in (S3/C6).
+// C3 / classic esp32-N4 reclaim this RAM.
+// 16 KB = four max wire frames (OD_LAN_MAX_FRAME 4096): headroom for the
+// streaming client to keep whole frames queued ahead of the parser.
 WiFiServer wifiServer;
 WiFiClient wifiClient;
 bool wifiServerConnected = false;
-uint8_t tcpReceiveBuffer[8192];
+uint8_t tcpReceiveBuffer[16384];
 uint32_t tcpReceiveBufferPos = 0;
 #endif
 

--- a/src/od_inflate_tinfl.cpp
+++ b/src/od_inflate_tinfl.cpp
@@ -1,0 +1,203 @@
+/*
+ * od_inflate_tinfl — ESP32 inflate adapter backed by the ROM miniz `tinfl`.
+ * See od_inflate_tinfl.h for the rationale, the RAM cost, and why the WiFi-keyed
+ * build gate does NOT limit this engine to WiFi traffic (it serves every compressed
+ * path, BLE included). Compiled to an empty TU when the gate is off (nRF52840 /
+ * classic ESP32), so miniz.h is only pulled in on ROM-tinfl builds.
+ */
+
+#include "od_inflate_tinfl.h"
+
+#if OPENDISPLAY_USE_TINFL
+
+#include <string.h>
+#include "miniz.h"   /* ROM tinfl on S3/C3/C6 (symbol via <chip>.rom.ld, header via esp_rom) */
+
+/* ------------------------------------------------------- dictionary/ring size ---
+ * This buffer serves TWO roles with DIFFERENT size requirements:
+ *
+ *  1) LZ77 history — the correctness FLOOR, equal to the DEFLATE window. A match can
+ *     never reference further back than the window, so bytes beyond it are unreachable
+ *     (never read as history). tinfl additionally REJECTS a stream whose CMF byte
+ *     declares a window larger than this buffer — a clean decode error at the zlib
+ *     header, never silent corruption — so the size must be >= the window.
+ *
+ *  2) Output staging ring — SPEED. tinfl's bulk paths need CONTIGUOUS headroom to the
+ *     ring end: symbol decode wants a couple of bytes, and the 8-bytes-at-a-time match
+ *     copy wants headroom >= the match length. DEFLATE's max match is 258 bytes
+ *     (RFC 1951 length codes 257..285; cf. length_base[] in lib/uzlib/src/od_zlib_stream.c),
+ *     so at a 512-byte ring a long match is often too close to the wrap and falls back
+ *     to the slow byte-at-a-time copy. The share of output affected scales as
+ *     match_len/ring_size, i.e. it halves per doubling with no threshold — ~50% at 512
+ *     vs ~6% at 4096 for worst-case 258-byte matches. E-paper images have large uniform
+ *     regions, which compress into long (often max-length) matches, so the worst case is
+ *     representative here rather than rare.
+ *
+ * Sizing rule:
+ *   - 9-bit window (512, the default): use 4096. The window alone leaves too little
+ *     staging headroom; 4096 restores the bulk paths while still reclaiming ~28 KB of
+ *     internal DRAM versus the old unconditional 32768.
+ *   - window > 9 bits: use the window size exactly. It already provides ample headroom,
+ *     so padding beyond the correctness floor would only waste DRAM.
+ *     (env:esp32-s3-E1004 pins BITS=15 => 32768, unchanged.)
+ *
+ * Overridable per-env via -DOD_TINFL_DICT_SIZE=<power of 2> to trade RAM against speed.
+ *
+ * NOTE: the dictionary is OURS, not tinfl's — `tinfl_decompressor` holds only the
+ * Huffman tables, and tinfl takes the ring as a caller-supplied buffer, so this array
+ * is the whole cost. TINFL_LZ_DICT_SIZE (32768) is a bare SDK #define that allocates
+ * nothing; it is deliberately NOT redefined here.
+ */
+#ifndef OD_TINFL_DICT_SIZE
+#  if OPENDISPLAY_ZLIB_WINDOW_BITS == 9
+#    define OD_TINFL_DICT_SIZE 4096u                          /* staging headroom */
+#  else
+#    define OD_TINFL_DICT_SIZE OPENDISPLAY_ZLIB_WINDOW_SIZE   /* window is ample */
+#  endif
+#endif
+/* Power of 2: tinfl derives its wrap mask from the buffer geometry passed in.
+ * >= window: else tinfl rejects the stream at the zlib header (see (1) above). */
+#if (OD_TINFL_DICT_SIZE & (OD_TINFL_DICT_SIZE - 1u)) != 0
+#error "OD_TINFL_DICT_SIZE must be a power of 2"
+#endif
+#if OD_TINFL_DICT_SIZE < OPENDISPLAY_ZLIB_WINDOW_SIZE
+#error "OD_TINFL_DICT_SIZE must be >= OPENDISPLAY_ZLIB_WINDOW_SIZE (the DEFLATE window)"
+#endif
+
+/* ------------------------------------------------------------------ state ---
+ * All static: plain arrays land in internal .bss/DRAM automatically, which is
+ * exactly what the history/output ring needs (fast match reads). The framebuffer
+ * is in PSRAM, so we decode into this SRAM ring and let the caller flush each
+ * delivered burst sequentially to PSRAM — never decode directly into PSRAM.
+ * s_dict is explicitly aligned: tinfl's fast match-copy path does 32-bit loads and
+ * stores through this pointer, which a 32 KB array got incidentally but a 512-byte
+ * one should not rely on.
+ */
+static tinfl_decompressor s_decomp;                 /* ~11 KB Huffman tables + bit buffer */
+static uint8_t            s_dict[OD_TINFL_DICT_SIZE] __attribute__((aligned(16)));
+                                                    /* LZ77 history AND output ring */
+
+static size_t   s_dict_ofs;      /* tinfl next-write position in the ring */
+static size_t   s_deliver_ofs;   /* start of the undelivered (pending) region */
+static size_t   s_pending;       /* bytes decoded but not yet copied to the caller (contiguous) */
+
+static const uint8_t *s_in;      /* staged input (current frame) */
+static size_t   s_in_remaining;
+static bool     s_more_input;    /* = !final of the current push (controls HAS_MORE_INPUT) */
+
+static uint32_t s_expected;      /* expected decompressed size (parity check with uzlib) */
+static uint32_t s_produced;      /* total bytes decoded so far */
+static bool     s_done;
+static bool     s_initialized;
+static const char *s_error;
+
+extern "C" {
+
+void od_inflate_tinfl_reset(uint32_t expected_output_size) {
+    tinfl_init(&s_decomp);
+    s_dict_ofs = 0;
+    s_deliver_ofs = 0;
+    s_pending = 0;
+    s_in = NULL;
+    s_in_remaining = 0;
+    s_more_input = true;
+    s_expected = expected_output_size;
+    s_produced = 0;
+    s_done = false;
+    s_error = NULL;
+    s_initialized = true;
+    /* s_dict is not cleared: tinfl only reads history bytes it has written. */
+}
+
+od_zlib_status_t od_inflate_tinfl_push(const uint8_t *input, size_t len, bool final) {
+    if (!s_initialized) { s_error = "tinfl stream not initialized"; return OD_ZLIB_STATUS_ERROR; }
+    if (s_error) return OD_ZLIB_STATUS_ERROR;
+    if (len > 0 && input == NULL) { s_error = "tinfl stream input is null"; return OD_ZLIB_STATUS_ERROR; }
+    if (s_in_remaining > 0) { s_error = "previous input not fully consumed"; return OD_ZLIB_STATUS_ERROR; }
+    if (s_done) {
+        if (len != 0) { s_error = "input after end of zlib stream"; return OD_ZLIB_STATUS_ERROR; }
+        return OD_ZLIB_STATUS_DONE;
+    }
+    s_in = input;
+    s_in_remaining = len;
+    s_more_input = !final;
+    return OD_ZLIB_STATUS_NEEDS_INPUT;
+}
+
+od_zlib_status_t od_inflate_tinfl_poll(uint8_t *output, size_t capacity, size_t *produced) {
+    *produced = 0;
+    if (!s_initialized) { s_error = "tinfl stream not initialized"; return OD_ZLIB_STATUS_ERROR; }
+    if (s_error) return OD_ZLIB_STATUS_ERROR;
+
+    for (;;) {
+        /* 1) Deliver already-decoded bytes to the caller first. The pending region is
+         *    always contiguous (each decode is bounded to the ring end), so this is a
+         *    plain memcpy — no ring wrap to handle here. */
+        if (s_pending > 0) {
+            size_t room = capacity - *produced;
+            if (room == 0) return OD_ZLIB_STATUS_OUTPUT_READY;
+            size_t n = (s_pending < room) ? s_pending : room;
+            memcpy(output + *produced, s_dict + s_deliver_ofs, n);
+            *produced += n;
+            s_deliver_ofs += n;
+            s_pending -= n;
+            if (s_pending > 0) return OD_ZLIB_STATUS_OUTPUT_READY;  /* caller's buffer is full */
+        }
+
+        /* pending == 0 here */
+        if (s_done) {
+            if (s_expected != 0 && s_produced != s_expected) {
+                s_error = "tinfl decompressed output size mismatch";
+                return OD_ZLIB_STATUS_ERROR;
+            }
+            return OD_ZLIB_STATUS_DONE;
+        }
+        if (*produced == capacity) return OD_ZLIB_STATUS_OUTPUT_READY;
+
+        /* 2) Decode the next contiguous burst into the ring (only when drained, so tinfl
+         *    can never overwrite bytes we have not delivered yet). Bound output to the
+         *    room up to the ring end; the wrap is handled by re-entering the loop. */
+        size_t in_bytes = s_in_remaining;
+        size_t out_bytes = OD_TINFL_DICT_SIZE - s_dict_ofs;
+        const mz_uint32 flags = (mz_uint32)(TINFL_FLAG_PARSE_ZLIB_HEADER |
+                                            (s_more_input ? TINFL_FLAG_HAS_MORE_INPUT : 0));
+        s_deliver_ofs = s_dict_ofs;  /* the pending region will start where tinfl writes */
+
+        tinfl_status st = tinfl_decompress(&s_decomp,
+                                           (const mz_uint8 *)s_in, &in_bytes,
+                                           (mz_uint8 *)s_dict, (mz_uint8 *)(s_dict + s_dict_ofs),
+                                           &out_bytes, flags);
+
+        s_in += in_bytes;
+        s_in_remaining -= in_bytes;
+        s_produced += (uint32_t)out_bytes;
+        s_pending = out_bytes;
+        s_dict_ofs = (s_dict_ofs + out_bytes) & (OD_TINFL_DICT_SIZE - 1u);
+
+        if (st < TINFL_STATUS_DONE) {  /* negative status codes are fatal */
+            s_error = (st == TINFL_STATUS_ADLER32_MISMATCH) ? "tinfl adler32 mismatch"
+                    : (st == TINFL_STATUS_BAD_PARAM)        ? "tinfl bad param"
+                    :                                         "tinfl inflate failed";
+            return OD_ZLIB_STATUS_ERROR;
+        }
+        if (st == TINFL_STATUS_DONE) {
+            s_done = true;
+            continue;  /* re-enter loop to deliver the final burst, then return DONE */
+        }
+        /* NEEDS_MORE_INPUT: staged frame consumed. If nothing was produced to deliver,
+         * ask the caller for the next frame; otherwise loop to deliver first. */
+        if (st == TINFL_STATUS_NEEDS_MORE_INPUT && s_pending == 0) {
+            return OD_ZLIB_STATUS_NEEDS_INPUT;
+        }
+        /* HAS_MORE_OUTPUT (ring end reached) or NEEDS_MORE_INPUT with pending>0:
+         * loop to deliver, then continue decoding / request input. */
+    }
+}
+
+const char *od_inflate_tinfl_error(void) { return s_error ? s_error : ""; }
+
+uint32_t od_inflate_tinfl_output_count(void) { return s_produced; }
+
+}  /* extern "C" */
+
+#endif /* OPENDISPLAY_USE_TINFL */

--- a/src/od_inflate_tinfl.h
+++ b/src/od_inflate_tinfl.h
@@ -1,0 +1,75 @@
+/*
+ * od_inflate_tinfl — ESP32 inflate adapter backed by the ROM miniz `tinfl`.
+ *
+ * Drop-in replacement for the uzlib streaming inflater (lib/uzlib,
+ * od_zlib_stream_*). It exposes the SAME streaming contract (reset / push / poll /
+ * error / output_count) and the SAME status type (od_zlib_status_t, reused from
+ * uzlib.h) so display_service.cpp can bind its existing od_zlib_stream_* call sites
+ * to this engine via a compile-time #define remap, with no changes to lib/uzlib and
+ * no changes to the call sites.
+ *
+ * SCOPE — this serves EVERY compressed path, not just WiFi/LAN. The remap in
+ * display_service.cpp is an unconditional compile-time #define, so when this engine
+ * is enabled it replaces uzlib for direct-write, partial-region, AND PIPE_WRITE
+ * regardless of transport. PIPE_WRITE is in fact BLE-only (see "NO PIPE ON LAN" in
+ * opendisplay_protocol.h), so the busiest BLE transfer path decodes through tinfl.
+ * The gate below keys off OPENDISPLAY_ENABLE_WIFI only as a proxy for "a build that
+ * cares about inflate throughput and can spare the RAM" — it does NOT mean the
+ * engine is limited to WiFi traffic. Do not read the gate as a transport filter.
+ *
+ * WHY: the uzlib engine is a bit-serial, byte-at-a-time resumable state machine —
+ * tolerable for BLE (wire << inflate), but the LAN wire is ~10-100x faster so
+ * software inflate becomes the bottleneck and compression turns into a net loss.
+ * `tinfl` is word-at-a-time + table-driven and lives in mask ROM on S3/C3/C6 (fixed
+ * addresses in <chip>.rom.ld), so it is faster at zero flash cost. BLE transfers get
+ * the same speedup for free; the LAN wire is just what made it necessary.
+ *
+ * COST: ~11 KB of internal DRAM for the Huffman tables (tinfl_decompressor), plus a
+ * caller-supplied LZ dictionary/output ring (see OD_TINFL_DICT_SIZE in
+ * od_inflate_tinfl.cpp — 4 KB at the default 9-bit window, sized for decode-path
+ * headroom rather than the 32 KB the TINFL_LZ_DICT_SIZE constant suggests; a window
+ * wider than 9 bits sizes it to the window instead). vs ~2.5 KB for uzlib.
+ *
+ * The status enum (od_zlib_status_t, OD_ZLIB_STATUS_*) is defined by uzlib.h; we
+ * only include it, never modify it.
+ */
+
+#ifndef OD_INFLATE_TINFL_H
+#define OD_INFLATE_TINFL_H
+
+#include "uzlib.h"   /* od_zlib_status_t + OD_ZLIB_STATUS_* (include only, not modified) */
+
+/* Gate: which BUILDS use this engine — NOT which transports it serves (see SCOPE
+ * above; once enabled it handles BLE too). Mirrors the condition that defines
+ * OPENDISPLAY_HAS_WIFI (src/wifi_service.h) because a LAN-capable build is the one
+ * that needs the throughput. ROM tinfl itself exists on S3/C3/C6 regardless.
+ * Overridable via a build flag if a target ever needs to force one engine or the
+ * other, e.g. -DOPENDISPLAY_USE_TINFL=0 to keep uzlib's smaller footprint. */
+#if !defined(OPENDISPLAY_USE_TINFL)
+#  if defined(TARGET_ESP32) && defined(OPENDISPLAY_ENABLE_WIFI)
+#    define OPENDISPLAY_USE_TINFL 1
+#  else
+#    define OPENDISPLAY_USE_TINFL 0
+#  endif
+#endif
+
+#if OPENDISPLAY_USE_TINFL
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Same semantics/signatures as od_zlib_stream_* in uzlib.h. */
+void od_inflate_tinfl_reset(uint32_t expected_output_size);
+od_zlib_status_t od_inflate_tinfl_push(const uint8_t *input, size_t len, bool final);
+od_zlib_status_t od_inflate_tinfl_poll(uint8_t *output, size_t capacity, size_t *produced);
+const char *od_inflate_tinfl_error(void);
+uint32_t od_inflate_tinfl_output_count(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OPENDISPLAY_USE_TINFL */
+
+#endif /* OD_INFLATE_TINFL_H */

--- a/src/touch_input.cpp
+++ b/src/touch_input.cpp
@@ -15,7 +15,8 @@
 extern struct GlobalConfig globalConfig;
 extern uint8_t dynamicreturndata[11];
 #ifdef TARGET_ESP32
-extern bool directWriteActive;
+// True while any of DIRECT / PIPE / PARTIAL is streaming (display_service.cpp).
+bool transferActive(void);
 #endif
 void updatemsdata(void);
 
@@ -577,7 +578,10 @@ void processTouchInput(void) {
         return;
     }
 #ifdef TARGET_ESP32
-    if (directWriteActive || s_epd_refresh_suspend > 0) {
+    // Skip the I2C poll while a transfer is streaming or an EPD refresh is in flight:
+    // GT911 reads contend with the transfer for the bus and the loop task. This used to
+    // test directWriteActive alone, so a PIPE or PARTIAL stream was left unprotected.
+    if (transferActive() || s_epd_refresh_suspend > 0) {
         return;
     }
 #endif

--- a/src/wifi_service.cpp
+++ b/src/wifi_service.cpp
@@ -100,46 +100,6 @@ static mbedtls_entropy_context  tlsEntropy;
 
 static uint32_t lastLanActivityMs = 0;  // for the OD_LAN_READ_TIMEOUT_S idle drop
 
-// --------------------------------------------------- transfer power save ---
-// Sticky across the whole transfer, unlike g_commandOrigin (per-frame, restored to
-// ORIGIN_BLE right after each dispatch). A transfer can be torn down from a loop()
-// timeout, disconnect cleanup, or an error path -- none of which know the origin --
-// so suspend is origin-gated at START and restore is unconditional everywhere else.
-static bool lanPsSuspended = false;
-
-// INTENTIONAL NO-OP -- do NOT re-enable WIFI_PS_NONE here.
-//
-// This was meant to dodge a DTIM ack-ladder stall by dropping modem sleep for the
-// duration of a LAN transfer. On this hardware WiFi and BLE share ONE radio and
-// software coexistence is compiled in (CONFIG_SW_COEXIST_ENABLE). The coex arbiter
-// relies on WiFi's modem-sleep (WIFI_PS_MIN_MODEM) windows to time-share the antenna
-// with the always-on BLE advertiser. WIFI_PS_NONE tells the AP "I never sleep, send
-// anytime", which is a lie under coex: BLE still periodically steals the radio, so the
-// AP fires downlink into windows where the device is off-channel. Those frames are
-// dropped at the PHY -> TCP retransmit + backoff on nearly every packet -> throughput
-// collapses to a crawl (measured on hardware, 2026-07-23). It hits WiFi in BOTH
-// directions (inbound data AND outbound acks), even though the transfer never touches
-// BLE -- BLE only has to EXIST for coex to be active.
-//
-// The DTIM stall it was chasing was measured negligible, so there is nothing to trade
-// off: the radio stays at the default WIFI_PS_MIN_MODEM for the whole session. The
-// function and its restore/safety-net machinery are retained as harmless no-ops
-// (lanPsSuspended never flips true) so the call sites and hook stay in place.
-void lanPowerSaveSuspend(void) {
-    // Deliberately does not touch esp_wifi_set_ps(). See the note above.
-}
-
-void lanPowerSaveRestore(void) {
-    if (!lanPsSuspended) return;
-    lanPsSuspended = false;
-    // Only touch the radio if it is still associated: after a disconnect the
-    // reconnect path re-applies MIN_MODEM itself (and would fail here anyway).
-    if (wifiConnected) esp_wifi_set_ps(WIFI_PS_MIN_MODEM);
-    lanLog("LAN: power save restored (WIFI_PS_MIN_MODEM)");
-}
-
-bool lanPowerSaveSuspended(void) { return lanPsSuspended; }
-
 static uint16_t lanBasePort(void) {
     return (wifiServerPort != 0) ? wifiServerPort : (uint16_t)OD_LAN_TCP_PORT;
 }
@@ -758,8 +718,8 @@ void initWiFi(bool waitForConnection) {
     lanLog("=== Initializing WiFi ===");
 
     // WiFi is NOT gated on power_mode: if COMM_MODE_WIFI is enabled the radio comes
-    // up on battery too. Radio cost on battery is managed by WIFI_PS_MIN_MODEM
-    // (below) and by deep sleep, not by refusing to associate.
+    // up on battery too. Radio cost on battery is managed by the driver's default
+    // power-save mode and by deep sleep, not by refusing to associate.
     if (!(globalConfig.system_config.communication_modes & COMM_MODE_WIFI)) {
         lanLog("WiFi not enabled in communication_modes, skipping");
         wifiInitialized = false;
@@ -828,7 +788,6 @@ void initWiFi(bool waitForConnection) {
         wifiConnected = true;
         lanLog("=== WiFi connected ===");
         lanLog("IP: " + WiFi.localIP().toString());
-        esp_wifi_set_ps(WIFI_PS_MIN_MODEM);  // F5: modem sleep between beacons
         startLanServer();
     } else {
         wifiConnected = false;
@@ -845,11 +804,6 @@ void disconnectWiFiServer() {
     }
     wifiServerConnected = false;
     tcpReceiveBufferPos = 0;
-    // The client is gone, so any transfer it owned is dead. Restore here rather than
-    // relying on the deferred cleanup below: serviceBleDisconnectCleanup() skips
-    // teardown while an EPD refresh is in flight or when the other transport still
-    // owns the session, either of which would leave the radio stuck at full power.
-    lanPowerSaveRestore();
     // F4: abort any in-flight direct-write / pipe / partial transfer + tear down a
     // mid-transfer panel session, DEFERRED to loop() (serviceBleDisconnectCleanup)
     // so cleanup never races an in-progress EPD refresh. Reuses the BLE path's flag.
@@ -905,11 +859,6 @@ void handleWiFiServer() {
         lanLog("IP: " + WiFi.localIP().toString() +
                     ", RSSI " + String(WiFi.RSSI()) + " dBm, ch " + String(WiFi.channel()) +
                     ", BSSID " + WiFi.BSSIDstr());
-        // Re-association: any transfer that suspended power save died with the old
-        // link, so clear the flag here rather than leaving it stuck across the
-        // reconnect (the teardown funnels may not run if the client vanished).
-        lanPowerSaveRestore();
-        esp_wifi_set_ps(WIFI_PS_MIN_MODEM);
         startLanServer();
     }
     if (!wifiConnected || WiFi.status() != WL_CONNECTED) {

--- a/src/wifi_service.cpp
+++ b/src/wifi_service.cpp
@@ -1,21 +1,29 @@
-#ifdef TARGET_ESP32
-
 #include "wifi_service.h"
+
+#ifdef OPENDISPLAY_HAS_WIFI
+
 #include "communication.h"
 #include "encryption.h"
 #include "structs.h"
 #include "od_log.h"
+#include "ble_init.h"   // NimBLE-Arduino + BLE* aliases (NimBLEDevice for the advertised MAC)
 #include <Arduino.h>
 #include <ESPmDNS.h>
 #include <WiFi.h>
+#include <esp_wifi.h>
+#include <esp_event.h>       // raw handler for WIFI_EVENT_STA_BSS_RSSI_LOW (no Arduino event id)
+#include <esp_heap_caps.h>
 #include <string.h>
+
+#include "mbedtls/ssl.h"
+#include "mbedtls/ctr_drbg.h"
+#include "mbedtls/entropy.h"
+#include "mbedtls/net_sockets.h"
+#include "mbedtls/ssl_ciphersuites.h"
+#include "mbedtls/platform.h"   // mbedtls_platform_set_calloc_free (MBEDTLS_PLATFORM_MEMORY is on via esp_config.h)
 
 #ifndef COMM_MODE_WIFI
 #define COMM_MODE_WIFI (1 << 2)
-#endif
-
-#ifndef WIFI_LAN_MAX_PAYLOAD
-#define WIFI_LAN_MAX_PAYLOAD 4096U
 #endif
 
 extern struct GlobalConfig globalConfig;
@@ -29,15 +37,365 @@ extern uint16_t wifiServerPort;
 extern WiFiServer wifiServer;
 extern WiFiClient wifiClient;
 extern bool wifiServerConnected;
-extern uint8_t tcpReceiveBuffer[8192];
+extern uint8_t tcpReceiveBuffer[16384];
 extern uint32_t tcpReceiveBufferPos;
 extern uint8_t msd_payload[16];
 
+// This file builds its log lines with Arduino String concatenation, while the rest
+// of the firmware logs printf-style through od_log_*. Rather than reflow 60-odd
+// call sites into format strings, funnel them through one adapter and route by the
+// message's own ERROR:/WARNING: prefix so the intended level survives. The String
+// is built by the caller either way, so this adds no allocation the call sites did
+// not already make -- and the EVENT-CONTEXT RULE below still forbids calling it
+// from a WiFi event callback.
+static void lanLog(const String& message, bool newLine = true) {
+    (void)newLine;
+    if (message.startsWith("ERROR")) {
+        od_log_error("%s", message.c_str());
+    } else if (message.startsWith("WARNING")) {
+        od_log_warn("%s", message.c_str());
+    } else {
+        od_log_info("%s", message.c_str());
+    }
+}
+
+// Command origin marker (F4): the shared dispatcher (imageDataWritten) reads this
+// to decide whether to run the app-layer AES-CCM gate. Defined in communication.cpp;
+// enum CommandOrigin comes from communication.h.
+// ORIGIN_LAN_TLS frames are already secured by TLS, so CCM MUST be bypassed.
+extern volatile uint8_t g_commandOrigin;
+
+// Roam gating: never re-associate (or full-channel scan, which steals the shared radio
+// from BLE under coex) while a transfer is in flight. directWriteActive is in main.h;
+// pipeWriteActive() is declared in display_service.h.
+extern bool directWriteActive;
+bool pipeWriteActive(void);
+
 String getChipIdHex();
+static void lanBeginConnect(void);   // defined with the roaming / RTC AP-cache block below
+uint8_t getFirmwareMajor();
+uint8_t getFirmwareMinor();
 
 typedef void* BLEConnHandle;
 typedef void* BLECharPtr;
 void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uint16_t len);
+
+// ------------------------------------------------------------------ TLS-PSK ---
+// One TLS session at a time, driven cooperatively from handleWiFiServer(). The
+// PSK identity string "opendisplay" must match the py-opendisplay client; the
+// PSK bytes come from deriveTlsPsk() (AES-CMAC over the master key).
+static const char* kTlsPskIdentity = "opendisplay";
+static const int kTlsCiphersuites[] = { MBEDTLS_TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256, 0 };
+
+static bool tlsMode = false;            // true when the ACTIVE channel is TLS-PSK
+static bool tlsInited = false;          // mbedTLS config objects built once
+static bool tlsSessionActive = false;   // an mbedtls_ssl_context is live for wifiClient
+static bool tlsHandshakeDone = false;
+static uint8_t tlsPsk[16];
+
+static mbedtls_ssl_context   tlsSsl;
+static mbedtls_ssl_config    tlsConf;
+static mbedtls_ctr_drbg_context tlsDrbg;
+static mbedtls_entropy_context  tlsEntropy;
+
+static uint32_t lastLanActivityMs = 0;  // for the OD_LAN_READ_TIMEOUT_S idle drop
+
+// --------------------------------------------------- transfer power save ---
+// Sticky across the whole transfer, unlike g_commandOrigin (per-frame, restored to
+// ORIGIN_BLE right after each dispatch). A transfer can be torn down from a loop()
+// timeout, disconnect cleanup, or an error path -- none of which know the origin --
+// so suspend is origin-gated at START and restore is unconditional everywhere else.
+static bool lanPsSuspended = false;
+
+// INTENTIONAL NO-OP -- do NOT re-enable WIFI_PS_NONE here.
+//
+// This was meant to dodge a DTIM ack-ladder stall by dropping modem sleep for the
+// duration of a LAN transfer. On this hardware WiFi and BLE share ONE radio and
+// software coexistence is compiled in (CONFIG_SW_COEXIST_ENABLE). The coex arbiter
+// relies on WiFi's modem-sleep (WIFI_PS_MIN_MODEM) windows to time-share the antenna
+// with the always-on BLE advertiser. WIFI_PS_NONE tells the AP "I never sleep, send
+// anytime", which is a lie under coex: BLE still periodically steals the radio, so the
+// AP fires downlink into windows where the device is off-channel. Those frames are
+// dropped at the PHY -> TCP retransmit + backoff on nearly every packet -> throughput
+// collapses to a crawl (measured on hardware, 2026-07-23). It hits WiFi in BOTH
+// directions (inbound data AND outbound acks), even though the transfer never touches
+// BLE -- BLE only has to EXIST for coex to be active.
+//
+// The DTIM stall it was chasing was measured negligible, so there is nothing to trade
+// off: the radio stays at the default WIFI_PS_MIN_MODEM for the whole session. The
+// function and its restore/safety-net machinery are retained as harmless no-ops
+// (lanPsSuspended never flips true) so the call sites and hook stay in place.
+void lanPowerSaveSuspend(void) {
+    // Deliberately does not touch esp_wifi_set_ps(). See the note above.
+}
+
+void lanPowerSaveRestore(void) {
+    if (!lanPsSuspended) return;
+    lanPsSuspended = false;
+    // Only touch the radio if it is still associated: after a disconnect the
+    // reconnect path re-applies MIN_MODEM itself (and would fail here anyway).
+    if (wifiConnected) esp_wifi_set_ps(WIFI_PS_MIN_MODEM);
+    lanLog("LAN: power save restored (WIFI_PS_MIN_MODEM)");
+}
+
+bool lanPowerSaveSuspended(void) { return lanPsSuspended; }
+
+static uint16_t lanBasePort(void) {
+    return (wifiServerPort != 0) ? wifiServerPort : (uint16_t)OD_LAN_TCP_PORT;
+}
+// Active LAN port: plaintext -> base; TLS -> base+1 (derived, no config field).
+uint16_t lanActivePort(void) {
+    uint16_t base = lanBasePort();
+    return isEncryptionEnabled() ? (uint16_t)(base + 1) : base;
+}
+
+bool lanTlsEnabled(void) { return isEncryptionEnabled(); }
+
+// mbedTLS BIO shims over the accepted WiFiClient (non-blocking cooperative model).
+static int tls_bio_send(void* ctx, const unsigned char* buf, size_t len) {
+    WiFiClient* c = static_cast<WiFiClient*>(ctx);
+    if (c == nullptr || !c->connected()) return MBEDTLS_ERR_NET_CONN_RESET;
+    int w = c->write(buf, len);
+    if (w <= 0) return MBEDTLS_ERR_SSL_WANT_WRITE;
+    return w;
+}
+static int tls_bio_recv(void* ctx, unsigned char* buf, size_t len) {
+    WiFiClient* c = static_cast<WiFiClient*>(ctx);
+    if (c == nullptr || !c->connected()) return MBEDTLS_ERR_NET_CONN_RESET;
+    if (c->available() <= 0) return MBEDTLS_ERR_SSL_WANT_READ;
+    int r = c->read(buf, len);
+    if (r <= 0) return MBEDTLS_ERR_SSL_WANT_READ;
+    return r;
+}
+
+// mbedTLS on this SDK is built with CONFIG_MBEDTLS_INTERNAL_MEM_ALLOC=y, so every TLS
+// allocation comes from internal DRAM only -- PSRAM is never eligible, however much of
+// it the board has. ssl_setup alone needs two ~16.4 KB contiguous blocks there
+// (CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN=16384, asymmetric length not set), which is the
+// dominant failure mode once WiFi + BLE coex and the static buffers have taken their cut.
+// Append this to any TLS failure so the log says whether it was OOM and by how much.
+static String tlsFailNote(int ret) {
+    const String code = (ret < 0) ? ("-0x" + String((unsigned)(-ret), HEX)) : String(ret);
+    return String(" (ret=") + code +
+           ", internal free=" + String((unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL)) +
+           ", largest block=" + String((unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL)) + ")";
+}
+
+// -------------------------------------------- TLS record pre-reservation ---
+// mbedtls_ssl_setup() allocates TWO record buffers of CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN
+// (16384) + record overhead, i.e. ~16.7 KB EACH, and CONFIG_MBEDTLS_INTERNAL_MEM_ALLOC=y
+// forces both into internal DRAM. Both values are baked into the prebuilt SDK libs, so
+// neither the size nor the region can be changed from here.
+//
+// That fails in the field even with plenty of free RAM, because what matters is the
+// LARGEST CONTIGUOUS block, not the total. Observed on hardware:
+//   ssl_setup failed (ret=-0x7f00, internal free=51144, largest block=31732)
+// 51 KB free, yet the first 16.7 KB allocation leaves only ~15 KB in that block and the
+// second has nowhere to go -- short by under 2 KB.
+//
+// Worse, ssl_setup runs on EVERY LAN client connect and ssl_free releases on every
+// disconnect, so TLS cycles 33 KB through the heap per connection while String logging
+// churns small blocks in between: the odds degrade the longer the device stays up.
+//
+// Fix: reserve the two slots ONCE at boot -- from setup(), right after full_config_init()
+// and BEFORE ble_init()/initWiFi() take their ~100 KB -- when the heap is still
+// contiguous, then serve mbedTLS from them via its allocator hook. This does not raise
+// peak usage (the buffers are needed whenever TLS runs); it moves the allocation to the
+// one moment where success is guaranteed, and recycling the slots stops TLS fragmenting
+// the heap for lwIP/BLE.
+//
+// Only record-sized requests come from the pool. Small handshake/bignum allocations (and
+// encryption.cpp's CCM/CMAC contexts) still go to the normal internal heap, so their
+// behavior and placement are unchanged.
+//
+// Single-task by design: every mbedTLS call here runs on the loop task (handleWiFiServer
+// drives handshake + reads), so the busy flags need no locking.
+#define OD_TLS_RECORD_SLOT_SIZE  17408u   /* 17 KB: 16384 content + record overhead margin */
+#define OD_TLS_RECORD_SLOTS      2        /* ssl_setup takes exactly one in + one out */
+#define OD_TLS_POOL_MIN_ALLOC    8192u    /* only record-sized requests use the pool */
+
+static uint8_t* s_tlsSlot[OD_TLS_RECORD_SLOTS];
+static bool     s_tlsSlotBusy[OD_TLS_RECORD_SLOTS];
+static bool     s_tlsAllocHooked = false;
+
+static void* od_tls_calloc(size_t n, size_t size) {
+    const size_t total = n * size;
+    if (total >= OD_TLS_POOL_MIN_ALLOC) {
+        for (int i = 0; i < OD_TLS_RECORD_SLOTS; i++) {
+            if (s_tlsSlot[i] != nullptr && !s_tlsSlotBusy[i] && total <= OD_TLS_RECORD_SLOT_SIZE) {
+                s_tlsSlotBusy[i] = true;
+                memset(s_tlsSlot[i], 0, total);   /* calloc semantics */
+                return s_tlsSlot[i];
+            }
+        }
+        // The pool could not serve a record-sized request: either the slot is too small
+        // or both are in use. This is exactly the case that reintroduces the original
+        // failure, so name it once -- the size tells us whether the slot needs raising.
+        static bool warned = false;
+        if (!warned) {
+            warned = true;
+            lanLog("WARNING: TLS alloc " + String((unsigned)total) +
+                        " B not served from the reserved pool (slot " +
+                        String((unsigned)OD_TLS_RECORD_SLOT_SIZE) + " B) -- falling back to heap");
+        }
+    }
+    return heap_caps_calloc(n, size, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+}
+
+static void od_tls_free(void* p) {
+    if (p == nullptr) return;
+    for (int i = 0; i < OD_TLS_RECORD_SLOTS; i++) {
+        if (p == s_tlsSlot[i]) {
+            s_tlsSlotBusy[i] = false;   /* recycle, never return it to the heap */
+            return;
+        }
+    }
+    heap_caps_free(p);
+}
+
+void od_tls_reserve_records(void) {
+    if (s_tlsAllocHooked) return;
+    // Gate on config: a device without encryption must not hold 34 KB it never uses.
+    if (!isEncryptionEnabled()) {
+        lanLog("TLS: encryption disabled, no record buffers reserved");
+        return;
+    }
+    int got = 0;
+    for (int i = 0; i < OD_TLS_RECORD_SLOTS; i++) {
+        s_tlsSlot[i] = (uint8_t*)heap_caps_malloc(OD_TLS_RECORD_SLOT_SIZE,
+                                                  MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+        s_tlsSlotBusy[i] = false;
+        if (s_tlsSlot[i] != nullptr) got++;
+    }
+    // Install the hook even on a partial reservation: whatever was reserved still helps,
+    // and od_tls_calloc falls back to the heap for the rest.
+    mbedtls_platform_set_calloc_free(od_tls_calloc, od_tls_free);
+    s_tlsAllocHooked = true;
+    lanLog("TLS: reserved " + String(got) + "/" + String((int)OD_TLS_RECORD_SLOTS) +
+                " record slots of " + String((unsigned)OD_TLS_RECORD_SLOT_SIZE) + " B" +
+                ", internal free=" + String((unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL)) +
+                ", largest block=" + String((unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL)));
+    if (got < OD_TLS_RECORD_SLOTS) {
+        lanLog("WARNING: TLS record reservation incomplete -- ssl_setup may still fail");
+    }
+}
+
+// Build the shared server config once (RNG + PSK + one ECDHE-PSK ciphersuite).
+static bool tlsEnsureConfig(void) {
+    // Late fallback: encryption can be turned on by a runtime config write, long after
+    // the boot-time reservation window has passed. Try anyway -- it may fail on a churned
+    // heap, but the log then says so instead of leaving it silently unreserved.
+    od_tls_reserve_records();
+    if (tlsInited) return true;
+    if (!deriveTlsPsk(tlsPsk)) {
+        lanLog("ERROR: TLS PSK derivation failed (no master key)");
+        return false;
+    }
+    mbedtls_ssl_config_init(&tlsConf);
+    mbedtls_ctr_drbg_init(&tlsDrbg);
+    mbedtls_entropy_init(&tlsEntropy);
+    const char* pers = "opendisplay-tls";
+    int rc = mbedtls_ctr_drbg_seed(&tlsDrbg, mbedtls_entropy_func, &tlsEntropy,
+                                   reinterpret_cast<const unsigned char*>(pers), strlen(pers));
+    if (rc != 0) {
+        lanLog("ERROR: TLS RNG seed failed" + tlsFailNote(rc));
+        return false;
+    }
+    rc = mbedtls_ssl_config_defaults(&tlsConf, MBEDTLS_SSL_IS_SERVER,
+                                     MBEDTLS_SSL_TRANSPORT_STREAM,
+                                     MBEDTLS_SSL_PRESET_DEFAULT);
+    if (rc != 0) {
+        lanLog("ERROR: TLS config defaults failed" + tlsFailNote(rc));
+        return false;
+    }
+    mbedtls_ssl_conf_rng(&tlsConf, mbedtls_ctr_drbg_random, &tlsDrbg);
+    mbedtls_ssl_conf_ciphersuites(&tlsConf, kTlsCiphersuites);
+    rc = mbedtls_ssl_conf_psk(&tlsConf, tlsPsk, sizeof(tlsPsk),
+                              reinterpret_cast<const unsigned char*>(kTlsPskIdentity),
+                              strlen(kTlsPskIdentity));
+    if (rc != 0) {
+        lanLog("ERROR: TLS conf_psk failed" + tlsFailNote(rc));
+        return false;
+    }
+    tlsInited = true;
+    return true;
+}
+
+static void tlsCloseSession(void) {
+    if (tlsSessionActive) {
+        mbedtls_ssl_close_notify(&tlsSsl);
+        mbedtls_ssl_free(&tlsSsl);
+    }
+    tlsSessionActive = false;
+    tlsHandshakeDone = false;
+}
+
+static bool tlsBeginSession(void) {
+    if (!tlsEnsureConfig()) return false;
+    mbedtls_ssl_init(&tlsSsl);
+    int rc = mbedtls_ssl_setup(&tlsSsl, &tlsConf);
+    if (rc != 0) {
+        // -0x7F00 == MBEDTLS_ERR_SSL_ALLOC_FAILED: the record buffers did not fit in
+        // internal DRAM. Compare "largest block" against ~16.4 KB in the note above.
+        lanLog("ERROR: TLS ssl_setup failed" + tlsFailNote(rc));
+        mbedtls_ssl_free(&tlsSsl);
+        return false;
+    }
+    mbedtls_ssl_set_bio(&tlsSsl, &wifiClient, tls_bio_send, tls_bio_recv, nullptr);
+    tlsSessionActive = true;
+    tlsHandshakeDone = false;
+    return true;
+}
+
+// Staging buffer so a frame leaves as ONE write. Two writes cost an extra packet
+// (and, before setNoDelay(), a 40-200 ms Nagle/delayed-ACK stall on every frame);
+// on TLS they also cost a second record header + MAC, which on a 2-byte ACK is more
+// overhead than payload. Sized past the largest response the device produces
+// (encrypted_response[600] in communication.cpp); anything larger falls back to the
+// two-write path rather than growing static RAM for a case that does not occur.
+static uint8_t lanTxFrame[2 + 640];
+
+// Write one [len:2 LE][payload] frame over the active LAN channel (TLS or plain).
+// Called by communication.cpp for LAN-origin responses (send_tls_lan_frame / plain).
+void opendisplay_lan_send_frame(const uint8_t* payload, uint16_t len) {
+    if (!wifiServerConnected || !wifiClient.connected() || len == 0) {
+        return;
+    }
+    if (tlsMode && (!tlsSessionActive || !tlsHandshakeDone)) return;
+
+    if ((uint32_t)len + 2u <= sizeof(lanTxFrame)) {
+        lanTxFrame[0] = (uint8_t)(len & 0xFF);
+        lanTxFrame[1] = (uint8_t)((len >> 8) & 0xFF);
+        memcpy(lanTxFrame + 2, payload, len);
+        const uint16_t total = (uint16_t)(len + 2u);
+        if (tlsMode) {
+            if (mbedtls_ssl_write(&tlsSsl, lanTxFrame, total) < 0) {
+                lanLog("ERROR: TLS LAN response write failed", true);
+            }
+        } else if (wifiClient.write(lanTxFrame, total) != total) {
+            lanLog("ERROR: LAN response write incomplete", true);
+        }
+        return;
+    }
+
+    // Oversized fallback: header then payload. A failure between the two leaves the
+    // peer waiting on a length prefix whose payload never arrives.
+    uint8_t hdr[2] = { (uint8_t)(len & 0xFF), (uint8_t)((len >> 8) & 0xFF) };
+    if (tlsMode) {
+        if (mbedtls_ssl_write(&tlsSsl, hdr, 2) < 0 ||
+            mbedtls_ssl_write(&tlsSsl, payload, len) < 0) {
+            lanLog("ERROR: TLS LAN response write failed", true);
+        }
+        return;
+    }
+    if (wifiClient.write(hdr, 2) != 2 || wifiClient.write(payload, len) != len) {
+        lanLog("ERROR: LAN response write incomplete", true);
+    }
+}
+
+bool wifiLanClientConnected(void) {
+    return wifiServerConnected && wifiClient.connected();
+}
 
 static void hex14_lower(const uint8_t* src, char* out29) {
     static const char* h = "0123456789abcdef";
@@ -70,53 +428,375 @@ void opendisplay_mdns_update_msd_txt(void) {
     MDNS.addServiceTxt("opendisplay", "tcp", "msd", static_cast<const char*>(hex));
 }
 
+// The advertised BLE address, lowercase colon-separated (SECTION 9 rule 6, key
+// `mac`). This is a genuinely new call: prior identity used getChipIdHex()
+// (eFuse), which is NOT what HA stores as the device unique_id. HARDWARE
+// VALIDATION REQUIRED: confirm NimBLEDevice::getAddress() == the advertised AdvA
+// HA sees (public vs static-random) on BOTH S3 and C6.
+static String advertisedBleMacLower(void) {
+    auto s = NimBLEDevice::getAddress().toString();
+    String out(s.c_str());
+    out.toLowerCase();
+    return out;
+}
+
 static void restartLanService(void) {
     String deviceName = "OD" + getChipIdHex();
     if (!MDNS.begin(deviceName.c_str())) {
-        od_log_error("ERROR: mDNS responder failed");
+        lanLog("ERROR: mDNS responder failed");
         return;
     }
-    od_log_info("mDNS: %s.local", deviceName.c_str());
-    MDNS.addService("opendisplay", "tcp", wifiServerPort);
-    od_log_info("mDNS: advertised _opendisplay._tcp port %u", wifiServerPort);
+    uint16_t port = lanActivePort();
+    lanLog("mDNS: " + deviceName + ".local");
+    MDNS.addService("opendisplay", "tcp", port);
+    // F1 -- identity/capability TXT keys (SECTION 9 rule 6, ADDITIVE to `msd`).
+    String mac = advertisedBleMacLower();
+    MDNS.addServiceTxt("opendisplay", "tcp", "mac", mac.c_str());        // REQUIRED
+    MDNS.addServiceTxt("opendisplay", "tcp", "tls", isEncryptionEnabled() ? "1" : "0"); // REQUIRED
+    // const char* overload (value) vs char* overload (key/value) — cast char[] to
+    // const char* to disambiguate, matching opendisplay_mdns_update_msd_txt().
+    char fw[12];
+    snprintf(fw, sizeof(fw), "%u.%u", (unsigned)getFirmwareMajor(), (unsigned)getFirmwareMinor());
+    MDNS.addServiceTxt("opendisplay", "tcp", "fw", static_cast<const char*>(fw));  // RECOMMENDED
+    char cm[3];
+    snprintf(cm, sizeof(cm), "%02x", (unsigned)globalConfig.system_config.communication_modes);
+    MDNS.addServiceTxt("opendisplay", "tcp", "cm", static_cast<const char*>(cm));  // RECOMMENDED
+    uint8_t did[4];
+    getAuthDeviceIdBytes(did);
+    char idhex[9];
+    snprintf(idhex, sizeof(idhex), "%02x%02x%02x%02x", did[0], did[1], did[2], did[3]);
+    MDNS.addServiceTxt("opendisplay", "tcp", "id", static_cast<const char*>(idhex));  // OPTIONAL
+    MDNS.addServiceTxt("opendisplay", "tcp", "pv", OD_PROTOCOL_VERSION_STR); // OPTIONAL
+    lanLog("mDNS: _opendisplay._tcp port " + String(port) +
+                " tls=" + (isEncryptionEnabled() ? "1" : "0") + " mac=" + mac);
     opendisplay_mdns_update_msd_txt();
 }
 
-void initWiFi(bool waitForConnection) {
-    od_log_info("=== Initializing WiFi ===");
+static void startLanServer(void) {
+    tlsMode = isEncryptionEnabled();
+    uint16_t port = lanActivePort();
+    wifiServer.begin(port);
+    lanLog(String(tlsMode ? "TLS-PSK" : "Plaintext") +
+                " LAN server listening on port " + String(port));
+    restartLanService();
+}
 
+// WiFi.status() collapses every association failure into WL_DISCONNECTED (6), which
+// is useless for field diagnosis. Log the 802.11/ESP reason code instead: 201
+// (NO_AP_FOUND) means the SSID was never seen -- typically a 5 GHz-only or hidden
+// network; 15 (4WAY_HANDSHAKE_TIMEOUT) / 202 (AUTH_FAIL) mean a bad password; 200
+// (BEACON_TIMEOUT) / 4 (ASSOC_EXPIRE) point at range or BLE coexistence.
+static bool wifiDiagEventsRegistered = false;
+
+// ------------------------------------------------------------------ roaming ---
+// Move to a stronger AP on the same SSID when the current link degrades. Two halves
+// that only work together:
+//
+//  (a) BEST-AP SELECTION. Arduino's default is scan_method = WIFI_FAST_SCAN, which
+//      stops at the FIRST SSID match and associates with it however weak; the
+//      sort_method it also defaults to (WIFI_CONNECT_AP_BY_SIGNAL) is INERT unless
+//      the scan is WIFI_ALL_CHANNEL_SCAN. So on a multi-AP SSID (mesh/extenders) the
+//      device can sit on a distant AP while a strong one exists on another channel,
+//      non-deterministically across reboots. Switching to ALL_CHANNEL_SCAN makes the
+//      RSSI sort actually apply, so every (re)connect picks the strongest AP.
+//      Cost: a full-channel scan per connect (~1.5-2.5 s vs ~0.3-0.5 s) -- radio-on
+//      time paid on each deep-sleep wake.
+//
+//  (b) THE TRIGGER. esp_wifi_set_rssi_threshold() posts WIFI_EVENT_STA_BSS_RSSI_LOW
+//      once the averaged RSSI drops below the threshold. It is ONE-SHOT (see the API
+//      note in esp_wifi.h) so it must be re-armed after every event and after every
+//      re-association. Arduino does not surface this event in arduino_event_id_t, so
+//      it needs a raw esp_event handler on WIFI_EVENT.
+//
+// Without (a), (b) is a footgun: a reconnect under FAST_SCAN can land on the SAME
+// weak AP, giving a pointless disconnect/reconnect loop. Do not enable one alone.
+//
+// The roam itself is DEFERRED to an idle moment (serviceLanRoam) because
+// re-association drops the TCP session and a full-channel scan steals the shared
+// radio from BLE under coex -- doing that mid-transfer would abort it.
+#ifndef OD_LAN_ROAM_RSSI_THRESHOLD
+#define OD_LAN_ROAM_RSSI_THRESHOLD (-75)   /* dBm; valid range -100..10 */
+#endif
+
+static bool roamPending = false;            // set by the RSSI-low event, cleared on roam
+static bool roamEventRegistered = false;
+
+// Event handlers run on tiny stacks (see EVENT-CONTEXT RULE below), so they only set
+// these and stash plain scalars; serviceWifiEventFollowUp() does the logging and the
+// esp_* calls on the loop task.
+static volatile bool assocNoticePending = false;
+static volatile bool disconnectNoticePending = false;
+static volatile bool gotIpPending = false;
+static volatile bool rssiLowNoticePending = false;
+static volatile bool cacheFailPending = false;
+static volatile int  s_lastAssocChannel = 0;
+static volatile int  s_lastDisconnectReason = 0;
+static volatile int  s_lastRssiLowDbm = 0;
+static volatile uint32_t s_lastGotIp = 0;
+
+// ------------------------------------------------------- RTC-cached AP choice ---
+// Deep sleep is a full reset, so without this every wake pays the all-channel scan
+// (~1.5-2.5 s of radio-on time) just to rediscover the AP it used seconds earlier.
+// Caching the winning BSSID + channel in RTC memory (which survives deep sleep) lets a
+// wake connect DIRECTLY to that BSSID on a single channel: no scan at all, faster than
+// even the old FAST_SCAN default, while still landing on the strongest AP because the
+// cache is only ever written from a scan-selected association.
+//
+// Kept file-local rather than in main.h (where the other RTC_DATA_ATTR state lives)
+// because nothing outside this translation unit uses it.
+//
+// Self-healing: any failure or degradation invalidates the cache and falls back to a
+// full scan -- see lanCacheInvalidate() callers. In particular a cached connect that
+// lands on a now-weak AP trips the RSSI threshold, which invalidates and rescans, so a
+// stale "best" choice cannot persist across days.
+RTC_DATA_ATTR static uint8_t s_cachedBssid[6];
+RTC_DATA_ATTR static uint8_t s_cachedChannel;   // 1..14; 0 = unset
+RTC_DATA_ATTR static bool    s_cachedValid;
+
+static bool usingCachedAp = false;      // this attempt used the cache (drives fallback)
+static bool rescanReconnectPending = false;  // cached BSSID failed; re-begin with a scan
+
+// Make every (re)connect choose the strongest AP for the SSID. Must be called
+// BEFORE WiFi.begin(); the setting is sticky for later auto-reconnects.
+static void lanApplyBestApSelection(void) {
+    WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);      // required for the sort below to apply
+    WiFi.setSortMethod(WIFI_CONNECT_AP_BY_SIGNAL);  // strongest RSSI wins
+}
+
+static void lanCacheInvalidate(const char* why) {
+    if (s_cachedValid) {
+        lanLog(String("WiFi: AP cache cleared (") + why + ") -- next connect will scan");
+    }
+    s_cachedValid = false;
+    s_cachedChannel = 0;
+}
+
+// Record the AP we actually associated with, so the next wake can go straight to it.
+static void lanCacheStoreCurrentAp(void) {
+    const uint8_t* b = WiFi.BSSID();
+    int32_t ch = WiFi.channel();
+    if (b == nullptr || ch < 1 || ch > 14) return;
+    memcpy(s_cachedBssid, b, 6);
+    s_cachedChannel = (uint8_t)ch;
+    s_cachedValid = true;
+}
+
+// Single entry point for association: cached BSSID when available, full scan otherwise.
+static void lanBeginConnect(void) {
+    if (s_cachedValid && s_cachedChannel >= 1 && s_cachedChannel <= 14) {
+        usingCachedAp = true;
+        char b[18];
+        snprintf(b, sizeof(b), "%02X:%02X:%02X:%02X:%02X:%02X",
+                 s_cachedBssid[0], s_cachedBssid[1], s_cachedBssid[2],
+                 s_cachedBssid[3], s_cachedBssid[4], s_cachedBssid[5]);
+        lanLog("WiFi: connecting to cached AP " + String(b) +
+                    " ch " + String((int)s_cachedChannel) + " (no scan)");
+        WiFi.begin(wifiSsid, wifiPassword, (int32_t)s_cachedChannel, s_cachedBssid);
+        return;
+    }
+    usingCachedAp = false;
+    lanLog("WiFi: scanning all channels for the strongest AP");
+    lanApplyBestApSelection();
+    WiFi.begin(wifiSsid, wifiPassword);
+}
+
+static void onWifiRssiLow(void* arg, esp_event_base_t base, int32_t id, void* data);
+
+// Register the raw WIFI_EVENT handler LAZILY, retrying until it takes.
+//
+// esp_event_handler_register() requires the default event loop, which Arduino creates
+// while starting the STA -- not before. Doing this pre-WiFi.begin() (where the Arduino
+// callback is registered) fails with ESP_ERR_INVALID_STATE and leaves roaming silently
+// dead, which is exactly what happened on hardware. Called from the association path,
+// by which point the loop and the WiFi task definitely exist; idempotent and self-
+// retrying so a transient failure does not permanently disable roaming.
+static void ensureRoamEventRegistered(void) {
+    if (roamEventRegistered) return;
+    esp_err_t rc = esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_STA_BSS_RSSI_LOW,
+                                              &onWifiRssiLow, NULL);
+    if (rc == ESP_OK) {
+        roamEventRegistered = true;
+        lanLog("WiFi: roaming armed (RSSI-low handler registered)");
+        return;
+    }
+    // Always report the code -- "could not register" with no reason is undiagnosable.
+    lanLog(String("WiFi: RSSI-low handler register failed (") + esp_err_to_name(rc) +
+                "); will retry on next association");
+}
+
+// One-shot: re-arm after every event and after every association.
+static void lanArmRssiThreshold(void) {
+    ensureRoamEventRegistered();   // no point arming a threshold nothing listens for
+    esp_err_t rc = esp_wifi_set_rssi_threshold(OD_LAN_ROAM_RSSI_THRESHOLD);
+    if (rc != ESP_OK) {
+        lanLog("WiFi: RSSI threshold arm failed (" + String((int)rc) + ")");
+    }
+}
+
+// EVENT-CONTEXT RULE (learned the hard way -- this handler previously panicked the
+// device): callbacks here run on tiny stacks -- the raw esp_event handler on the system
+// event task, and the Arduino callbacks on "arduino_events" with a 4096-byte stack
+// (ARDUINO_NETWORK_EVENT_TASK_STACK_SIZE). Arduino String concatenation plus
+// lanLog(String) BY VALUE, plus esp_wifi_*/esp_event_* calls, is far too much for
+// that budget. So handlers ONLY set flags; every String, log, and esp_* call happens in
+// serviceWifiEventFollowUp() on the loop task. Keep it that way.
+static void onWifiRssiLow(void* arg, esp_event_base_t base, int32_t id, void* data) {
+    (void)arg; (void)base; (void)id;
+    const wifi_event_bss_rssi_low_t* e = (const wifi_event_bss_rssi_low_t*)data;
+    s_lastRssiLowDbm = e ? (int)e->rssi : 0;   // plain int store; logged from loop()
+    roamPending = true;
+    rssiLowNoticePending = true;
+}
+
+// Flags only -- see the EVENT-CONTEXT RULE above. No String, no lanLog, no esp_*
+// calls: this runs on the 4096-byte "arduino_events" task.
+static void onWiFiDiagEvent(arduino_event_id_t event, arduino_event_info_t info) {
+    switch (event) {
+        case ARDUINO_EVENT_WIFI_STA_CONNECTED:
+            s_lastAssocChannel = (int)info.wifi_sta_connected.channel;
+            assocNoticePending = true;
+            break;
+        case ARDUINO_EVENT_WIFI_STA_DISCONNECTED:
+            s_lastDisconnectReason = (int)info.wifi_sta_disconnected.reason;
+            disconnectNoticePending = true;
+            // A BSSID-pinned begin() leaves bssid_set = 1 in the driver config, so the
+            // framework's auto-reconnect would retry that ONE AP forever -- fatal if it
+            // moved, changed channel, or powered off. Ask the loop to drop the cache and
+            // re-begin WITHOUT a BSSID, which both clears bssid_set and rescans.
+            if (usingCachedAp) {
+                usingCachedAp = false;
+                cacheFailPending = true;      // loop() invalidates + logs
+                rescanReconnectPending = true;
+            }
+            break;
+        case ARDUINO_EVENT_WIFI_STA_GOT_IP:
+            s_lastGotIp = info.got_ip.ip_info.ip.addr;
+            rescanReconnectPending = false;
+            gotIpPending = true;              // loop() logs RSSI/ch/BSSID, caches, arms
+            break;
+        default:
+            break;
+    }
+}
+
+static void registerWiFiDiagEvents(void) {
+    if (wifiDiagEventsRegistered) return;
+    WiFi.onEvent(onWiFiDiagEvent);
+    wifiDiagEventsRegistered = true;
+    // The raw WIFI_EVENT handler is NOT registered here: this runs before WiFi.begin(),
+    // and esp_event_handler_register() needs the default event loop, which Arduino only
+    // creates while bringing the STA up. Registering here fails with ESP_ERR_INVALID_STATE
+    // and silently disabled roaming. It is now done lazily -- see ensureRoamEventRegistered().
+}
+
+// Execute a queued roam, but only when nothing is in flight. Called from
+// handleWiFiServer() each tick.
+// Everything the event handlers deferred, run on the loop task where the stack is ample.
+// Called from handleWiFiServer() each tick.
+static void serviceWifiEventFollowUp(void) {
+    if (assocNoticePending) {
+        assocNoticePending = false;
+        lanLog("WiFi event: associated (channel " + String((int)s_lastAssocChannel) + ")");
+    }
+    if (disconnectNoticePending) {
+        disconnectNoticePending = false;
+        lanLog("WiFi event: disconnected, reason " + String((int)s_lastDisconnectReason));
+    }
+    if (cacheFailPending) {
+        cacheFailPending = false;
+        lanCacheInvalidate("cached BSSID did not associate");
+    }
+    if (rssiLowNoticePending) {
+        rssiLowNoticePending = false;
+        lanLog("WiFi: RSSI " + String((int)s_lastRssiLowDbm) + " dBm below " +
+                    String(OD_LAN_ROAM_RSSI_THRESHOLD) + " dBm -- roam queued (deferred to idle)");
+        lanArmRssiThreshold();   // one-shot: re-arm so a deferred roam still re-triggers
+    }
+    if (gotIpPending) {
+        gotIpPending = false;
+        lanLog("WiFi event: got IP " + IPAddress((uint32_t)s_lastGotIp).toString() +
+                    ", RSSI " + String(WiFi.RSSI()) + " dBm, ch " + String(WiFi.channel()) +
+                    ", BSSID " + WiFi.BSSIDstr());
+        lanCacheStoreCurrentAp();   // remember this AP for the next deep-sleep wake
+        lanArmRssiThreshold();      // also (re)registers the RSSI-low handler
+    }
+}
+
+void serviceLanRoam(void) {
+    serviceWifiEventFollowUp();
+    // A cached BSSID that failed to associate (AP moved, changed channel, or powered
+    // off). Re-begin WITHOUT a BSSID from loop context -- never from the event callback --
+    // so the driver's bssid_set is cleared and a full scan picks a live AP.
+    if (rescanReconnectPending && !wifiConnected) {
+        rescanReconnectPending = false;
+        lanLog("WiFi: cached AP unreachable -- falling back to a full scan");
+        WiFi.disconnect(false);
+        lanBeginConnect();   // cache was invalidated on the disconnect -> scan path
+        return;
+    }
+    if (!roamPending || !wifiConnected) return;
+    // A LAN client implies a possible in-flight transfer; BLE transfers would also be
+    // disrupted by a full-channel scan under coex. Wait for genuine idle.
+    if (wifiClient.connected() || wifiServerConnected) return;
+    if (directWriteActive || pipeWriteActive()) return;
+
+    roamPending = false;
+    lanLog("WiFi: roaming -- re-associating to the strongest AP for this SSID");
+    // MUST drop the cache first: the whole point of a roam is to leave this AP, and
+    // lanBeginConnect() would otherwise pin us straight back to the one we are escaping.
+    lanCacheInvalidate("roaming to a stronger AP");
+    usingCachedAp = false;
+    rescanReconnectPending = false;
+    // Clearing wifiConnected lets handleWiFiServer()'s existing re-association path
+    // restart the LAN server once the new link is up.
+    wifiConnected = false;
+    WiFi.disconnect(false);
+    lanBeginConnect();   // cache now invalid -> full scan, strongest AP wins
+}
+
+void initWiFi(bool waitForConnection) {
+    lanLog("=== Initializing WiFi ===");
+
+    // WiFi is NOT gated on power_mode: if COMM_MODE_WIFI is enabled the radio comes
+    // up on battery too. Radio cost on battery is managed by WIFI_PS_MIN_MODEM
+    // (below) and by deep sleep, not by refusing to associate.
     if (!(globalConfig.system_config.communication_modes & COMM_MODE_WIFI)) {
-        od_log_info("WiFi not enabled in communication_modes, skipping");
+        lanLog("WiFi not enabled in communication_modes, skipping");
         wifiInitialized = false;
         return;
     }
     if (!wifiConfigured) {
-        od_log_warn("WiFi: system_config has WiFi mode on, but wifi_config TLV (0x26) is not in saved "
+        lanLog("WiFi: system_config has WiFi mode on, but wifi_config TLV (0x26) is not in saved "
                     "configuration (or failed to parse). Enable Wi-Fi in config, set SSID, and write full "
                     "config to the device.");
         wifiInitialized = false;
         return;
     }
     if (wifiSsid[0] == '\0' || strlen(wifiSsid) == 0) {
-        od_log_warn("WiFi: wifi_config packet present but SSID field is empty.");
+        lanLog("WiFi: wifi_config packet present but SSID field is empty.");
         wifiInitialized = false;
         return;
     }
-    od_log_info("SSID: \"%s\"", wifiSsid);
+    // Do not log the SSID or password (credentials); log only presence/length.
+    lanLog("WiFi: connecting to configured SSID (len " + String(strlen(wifiSsid)) + ")");
+    registerWiFiDiagEvents();
     WiFi.setAutoReconnect(true);
-    WiFi.setTxPower(WIFI_POWER_15dBm);
     wifiSsid[32] = '\0';
     wifiPassword[32] = '\0';
-    od_log_info("Encryption type: 0x%02X", wifiEncryptionType);
+    lanLog("Encryption type: 0x" + String(wifiEncryptionType, HEX));
     wifiConnected = false;
     wifiInitialized = true;
-    WiFi.begin(wifiSsid, wifiPassword);
+    // Cached BSSID when RTC memory still holds one (the deep-sleep-wake fast path:
+    // single channel, no scan), otherwise an all-channel scan for the strongest AP.
+    lanBeginConnect();
+    // Tx power can only be set once the STA is started, i.e. after begin(); the
+    // pre-begin() call this replaces failed with ESP_ERR_WIFI_NOT_START.
     WiFi.setTxPower(WIFI_POWER_15dBm);
     if (!waitForConnection) {
-        od_log_info("WiFi: STA started (non-blocking; LAN starts when associated)");
+        lanLog("WiFi: STA started (non-blocking; LAN starts when associated)");
         return;
     }
-    od_log_info("Waiting for WiFi connection...");
+    lanLog("Waiting for WiFi connection...");
     const int maxRetries = 3;
     const unsigned long timeoutPerRetry = 10000;
     bool connected = false;
@@ -126,9 +806,9 @@ void initWiFi(bool waitForConnection) {
         while (WiFi.status() != WL_CONNECTED && (millis() - startAttempt < timeoutPerRetry)) {
             delay(500);
             wl_status_t status = WiFi.status();
-            od_log_debug("WiFi status: %d", status);
+            lanLog("WiFi status: " + String(status));
             if (status == WL_CONNECT_FAILED || status == WL_NO_SSID_AVAIL) {
-                od_log_warn("Connection failed immediately (Status: %d)", status);
+                lanLog("Connection failed immediately (Status: " + String(status) + ")");
                 abortCurrentRetry = true;
                 break;
             }
@@ -138,7 +818,7 @@ void initWiFi(bool waitForConnection) {
             break;
         }
         if (!abortCurrentRetry) {
-            od_log_warn("WiFi attempt %d timed out", retry + 1);
+            lanLog("WiFi attempt " + String(retry + 1) + " timed out");
         }
         if (retry < maxRetries - 1) {
             delay(2000);
@@ -146,41 +826,95 @@ void initWiFi(bool waitForConnection) {
     }
     if (WiFi.status() == WL_CONNECTED) {
         wifiConnected = true;
-        od_log_info("=== WiFi connected ===");
-        String ip = WiFi.localIP().toString();
-        od_log_info("IP: %s", ip.c_str());
-        wifiServer.begin(wifiServerPort);
-        od_log_info("TCP server listening on port %u", wifiServerPort);
-        restartLanService();
+        lanLog("=== WiFi connected ===");
+        lanLog("IP: " + WiFi.localIP().toString());
+        esp_wifi_set_ps(WIFI_PS_MIN_MODEM);  // F5: modem sleep between beacons
+        startLanServer();
     } else {
         wifiConnected = false;
-        od_log_warn("=== WiFi connection failed ===");
+        lanLog("=== WiFi connection failed ===");
     }
 }
 
 void disconnectWiFiServer() {
+    tlsCloseSession();
     if (wifiClient.connected()) {
-        od_log_info("Closing LAN client");
+        lanLog("Closing LAN client");
         clearEncryptionSession();
         wifiClient.stop();
     }
     wifiServerConnected = false;
     tcpReceiveBufferPos = 0;
+    // The client is gone, so any transfer it owned is dead. Restore here rather than
+    // relying on the deferred cleanup below: serviceBleDisconnectCleanup() skips
+    // teardown while an EPD refresh is in flight or when the other transport still
+    // owns the session, either of which would leave the radio stuck at full power.
+    lanPowerSaveRestore();
+    // F4: abort any in-flight direct-write / pipe / partial transfer + tear down a
+    // mid-transfer panel session, DEFERRED to loop() (serviceBleDisconnectCleanup)
+    // so cleanup never races an in-progress EPD refresh. Reuses the BLE path's flag.
+    bleDisconnectCleanupPending = true;
+}
+
+// lanReadIntoBuffer() return codes. A graceful peer close is deliberately distinct from
+// a fault: both end the session, but only one is worth an ERROR in the log.
+#define OD_LAN_READ_ERROR   (-1)
+#define OD_LAN_READ_CLOSED  (-2)
+static int s_lastLanReadErr = 0;   // mbedTLS ret for the last OD_LAN_READ_ERROR
+
+// Drain readable bytes from the active channel into tcpReceiveBuffer. Returns the number
+// of bytes appended (>=0), OD_LAN_READ_CLOSED on a graceful peer close, or
+// OD_LAN_READ_ERROR on a fatal channel error (caller drops in both cases).
+static int lanReadIntoBuffer(void) {
+    int space = (int)sizeof(tcpReceiveBuffer) - (int)tcpReceiveBufferPos;
+    if (space <= 0) {
+        lanLog("LAN RX buffer full, dropping connection");
+        return -1;
+    }
+    if (tlsMode) {
+        int r = mbedtls_ssl_read(&tlsSsl, &tcpReceiveBuffer[tcpReceiveBufferPos], (size_t)space);
+        if (r == MBEDTLS_ERR_SSL_WANT_READ || r == MBEDTLS_ERR_SSL_WANT_WRITE) return 0;
+        // A GRACEFUL close is not a fault. The client sends close_notify right after its
+        // last frame (e.g. the 0x0073 ack at the end of a push), so every successful
+        // transfer used to end with "channel read error" -- alarming and wrong. Separate
+        // it from a real failure so the log distinguishes "done" from "broken".
+        if (r == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY || r == 0) return OD_LAN_READ_CLOSED;
+        if (r < 0) {
+            s_lastLanReadErr = r;      // carried out so the caller can name the code
+            return OD_LAN_READ_ERROR;
+        }
+        tcpReceiveBufferPos += (uint32_t)r;
+        return r;
+    }
+    int available = wifiClient.available();
+    if (available <= 0) return 0;
+    int bytesToRead = (available > space) ? space : available;
+    int bytesRead = wifiClient.read(&tcpReceiveBuffer[tcpReceiveBufferPos], bytesToRead);
+    if (bytesRead > 0) tcpReceiveBufferPos += (uint32_t)bytesRead;
+    return (bytesRead > 0) ? bytesRead : 0;
 }
 
 void handleWiFiServer() {
+    // Execute a queued roam (RSSI dropped below OD_LAN_ROAM_RSSI_THRESHOLD) before any
+    // other work; it self-gates on idle, so this is a no-op mid-transfer.
+    serviceLanRoam();
+
     if (wifiInitialized && WiFi.status() == WL_CONNECTED && !wifiConnected) {
         wifiConnected = true;
-        od_log_info("=== WiFi connected ===");
-        String ip = WiFi.localIP().toString();
-        od_log_info("IP: %s", ip.c_str());
-        wifiServer.begin(wifiServerPort);
-        od_log_info("TCP server listening on port %u", wifiServerPort);
-        restartLanService();
+        lanLog("=== WiFi connected ===");
+        lanLog("IP: " + WiFi.localIP().toString() +
+                    ", RSSI " + String(WiFi.RSSI()) + " dBm, ch " + String(WiFi.channel()) +
+                    ", BSSID " + WiFi.BSSIDstr());
+        // Re-association: any transfer that suspended power save died with the old
+        // link, so clear the flag here rather than leaving it stuck across the
+        // reconnect (the teardown funnels may not run if the client vanished).
+        lanPowerSaveRestore();
+        esp_wifi_set_ps(WIFI_PS_MIN_MODEM);
+        startLanServer();
     }
     if (!wifiConnected || WiFi.status() != WL_CONNECTED) {
         if (wifiServerConnected || wifiClient.connected()) {
-            od_log_warn("WiFi lost, closing LAN session");
+            lanLog("WiFi lost, closing LAN session");
             disconnectWiFiServer();
         }
         return;
@@ -189,64 +923,122 @@ void handleWiFiServer() {
     WiFiClient incoming = wifiServer.accept();
     if (incoming) {
         if (wifiClient.connected()) {
-            od_log_info("LAN: new client, replacing previous");
+            lanLog("LAN: new client, replacing previous");
+            tlsCloseSession();
             clearEncryptionSession();
             wifiClient.stop();
         }
         wifiClient = incoming;
+        // TCP_NODELAY: every LAN write is a complete, self-delimited frame, so there
+        // is never a following write for Nagle to coalesce it with -- it can only
+        // hold a small frame until the peer's delayed ACK fires (40-200 ms). With
+        // per-chunk direct-write ACKs that lands on every frame of a transfer.
+        wifiClient.setNoDelay(true);
         wifiClient.setTimeout(30000);
         tcpReceiveBufferPos = 0;
         wifiServerConnected = true;
-        String remoteIp = wifiClient.remoteIP().toString();
-        od_log_info("LAN client connected from %s", remoteIp.c_str());
+        lastLanActivityMs = millis();
+        lanLog("LAN client connected from " + wifiClient.remoteIP().toString());
+        if (tlsMode) {
+            if (!tlsBeginSession()) {
+                lanLog("LAN: TLS session start failed, dropping");
+                disconnectWiFiServer();
+                return;
+            }
+        }
     }
 
     if (!wifiServerConnected || !wifiClient.connected()) {
         if (wifiServerConnected) {
-            od_log_info("LAN client disconnected");
-            clearEncryptionSession();
-            wifiServerConnected = false;
-            tcpReceiveBufferPos = 0;
+            lanLog("LAN client disconnected");
+            disconnectWiFiServer();
         }
         return;
     }
 
-    int available = wifiClient.available();
-    if (available <= 0) {
-        return;
-    }
-    int bytesToRead = available;
-    if (tcpReceiveBufferPos + bytesToRead > (int)sizeof(tcpReceiveBuffer)) {
-        bytesToRead = (int)sizeof(tcpReceiveBuffer) - (int)tcpReceiveBufferPos;
-    }
-    if (bytesToRead <= 0) {
-        od_log_warn("LAN RX buffer full, dropping connection");
-        disconnectWiFiServer();
-        return;
-    }
-    int bytesRead = wifiClient.read(&tcpReceiveBuffer[tcpReceiveBufferPos], bytesToRead);
-    if (bytesRead > 0) {
-        tcpReceiveBufferPos += (uint32_t)bytesRead;
-    }
-
-    while (tcpReceiveBufferPos >= 2) {
-        uint16_t flen = (uint16_t)(tcpReceiveBuffer[0] | (tcpReceiveBuffer[1] << 8));
-        if (flen == 0 || flen > WIFI_LAN_MAX_PAYLOAD) {
-            od_log_warn("LAN: invalid frame length, closing");
+    // Drive the TLS handshake incrementally; return until it completes.
+    if (tlsMode && tlsSessionActive && !tlsHandshakeDone) {
+        int hs = mbedtls_ssl_handshake(&tlsSsl);
+        if (hs == 0) {
+            tlsHandshakeDone = true;
+            lastLanActivityMs = millis();
+            lanLog("LAN: TLS handshake complete");
+        } else if (hs == MBEDTLS_ERR_SSL_WANT_READ || hs == MBEDTLS_ERR_SSL_WANT_WRITE) {
+            // still handshaking; but honor the idle timeout below
+        } else {
+            // The handshake struct is another internal-DRAM allocation, so annotate the
+            // heap here too -- an OOM mid-handshake looks like a protocol error otherwise.
+            lanLog("LAN: TLS handshake failed" + tlsFailNote(hs) + ", dropping");
             disconnectWiFiServer();
             return;
         }
-        if (tcpReceiveBufferPos < (uint32_t)(2 + flen)) {
-            break;
-        }
-        imageDataWritten(NULL, NULL, tcpReceiveBuffer + 2, flen);
-        uint32_t consumed = 2u + (uint32_t)flen;
-        uint32_t rem = tcpReceiveBufferPos - consumed;
-        if (rem > 0) {
-            memmove(tcpReceiveBuffer, tcpReceiveBuffer + consumed, rem);
-        }
-        tcpReceiveBufferPos = rem;
     }
+
+    // Bounded drain: keep reading and dispatching until the channel is dry or a
+    // per-tick byte budget (one full tcpReceiveBuffer) is spent. Parsing INSIDE
+    // the loop frees buffer space before the next read -- essential on TLS, where
+    // one mbedtls_ssl_read can return a whole max-size record. The budget bounds
+    // LAN's hold on loop() so BLE drain, buttons/touch/buzzer, and the deep-sleep
+    // gate still run under a saturating streaming client.
+    uint32_t drainedBytes = 0;
+    int got;
+    do {
+        got = lanReadIntoBuffer();
+        if (got == OD_LAN_READ_CLOSED) {
+            // Normal end of a push: the client finished and sent close_notify.
+            lanLog("LAN: client closed the connection");
+            disconnectWiFiServer();
+            return;
+        }
+        if (got < 0) {
+            // Real fault -- name the mbedTLS code, otherwise this is undiagnosable.
+            lanLog("LAN: channel read error" + tlsFailNote(s_lastLanReadErr) + ", dropping");
+            disconnectWiFiServer();
+            return;
+        }
+        if (got > 0) {
+            lastLanActivityMs = millis();
+            drainedBytes += (uint32_t)got;
+        } else if (drainedBytes == 0) {
+            // No traffic at all this tick: drop only after OD_LAN_READ_TIMEOUT_S
+            // of silence (persistent client is otherwise kept). Any valid frame
+            // below resets the timer.
+            if ((millis() - lastLanActivityMs) > (uint32_t)OD_LAN_READ_TIMEOUT_S * 1000UL) {
+                lanLog("LAN: idle timeout, dropping client");
+                disconnectWiFiServer();
+            }
+            return;
+        }
+
+        while (tcpReceiveBufferPos >= 2) {
+            uint16_t flen = (uint16_t)(tcpReceiveBuffer[0] | (tcpReceiveBuffer[1] << 8));
+            if (flen == 0 || flen > OD_LAN_MAX_PAYLOAD) {
+                lanLog("LAN: invalid frame length, closing");
+                disconnectWiFiServer();
+                return;
+            }
+            if (tcpReceiveBufferPos < (uint32_t)(2 + flen)) {
+                break;
+            }
+            // F4: tag the frame's origin so the dispatcher bypasses app-layer CCM on
+            // TLS (already-secure) and routes the response back over LAN only.
+            g_commandOrigin = tlsMode ? ORIGIN_LAN_TLS : ORIGIN_LAN_PLAIN;
+            lastLanActivityMs = millis();
+            imageDataWritten(NULL, NULL, tcpReceiveBuffer + 2, flen);
+            g_commandOrigin = ORIGIN_BLE;   // restore default for any subsequent BLE drain
+            uint32_t consumed = 2u + (uint32_t)flen;
+            uint32_t rem = tcpReceiveBufferPos - consumed;
+            if (rem > 0) {
+                memmove(tcpReceiveBuffer, tcpReceiveBuffer + consumed, rem);
+            }
+            tcpReceiveBufferPos = rem;
+        }
+        // A dispatched command may have torn the session down (reboot, power-off,
+        // config-driven LAN restart). Never read from a dead client.
+        if (!wifiServerConnected || !wifiClient.connected()) {
+            return;
+        }
+    } while (got > 0 && drainedBytes < sizeof(tcpReceiveBuffer));
 }
 
 void restartWiFiLanAfterReconnect() {
@@ -254,9 +1046,28 @@ void restartWiFiLanAfterReconnect() {
         return;
     }
     disconnectWiFiServer();
-    wifiServer.begin(wifiServerPort);
-    od_log_info("TCP server restarted on port %u", wifiServerPort);
-    restartLanService();
+    startLanServer();
 }
 
-#endif
+// F5 -- reboot teardown: drop the LAN client + TLS context, stop the TCP server,
+// and disconnect WiFi so esp_restart() does not leave the radio/socket half-up.
+// Extends PR #114's BLE-only teardown (device_control.cpp) to the WiFi surface.
+void opendisplay_lan_teardown(void) {
+    tlsCloseSession();
+    if (wifiClient.connected()) {
+        wifiClient.stop();
+    }
+    wifiServer.end();
+    wifiServerConnected = false;
+    tcpReceiveBufferPos = 0;
+    if (tlsInited) {
+        mbedtls_ssl_config_free(&tlsConf);
+        mbedtls_ctr_drbg_free(&tlsDrbg);
+        mbedtls_entropy_free(&tlsEntropy);
+        tlsInited = false;
+    }
+    WiFi.disconnect(true);
+    lanLog("LAN/WiFi torn down before restart", true);
+}
+
+#endif  // OPENDISPLAY_HAS_WIFI

--- a/src/wifi_service.cpp
+++ b/src/wifi_service.cpp
@@ -66,10 +66,9 @@ static void lanLog(const String& message, bool newLine = true) {
 extern volatile uint8_t g_commandOrigin;
 
 // Roam gating: never re-associate (or full-channel scan, which steals the shared radio
-// from BLE under coex) while a transfer is in flight. directWriteActive is in main.h;
-// pipeWriteActive() is declared in display_service.h.
-extern bool directWriteActive;
-bool pipeWriteActive(void);
+// from BLE under coex) while a transfer is in flight. transferActive() covers all three
+// transfer types and is declared in display_service.h.
+bool transferActive(void);
 
 String getChipIdHex();
 static void lanBeginConnect(void);   // defined with the roaming / RTC AP-cache block below
@@ -696,9 +695,12 @@ void serviceLanRoam(void) {
     }
     if (!roamPending || !wifiConnected) return;
     // A LAN client implies a possible in-flight transfer; BLE transfers would also be
-    // disrupted by a full-channel scan under coex. Wait for genuine idle.
+    // disrupted by a full-channel scan under coex. Wait for genuine idle. transferActive()
+    // covers DIRECT/PIPE/PARTIAL -- the previous direct+pipe test let a BLE-origin partial
+    // write (no LAN client attached, so the check above does not fire either) be
+    // interrupted by the scan.
     if (wifiClient.connected() || wifiServerConnected) return;
-    if (directWriteActive || pipeWriteActive()) return;
+    if (transferActive()) return;
 
     roamPending = false;
     lanLog("WiFi: roaming -- re-associating to the strongest AP for this SSID");

--- a/src/wifi_service.h
+++ b/src/wifi_service.h
@@ -49,16 +49,12 @@ bool wifiLanClientConnected(void);
 uint16_t lanActivePort(void);
 /// True when the LAN channel is TLS-PSK rather than plaintext (= isEncryptionEnabled()).
 bool lanTlsEnabled(void);
-/// Drop to WIFI_PS_NONE for the duration of a LAN-origin streaming transfer.
-/// Modem sleep only guarantees the radio listens at each DTIM beacon, so the
-/// per-chunk ack ladder of a direct/partial write can stall up to DTIM x 102.4 ms
-/// on every inbound frame. Idempotent; no-op when WiFi is down or already suspended.
-void lanPowerSaveSuspend(void);
-/// Restore WIFI_PS_MIN_MODEM. Idempotent; no-op when not suspended. Called from the
-/// transfer teardown funnels, so it must tolerate being invoked when no transfer ran.
-void lanPowerSaveRestore(void);
-/// True while power save is suspended for a transfer (for the loop() safety net).
-bool lanPowerSaveSuspended(void);
+// NOTE: this firmware deliberately never calls esp_wifi_set_ps(). WiFi and BLE share
+// one radio with software coex compiled in, and the coex arbiter needs WiFi's
+// modem-sleep windows to time-share the antenna with the always-on BLE advertiser.
+// Forcing WIFI_PS_NONE for a transfer was measured on hardware (2026-07-23) to
+// collapse throughput in both directions; the DTIM ack-ladder stall it was chasing
+// was negligible. The driver default is left untouched.
 
 #endif
 

--- a/src/wifi_service.h
+++ b/src/wifi_service.h
@@ -1,14 +1,64 @@
 #ifndef WIFI_SERVICE_H
 #define WIFI_SERVICE_H
 
-#ifdef TARGET_ESP32
+#include <stdint.h>
+
+// OPENDISPLAY_HAS_WIFI gates the entire WiFi/LAN transport surface (mDNS, TCP
+// server, TLS-PSK listener, RX reassembly buffer, LAN response framing). It is
+// defined only on ESP32 targets built with -DOPENDISPLAY_ENABLE_WIFI, which is
+// applied to the S3, C6, and C3 platformio envs. The classic esp32-N4 builds
+// without it, so it does not compile the WiFi surface and reclaims the 8 KB RX
+// buffer + WiFiServer/WiFiClient RAM. Call sites in main.cpp /
+// communication.cpp / display_service.cpp are #ifdef-guarded on this macro.
+#if defined(TARGET_ESP32) && defined(OPENDISPLAY_ENABLE_WIFI)
+#define OPENDISPLAY_HAS_WIFI 1
+#endif
+
+#ifdef OPENDISPLAY_HAS_WIFI
+
+// Reserve mbedTLS's two ~16.7 KB record buffers while the heap is still contiguous, and
+// route mbedTLS allocations through them. MUST be called early in setup() -- after
+// full_config_init() (it needs securityConfig to know whether TLS is used) and before
+// ble_init()/initWiFi() take their ~100 KB. No-op when encryption is disabled, and
+// idempotent. Without it, ssl_setup() intermittently fails with -0x7f00 even with ~50 KB
+// free, because the two buffers need contiguous internal DRAM.
+void od_tls_reserve_records(void);
 
 void initWiFi(bool waitForConnection = true);
 void disconnectWiFiServer();
 void handleWiFiServer();
+
+// Re-associate to the strongest AP for the configured SSID after the link degrades
+// past OD_LAN_ROAM_RSSI_THRESHOLD (-75 dBm default). Self-gating: does nothing unless a
+// roam is queued AND no LAN client / direct-write / pipe transfer is in flight, since
+// re-association drops the TCP session and the full-channel scan steals the shared radio
+// from BLE under coex. Called from handleWiFiServer() each tick.
+void serviceLanRoam(void);
 void restartWiFiLanAfterReconnect();
 /// Publish MSD (bytes after company ID) as mDNS TXT key ``msd`` (28 hex chars). No-op if Wi-Fi down.
 void opendisplay_mdns_update_msd_txt(void);
+/// Tear down the LAN session, TLS context, TCP server, and WiFi before a reboot.
+void opendisplay_lan_teardown(void);
+/// Frame [len:2 LE][payload] and write it over the ACTIVE LAN channel (TLS or
+/// plaintext). Used by communication.cpp to route LAN-origin responses.
+void opendisplay_lan_send_frame(const uint8_t* payload, uint16_t len);
+/// True while a LAN client is connected (plaintext or TLS).
+bool wifiLanClientConnected(void);
+/// Port the LAN listener binds: WifiConfig.server_port (or OD_LAN_TCP_PORT when 0),
+/// +1 when the TLS-PSK channel is active. Derived, never configured directly.
+uint16_t lanActivePort(void);
+/// True when the LAN channel is TLS-PSK rather than plaintext (= isEncryptionEnabled()).
+bool lanTlsEnabled(void);
+/// Drop to WIFI_PS_NONE for the duration of a LAN-origin streaming transfer.
+/// Modem sleep only guarantees the radio listens at each DTIM beacon, so the
+/// per-chunk ack ladder of a direct/partial write can stall up to DTIM x 102.4 ms
+/// on every inbound frame. Idempotent; no-op when WiFi is down or already suspended.
+void lanPowerSaveSuspend(void);
+/// Restore WIFI_PS_MIN_MODEM. Idempotent; no-op when not suspended. Called from the
+/// transfer teardown funnels, so it must tolerate being invoked when no transfer ran.
+void lanPowerSaveRestore(void);
+/// True while power save is suspended for a transfer (for the loop() safety net).
+bool lanPowerSaveSuspended(void);
 
 #endif
 


### PR DESCRIPTION
Ports the WiFi/LAN transport and the ROM-tinfl inflate path onto current `main`, plus the build and cleanup work that came out of getting it green.

Five commits, each self-contained — happy to split the build/refactor ones into separate PRs if you'd rather review the feature alone.

## `2f38224` — WiFi/LAN transport + tinfl inflate

Squashed replay of a 31-commit branch. A commit-by-commit rebase wasn't viable: `#120` (Seeed GFX → FastEPD) and `#121` (`writeSerial` → `od_log_*`) touch the same files, so every intermediate commit conflicted on the same renames and none would have compiled.

- **LAN transport** — mDNS identity TXT, port/mode selection, TLS-PSK listener, command-origin routing with CCM bypass on TLS, per-transport session ownership, Nagle off, drain-to-dry RX with single compaction.
- **WiFi** — strongest-AP selection with RTC-cached BSSID, roaming at −75 dBm, all work moved out of the event callbacks (fixes a panic — handlers ran `String` concatenation on a 4 KB stack), lazy RSSI-low handler registration.
- **TLS** — both mbedTLS record buffers pre-reserved at boot while internal DRAM is still contiguous. `ssl_setup` was failing in the field at 51 KB free / 31.7 KB largest block, because it needs two ~16.7 KB *contiguous* internal-DRAM blocks and cycles 33 KB per connection.
- **Inflate** — compressed transfers routed through ROM tinfl, LZ dict sized to the actual DEFLATE window.

Conflict resolutions kept your `od_log_*` form while preserving this branch's content: transport tag and pre-enqueue `[Q:n]` depth on the TX line, backlog-only queue logging, compression mode/ratio on DW start/complete, and SSID/password redaction in the config dump. `setConfigLoggingQuiet()`/`cfgInfo()` were dropped — they existed to skip the config dump in the deep-sleep wake window, which the compile-time `OD_LOG_LEVEL` default (INFO) now does by eliding every `od_log_debug`.

**Note:** the vendored `include/opendisplay_protocol.h` resolved to `main`'s copy, which is newer than the canonical one in `opendisplay-protocol` (upstream added the 0x43 version-response docs). That repo needs a `--pull`, or the next `--push` reverts them.

## `2645c43` — pin pioarduino `55.03.39`, make the C6 mempool script non-fatal

Moves the pin from `55.03.32` **forward** to `55.03.39` (Arduino 3.3.9 / IDF 5.5.4). This restores the platform's own merged-image post-build action — `firmware.factory.bin` next to `firmware.bin`, flashable at offset 0. That action doesn't exist in `55.03.32`, so local merged images disappeared when the floating `stable` URL was pinned back in `0d95b37`.

**Deliberately not `55.03.311`**, which is what `stable` currently serves. IDF 5.5.5 drops the `r_` prefix on the C6 BLE controller's mempool exports and moves them from `libble_app.a` to `libbt.a` (`r_os_mempool_init` → `os_mempool_init`, likewise `os_memblock_get`/`_put`). NimBLE-Arduino 2.5.0 — latest release, 2026-04-02 — still calls the `r_` names, so `esp32-c6-N4` fails to link there. No library-side fix exists; it has to land upstream in NimBLE-Arduino. Only C6 is affected: it alone ships a precompiled controller blob carrying its own NimBLE porting layer (`CONFIG_BT_LE_CONTROLLER_NPL_OS_PORTING_SUPPORT=y`). Full analysis in `docs/FINDINGS_C6_NIMBLE_IDF555_MEMPOOL_ABI_2026-07-25.md`, and the constraint is recorded in `platformio.ini` and `CLAUDE.md` so the next bump doesn't walk into it.

`esp32c6_nimble_mempool_link.py` now warns and skips on every failure path instead of `sys.exit(1)`. On `55.03.311` the hard exit aborted with `no entry os_mempool.c.o in archive`, hiding the real cause behind a missing-member error; skipping lets the link proceed and report the genuine `undefined reference to r_os_mempool_init`.

Measured across three platform versions, all eleven envs:

| Platform | C6 without script | C6 with script | Other 10 |
|---|---|---|---|
| 55.03.32 | links | links (no-op, +28 B) | OK |
| **55.03.39** | links | links (no-op, +148 B) | OK |
| 55.03.311 | link fails | link fails | OK |

## `47432e0` — `esp32-s3-N16R8-extuart-debug` env

`OD_LOG_LEVEL` defaults to INFO, which compiles away every `od_log_debug()` — and that's where the config dump, BLE RX/TX hex with `[BLE][Q:n]` depth, and DIRECT_WRITE throughput live. Adds a variant env via `extends` (same pattern as `esp32-s3-E1004`) rather than a flag on the shipping one. Costs 12,392 bytes flash, no extra RAM. CI and `release.yml` enumerate envs explicitly, so neither picks it up.

## `799f324` — delete the WiFi power-save scaffolding

The transfer-scoped `WIFI_PS_NONE` experiment was already gutted after hardware measurement showed it collapses throughput under BLE coex. What remained was a subsystem that couldn't do anything: `lanPsSuspended` was never assigned `true` anywhere, so `lanPowerSaveSuspend()` was an empty body, `lanPowerSaveRestore()` early-returned before touching the radio, and `lanPowerSaveSuspended()` was a constant `false` — yet eight call sites and an 18-line `loop()` safety net with its own timer and warning log still guarded it, and the header advertised the original semantics with no hint the functions were inert.

Also drops the two `esp_wifi_set_ps(WIFI_PS_MIN_MODEM)` calls, so the firmware never sets power-save mode at all. **MIN_MODEM is the driver default and exactly what those calls set, so runtime behaviour should be unchanged** — flagging it explicitly since that's an assumption about the IDF default rather than something measured. A note in `wifi_service.h` records *why* nothing calls `esp_wifi_set_ps()`, so "force PS_NONE during transfers" doesn't read like an untried optimisation.

Separately: the two `DW complete: … KB/s` lines move from `od_log_debug` to `od_log_info`, so upload throughput is visible in a normal build.

## `d785ac0` — `transferActive()`

Three flags mark an in-flight transfer — `directWriteActive` (global in `main.h`), `pipeState.active` and `partialCtx.active` (file-static in `display_service.cpp`). Callers meaning "a transfer is in flight" spelled the disjunction out themselves, and drifted: the log predicates had all three (longhand, twice), the roam gate had direct+pipe, the touch poll had direct only.

Two behaviour changes fall out, both widening an existing skip:

- **Roam gate** — a BLE-origin PARTIAL write with no LAN client attached could be interrupted mid-stream by a full-channel scan. Neither the LAN-client check nor the direct+pipe check fired, though the surrounding comment already claimed BLE transfers were protected.
- **Touch poll** — GT911 I²C reads are now skipped during PIPE and PARTIAL too. The original rationale (bus and loop-task contention) applies identically to all three.

Clear-timing was checked before unifying: all three flags are cleared before their panel teardown, so the predicate drops at the same relative point and gates open no earlier than before. Left deliberately specific: the direct-write watchdog and teardown in `main.cpp`, and the `(directWriteActive || partialCtx.active)` 0x0072 session-ownership check that excludes PIPE.

Also removes two dead symbols: `handleButtonPress(uint8_t)` (declared 2026-02-12, never defined or called — `processButtonEvents()` does the job) and `partialWriteActive()` (only caller was the deleted power-save net).

## Verification

**Hardware:** the WiFi/LAN transport and TLS-PSK encryption have been flashed and exercised end-to-end on an **E1003** — the full chain from Home Assistant through `py-opendisplay` to the firmware, not just a local loopback. That covers the substance of `2f38224`: association, mDNS discovery, the TLS-PSK listener, command-origin routing with the CCM bypass, and image delivery over LAN.

**Build:** all eleven environments compile on `55.03.39` — `nrf52840custom`, all five S3 variants, `esp32-s3-E1004`, both C3, `esp32-c6-N4`, `esp32-N4`.

Not separately exercised on hardware, and worth a look during review:

- **C6 BLE on the newer IDF.** The pin bump changes the controller blob under NimBLE-Arduino; C6 links and builds clean, but a C6 board should advertise, connect and complete a transfer before this is trusted.
- **The two gate changes in `d785ac0`** — roaming now deferred during PARTIAL writes, touch polling suppressed during PIPE/PARTIAL. Both only widen an existing skip, so the worst case should be touch being unresponsive slightly longer during an upload; a GT911 device running a long partial-write stream is the case to exercise.
- **The `esp_wifi_set_ps()` removal** rests on `WIFI_PS_MIN_MODEM` being the driver default, which is reasoning from the IDF default rather than a measurement.

One environment note: `55.03.311` requires PlatformIO Core ≥ 6.1.19 (it silently uninstalls itself on older Core). The pinned `.39` has no such requirement.
