### PR TITLE
Phase 1: nonce/replay correctness + unauthenticated-command guard

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,26 @@ on:
   pull_request:
 
 jobs:
+  # Separate top-level job on purpose ([L5]): the `build` job below is an
+  # 11-entry matrix, so a step added there would run the host test eleven times.
+  # This needs no toolchain beyond the runner's stock g++ and gates every push
+  # alongside the firmware builds. tools/ is invisible to every firmware build
+  # (build_src_filter is relative to src_dir and no env adds tools/), so the
+  # test file cannot affect the matrix.
+  host-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and run the nonce-window host test
+        # -fsanitize=undefined is not decoration: it is what catches the `x << 64`
+        # UB in the bitmap shift automatically rather than relying on the test
+        # author to predict it. See Decision D in
+        # docs/PLAN_PHASE1_NONCE_REPLAY_2026-07-26.md.
+        run: |
+          g++ -std=c++17 -Wall -Wextra -Werror -O1 -fsanitize=undefined,address \
+              tools/test_nonce_window.cpp -o /tmp/test_nonce_window
+          /tmp/test_nonce_window
+
   build:
     runs-on: ubuntu-latest
     strategy:

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -142,6 +142,27 @@ void rejectUnauthenticated(uint16_t command) {
     // can verify it is still dropping the same link.
     authAbuseDisconnectHandle = handle;
     authAbuseDisconnectPending = true;
+
+#ifdef TARGET_NRF
+    // ...except on nRF, where deferring does not work during a transfer. This
+    // dispatch IS the Bluefruit event-task write callback, and that task runs at a
+    // higher priority than the Arduino loop task. Measured: while a client floods
+    // gated frames inside a direct/pipe write, loop() is not scheduled at all --
+    // neither the drop nor its skip diagnostic printed until the flood stopped,
+    // which is precisely the window the guard exists to close.
+    //
+    // Safe inline here, unlike on ESP32:
+    //   - The 0xFE above has already gone out. nRF notifies from
+    //     sendResponseUnencrypted directly (imageCharacteristic.notify), with no
+    //     response ring to drain first, so there is nothing left to strand.
+    //   - Bluefruit.disconnect() only asks the SoftDevice to tear the link down.
+    //     The BLE_GAP_EVT_DISCONNECTED event arrives afterwards on this same event
+    //     task rather than unwinding the callback we are currently inside.
+    // This consumes the flag set above (the service clears it on every path), so
+    // loop()'s own call becomes a no-op -- it stays as the ESP32 path and as the
+    // fallback for anything that arms the guard from outside a write callback.
+    serviceBleAuthAbuseDisconnect();
+#endif
 }
 
 void serviceBleAuthAbuseDisconnect(void) {
@@ -151,7 +172,17 @@ void serviceBleAuthAbuseDisconnect(void) {
     // from Bluefruit.disconnect(), and would otherwise leave a stale request
     // armed against whatever link comes next.
     authAbuseDisconnectPending = false;
-    if (handle == AUTH_GUARD_NO_CONN_HANDLE) return;   // peer already left
+    if (handle == AUTH_GUARD_NO_CONN_HANDLE) {
+        // Normally means the offender left before this pass -- benign. But it is
+        // also what a stack that fails to report a live link looks like, and that
+        // case is NOT benign: the guard arms against 0xFFFF and then quietly
+        // declines to drop anything, which reads exactly like the guard not
+        // running at all. Log both the armed handle and what the stack says right
+        // now, so the two are distinguishable without a rebuild.
+        od_log_warn("Auth-abuse drop skipped: no live link (armed handle 0x%04X, stack now 0x%04X)",
+                    (unsigned)handle, (unsigned)authGuardLiveConnHandle());
+        return;
+    }
     // Between the rejection and this pass the offender may have disconnected and
     // another central taken its place. Drop only the link that actually earned
     // it -- never the innocent client that replaced it.

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -52,6 +52,124 @@ static const char* originTag(void) {
     }
 }
 
+// ------------------------------------------- unauthenticated-command guard ---
+// The encryption gate answers every gated frame sent without a usable session
+// with RESP_AUTH_REQUIRED and has no counter of its own, so a client that
+// ignores 0xFE can drive one response + one unrate-limited error line per frame
+// indefinitely. Observed in the field: a client that got 00 70 FE and streamed
+// its 0x0071 image data anyway, ~100 ms apart, until it ran out of image.
+//
+// Count consecutive 0xFE answers; at the threshold, drop the link. That forces
+// the client through a fresh connect + CMD_AUTHENTICATE (0x0050) handshake
+// instead of letting it spin.
+//
+// TEN, not three. Two reasons it cannot be tighter:
+//   - A legitimate client may probe several gated commands before it
+//     authenticates. The field trace shows 0x0040, 0x0044, 0x0070 and then data
+//     frames -- a threshold of 3 disconnects that client mid-connect, before it
+//     ever gets a chance to run the handshake.
+//   - It matches the only other auth-abuse limit in the firmware, the
+//     10-attempts-per-60s cap on CMD_AUTHENTICATE (encryption.cpp), which exists
+//     for the same "confused client, not attacker" case.
+// It is a count, not a rate: 10 rejections spread over an hour still drop the
+// link, because nothing in between cleared the counter.
+//
+// CONSECUTIVE. Any frame that clears the gate resets it (see the reset below the
+// decrypt), as does a successful authentication (encryption.cpp calls
+// resetAuthGateRejects when it sets authenticated = true). A client that gets one
+// command wrong and then authenticates never trips it.
+//
+// BLE ONLY. encryptionSession is a single global shared by BLE and LAN, so
+// counting a LAN peer's rejections here would let it cost an unrelated BLE
+// client its link -- the same cross-transport bleed auth_attempts already has.
+// LAN-TLS frames bypass the gate entirely; LAN-plaintext ones are answered 0xFE
+// as before, just not counted.
+#define AUTH_GATE_MAX_CONSECUTIVE_REJECTS 10
+
+// 0xFFFF is BLE_CONN_HANDLE_INVALID on the nRF SoftDevice and is never a valid
+// NimBLE handle either, so it means "no link" on both stacks.
+#define AUTH_GUARD_NO_CONN_HANDLE 0xFFFFu
+
+static uint8_t authGateRejects = 0;
+static uint16_t authGateLastHandle = AUTH_GUARD_NO_CONN_HANDLE;
+static volatile bool authAbuseDisconnectPending = false;
+static volatile uint16_t authAbuseDisconnectHandle = AUTH_GUARD_NO_CONN_HANDLE;
+
+void resetAuthGateRejects(void) { authGateRejects = 0; }
+
+// The live central's handle, asked of the stack rather than cached from the
+// connect callbacks: both stacks already track it, and mirroring it here would
+// mean a second copy to keep in sync across every connect/disconnect path
+// (including the ones that fire on reconnect during a refresh).
+static uint16_t authGuardLiveConnHandle(void) {
+#ifdef TARGET_NRF
+    return Bluefruit.connHandle();   // BLE_CONN_HANDLE_INVALID when idle
+#endif
+#ifdef TARGET_ESP32
+    if (pServer == nullptr || pServer->getConnectedCount() == 0) return AUTH_GUARD_NO_CONN_HANDLE;
+    return pServer->getPeerInfo(0).getConnHandle();
+#endif
+}
+
+void rejectUnauthenticated(uint16_t command) {
+    uint8_t response[] = {RESP_ACK, (uint8_t)(command & 0xFF), RESP_AUTH_REQUIRED};
+    sendResponseUnencrypted(response, sizeof(response));
+
+    if (g_commandOrigin != ORIGIN_BLE) return;
+
+    // A different central than the one that accrued the count gets a clean slate:
+    // a client must never inherit its predecessor's rejections and be dropped
+    // early for them.
+    const uint16_t handle = authGuardLiveConnHandle();
+    if (handle != authGateLastHandle) {
+        authGateLastHandle = handle;
+        authGateRejects = 0;
+    }
+
+    if (authGateRejects < 0xFF) authGateRejects++;
+    if (authGateRejects < AUTH_GATE_MAX_CONSECUTIVE_REJECTS) return;
+
+    od_log_error("ERROR: %u consecutive unauthenticated commands (last 0x%04X) -- BLE link drop pending",
+                 (unsigned)authGateRejects, (unsigned)command);
+    authGateRejects = 0;
+    // Flag-only: this runs on the BLE host task (NimBLE) or in a SoftDevice
+    // callback (nRF), and tearing a link down from inside the stack's own write
+    // callback is how you get a use-after-free. loop() does the work, after the
+    // response queue drains, so the client still receives this last 0xFE. Same
+    // deferral bleDisconnectCleanupPending already uses.
+    //
+    // The offender's handle rides along with the request so the deferred drop
+    // can verify it is still dropping the same link.
+    authAbuseDisconnectHandle = handle;
+    authAbuseDisconnectPending = true;
+}
+
+void serviceBleAuthAbuseDisconnect(void) {
+    if (!authAbuseDisconnectPending) return;
+    const uint16_t handle = authAbuseDisconnectHandle;
+    // Clear before disconnecting: the nRF disconnect callback runs synchronously
+    // from Bluefruit.disconnect(), and would otherwise leave a stale request
+    // armed against whatever link comes next.
+    authAbuseDisconnectPending = false;
+    if (handle == AUTH_GUARD_NO_CONN_HANDLE) return;   // peer already left
+    // Between the rejection and this pass the offender may have disconnected and
+    // another central taken its place. Drop only the link that actually earned
+    // it -- never the innocent client that replaced it.
+    if (handle != authGuardLiveConnHandle()) {
+        od_log_info("Auth-abuse drop skipped: offending link %u is already gone", (unsigned)handle);
+        return;
+    }
+
+    od_log_error("ERROR: Dropping BLE link (handle %u) after repeated unauthenticated commands",
+                 (unsigned)handle);
+#ifdef TARGET_NRF
+    Bluefruit.disconnect(handle);
+#endif
+#ifdef TARGET_ESP32
+    if (pServer != nullptr) pServer->disconnect(handle);
+#endif
+}
+
 static void reloadConfigAfterSave(void) {
     if (!loadGlobalConfig()) {
         od_log_warn("WARNING: Config was saved but reload from storage failed (see errors above). "
@@ -663,15 +781,13 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
     if (isEncryptionEnabled() && g_commandOrigin != ORIGIN_LAN_TLS) {
         if (!isAuthenticated()) {
             od_log_error("ERROR: [%s] Command requires authentication (encryption enabled)", originTag());
-            uint8_t response[] = {RESP_ACK, (uint8_t)(command & 0xFF), RESP_AUTH_REQUIRED};
-            sendResponseUnencrypted(response, sizeof(response));
+            rejectUnauthenticated(command);
             return;
         }
 
         if (len < BLE_CMD_HEADER_SIZE + ENCRYPTION_NONCE_SIZE + ENCRYPTION_TAG_SIZE) {
             od_log_error("ERROR: [%s] Unencrypted command received when encryption is enabled", originTag());
-            uint8_t response[] = {RESP_ACK, (uint8_t)(command & 0xFF), RESP_AUTH_REQUIRED};
-            sendResponseUnencrypted(response, sizeof(response));
+            rejectUnauthenticated(command);
             return;
         }
 
@@ -746,8 +862,7 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
             if (decrypt_reason == NONCE_BAD_SESSION) {
                 od_log_warn("Nonce session_id mismatch on 0x%04X - answering AUTH_REQUIRED so the client re-authenticates",
                             (unsigned)command);
-                uint8_t response[] = {RESP_ACK, (uint8_t)(command & 0xFF), RESP_AUTH_REQUIRED};
-                sendResponseUnencrypted(response, sizeof(response));
+                rejectUnauthenticated(command);
                 return;
             }
 
@@ -756,6 +871,10 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
             sendResponseUnencrypted(response, sizeof(response));
             return;
         }
+
+        // Cleared the gate: the peer is holding a live session and talking to it
+        // correctly, so the consecutive-rejection count starts over.
+        resetAuthGateRejects();
 
         static uint8_t decrypted_data[512];
         decrypted_data[0] = data[0];

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -695,7 +695,30 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
                          nonce_full[12], nonce_full[13], nonce_full[14], nonce_full[15]);
         }
 
-        if (!decryptCommand(data + BLE_CMD_HEADER_SIZE + ENCRYPTION_NONCE_SIZE, encrypted_data_len, plaintext, &plaintext_len, nonce_full, auth_tag, command)) {
+        NonceResult decrypt_reason = NONCE_OK;
+        if (!decryptCommand(data + BLE_CMD_HEADER_SIZE + ENCRYPTION_NONCE_SIZE, encrypted_data_len, plaintext, &plaintext_len, nonce_full, auth_tag, command, &decrypt_reason)) {
+            // Step 4b / [H1]: a pipe DATA frame rejected because its nonce fell
+            // outside the window IS ordinary packet loss - it is the direct
+            // consequence of frames having been dropped. pipe-write-protocol.md
+            // §5.2 already reserves NACKs for unrecoverable conditions, "not
+            // ordinary packet loss", and §5.1 makes a 0x81 NACK unconditionally
+            // fatal, so answering one here violates the spec as written. Send
+            // NOTHING: silence is a first-class signal on the pipe path. The seq
+            // is absent from the next SACK mask, the client retransmits it, and
+            // the transfer continues. Answering with the 3-byte NACK instead
+            // makes the client raise IntegrityCheckError, which its pipe send
+            // loop does not catch, killing the whole upload on the first
+            // rejected frame.
+            //
+            // Deliberately narrow:
+            //  - TAG failures keep the NACK. They are tamper evidence, not loss.
+            //  - 0x0071 (legacy DIRECT_WRITE_DATA) is left alone on purpose: it
+            //    has a different ACK discipline that has not been analysed, and
+            //    the field failure lives on the pipe path. Not an oversight.
+            const bool nonce_loss = (decrypt_reason == NONCE_OUT_OF_WINDOW || decrypt_reason == NONCE_REPLAY);
+            if (nonce_loss && command == CMD_PIPE_WRITE_DATA) {
+                return;
+            }
             od_log_error("ERROR: Decryption failed");
             uint8_t response[] = {RESP_ACK, (uint8_t)(command & 0xFF), RESP_NACK};
             sendResponseUnencrypted(response, sizeof(response));
@@ -769,10 +792,25 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
             handlePipeWriteStart(data + 2, len - 2);
             break;
         case CMD_PIPE_WRITE_DATA:     // 0x0081
-            // The replay counter (verifyNonceReplay) already advanced at decrypt time,
-            // above this switch, for every 0x0081 frame — including ones the handler
-            // then queues or discards — so drops/dupes never desync it and the counter
-            // delta stays within in-flight <= W <= 32 <= the +-32 replay window.
+            // Replay state is committed at decrypt time (nonceCommit, first
+            // statement of decryptCommand's success arm) for every 0x0081 frame
+            // that authenticates — including ones this handler then queues or
+            // discards — so drops/dupes never desync it.
+            //
+            // What bounds the forward gap is NOT a firmware constant. The client
+            // burns a nonce counter per *transmission*, landed or not, and its
+            // three transmit sites are new sends (window-credit-limited), PTO
+            // probes, and selective repair — and selective repair spends no
+            // window credit at all. The only ceiling is the client's retransmit
+            // budget max_retx = max(3*W, n/2), scaled by blocks_per_ack, which
+            // is a user-facing Home Assistant option (1..32) in another repo.
+            // OD_NONCE_FORWARD_CAP (src/nonce_window.h) is therefore a HEURISTIC
+            // with headroom over the realistic worst case, not an invariant this
+            // firmware can prove; a client-side blocks_per_ack change would
+            // silently falsify any specific number written here. A gap beyond
+            // the cap is no longer fatal: the frame is dropped silently (Step 4b
+            // above) and repaired by the normal SACK path. See Decision A / [C1]
+            // in docs/PLAN_PHASE1_NONCE_REPLAY_2026-07-26.md.
             handlePipeWriteData(data + 2, len - 2);
             break;
         case CMD_PIPE_WRITE_END:      // 0x0082

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -719,6 +719,38 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
             if (nonce_loss && command == CMD_PIPE_WRITE_DATA) {
                 return;
             }
+
+            // NONCE_BAD_SESSION is NOT loss and NOT tampering — it means the two
+            // sides disagree about which session is live, and no amount of client
+            // retrying can resolve that. Only a re-authentication can. Answer
+            // RESP_AUTH_REQUIRED, which says exactly that; the client raises
+            // AuthenticationRequiredError and re-authenticates, and the mismatch
+            // clears in one round trip.
+            //
+            // This restores a recovery path Phase 1 removed. Before Phase 1 a
+            // session-id mismatch counted toward integrity_failures, so three of
+            // them cleared the session and every later command answered 0xFE —
+            // which is what actually made the client re-authenticate. Routing
+            // BAD_SESSION to "does not count" ([L7]) was correct in refusing to
+            // treat it as tamper evidence, but it left the device answering a
+            // fatal 0xFF forever to a client that had lost its session and fallen
+            // back to plaintext uploads (observable as len=232 = 2 + CHUNK_SIZE
+            // 230, the *unencrypted* chunk budget; an encrypted 0x0071 frame
+            // cannot exceed 185 B). The device must tell the client to
+            // re-authenticate instead of NACKing it forever.
+            //
+            // In bounds under the parent plan's wire constraint: RESP_AUTH_REQUIRED
+            // is an existing response code used in its documented meaning ("this
+            // command requires a live authenticated session"), which is precisely
+            // the condition here.
+            if (decrypt_reason == NONCE_BAD_SESSION) {
+                od_log_warn("Nonce session_id mismatch on 0x%04X - answering AUTH_REQUIRED so the client re-authenticates",
+                            (unsigned)command);
+                uint8_t response[] = {RESP_ACK, (uint8_t)(command & 0xFF), RESP_AUTH_REQUIRED};
+                sendResponseUnencrypted(response, sizeof(response));
+                return;
+            }
+
             od_log_error("ERROR: Decryption failed");
             uint8_t response[] = {RESP_ACK, (uint8_t)(command & 0xFF), RESP_NACK};
             sendResponseUnencrypted(response, sizeof(response));

--- a/src/communication.h
+++ b/src/communication.h
@@ -26,4 +26,29 @@ enum CommandOrigin { ORIGIN_BLE = 0, ORIGIN_LAN_PLAIN = 1, ORIGIN_LAN_TLS = 2 };
 /// Origin of the command currently being dispatched (a CommandOrigin value).
 uint8_t commandOrigin(void);
 
+// ------------------------------------------- unauthenticated-command guard ---
+// Guard against a client that keeps sending gated commands into a dead session.
+// Rationale and the choice of threshold are at the implementation in
+// communication.cpp.
+//
+// Declared HERE, not in ble_init.h, because loop() calls into the guard on both
+// targets. ble_init.h includes NimBLEDevice.h on ESP32, so including it from
+// shared code drags the whole NimBLE surface into translation units that must
+// also compile for the nRF SoftDevice. This header stays free of any BLE-stack
+// include -- keep it that way; everything stack-specific is #ifdef'd inside
+// communication.cpp, which already has both stacks available.
+
+// Answers a gated frame with RESP_AUTH_REQUIRED (0xFE) and, on BLE, counts it
+// toward the disconnect threshold. Every 0xFE the encryption gate emits must go
+// through here rather than building the response inline, or the count is wrong.
+void rejectUnauthenticated(uint16_t command);
+
+// Clears the consecutive-rejection count. Called whenever a frame clears the
+// encryption gate, and on a successful authentication.
+void resetAuthGateRejects(void);
+
+// Performs a drop requested by the guard. Serviced from loop() on both targets;
+// no-op unless one is pending.
+void serviceBleAuthAbuseDisconnect(void);
+
 #endif

--- a/src/encryption.cpp
+++ b/src/encryption.cpp
@@ -29,6 +29,7 @@ using namespace Adafruit_LittleFS_Namespace;
 #endif
 
 void sendResponse(uint8_t* response, uint16_t len);
+void resetAuthGateRejects(void);   // communication.cpp: unauthenticated-command guard
 bool aes_cmac(const uint8_t* key, const uint8_t* message, size_t message_len, uint8_t* mac);
 bool aes_ecb_encrypt(const uint8_t* key, const uint8_t* input, uint8_t* output);
 bool aes_ccm_encrypt(const uint8_t* key, const uint8_t* nonce, size_t nonce_len,
@@ -685,6 +686,9 @@ bool handleAuthenticate(uint8_t* data, uint16_t len) {
             return false;
         }
         encryptionSession.authenticated = true;
+        // The client just proved it holds the key: whatever gated commands it got
+        // wrong before this point must not count toward the link drop.
+        resetAuthGateRejects();
         resetNonceState();
         encryptionSession.session_start_time = currentTime;
         encryptionSession.last_activity = currentTime;

--- a/src/encryption.cpp
+++ b/src/encryption.cpp
@@ -111,48 +111,70 @@ void deriveSessionId(const uint8_t* session_key, const uint8_t* client_nonce,
     }
 }
 
-bool verifyNonceReplay(uint8_t* nonce) {
-    if (!encryptionSession.authenticated) return false;
+// Reset ONLY the four nonce/replay fields. Named explicitly rather than
+// described loosely ([M3]): clearEncryptionSession() and handleAuthenticate()'s
+// fresh-session block share exactly these four and are *opposite* on everything
+// else (authenticated false vs true, timestamps zeroed vs stamped, keys wiped vs
+// populated). In particular nonce_counter — the device's OWN outbound counter —
+// must keep being zeroed here: a device that carried it across a re-auth while
+// the client restarts at 0 would reproduce the [H2] keystream reuse against
+// itself. See docs/PLAN_PHASE1_NONCE_REPLAY_2026-07-26.md Step 1.
+static void resetNonceState(void) {
+    encryptionSession.nonce_counter      = 0;   /* device's OWN outbound counter */
+    encryptionSession.last_seen_counter  = 0;
+    encryptionSession.integrity_failures = 0;
+    memset(encryptionSession.replay_bitmap, 0, sizeof(encryptionSession.replay_bitmap));
+}
+
+// Rate limiter for the two nonce-rejection logs. Once nonce failures stop
+// counting toward integrity_failures ([L7]) nothing else throttles a peer that
+// drives these lines, and out-of-window now fires routinely on a lossy link.
+static uint32_t nonce_log_last_ms = 0;
+static bool nonceLogAllowed(void) {
+    uint32_t now = millis();
+    if (nonce_log_last_ms != 0 && (uint32_t)(now - nonce_log_last_ms) < 5000u) return false;
+    nonce_log_last_ms = now;
+    return true;
+}
+
+// PURE. Parses the counter out of the 16-byte nonce and decides whether the
+// frame may be accepted. Writes NOTHING to encryptionSession on any path — that
+// is the property the host test asserts by memcmp, and it is what "only a
+// CCM-verified frame may advance replay state" (D2) rests on.
+//
+// File-static by design (Decision C): nothing outside decryptCommand should be
+// able to reach the commit side. The pure logic lives in src/nonce_window.h.
+static NonceResult nonceCheck(const uint8_t* nonce, uint64_t* counter_out) {
     uint8_t nonce_session_id[8];
     uint64_t nonce_counter = 0;
     memcpy(nonce_session_id, nonce, 8);
     for (int i = 0; i < 8; i++) {
         nonce_counter = (nonce_counter << 8) | nonce[8 + i];
     }
+    if (counter_out != nullptr) *counter_out = nonce_counter;
+
     if (!constantTimeCompare(nonce_session_id, encryptionSession.session_id, 8)) {
-        od_log_error("ERROR: Nonce session_id mismatch\n  Nonce ID: %02X%02X%02X%02X%02X%02X%02X%02X\n  Expected: %02X%02X%02X%02X%02X%02X%02X%02X",
-                     nonce_session_id[0], nonce_session_id[1], nonce_session_id[2], nonce_session_id[3],
-                     nonce_session_id[4], nonce_session_id[5], nonce_session_id[6], nonce_session_id[7],
-                     encryptionSession.session_id[0], encryptionSession.session_id[1], encryptionSession.session_id[2], encryptionSession.session_id[3],
-                     encryptionSession.session_id[4], encryptionSession.session_id[5], encryptionSession.session_id[6], encryptionSession.session_id[7]);
-        return false;
-    }
-    int64_t counter_diff = (int64_t)nonce_counter - (int64_t)encryptionSession.last_seen_counter;
-    if (counter_diff < -32 || counter_diff > 32) {
-        od_log_error("ERROR: Nonce counter outside replay window (counter=%llu, last_seen=%llu, diff=%lld)",
-                     (unsigned long long)nonce_counter, (unsigned long long)encryptionSession.last_seen_counter, (long long)counter_diff);
-        return false;
-    }
-    if (nonce_counter <= encryptionSession.last_seen_counter && counter_diff != 0) {
-        bool already_seen = false;
-        for (int i = 0; i < 64; i++) {
-            if (encryptionSession.replay_window[i] == nonce_counter) {
-                already_seen = true;
-                break;
-            }
+        // [L7] Demoted from ERROR + rate-limited, and the full session-id dump
+        // is gone: a mismatched session id is usually a stale client talking to
+        // a device that re-authenticated, i.e. confusion rather than attack.
+        // The CCM tag remains the only tamper oracle.
+        if (nonceLogAllowed()) {
+            od_log_warn("Nonce session_id mismatch (%02X%02X.. vs %02X%02X..) - frame dropped, session kept",
+                        nonce_session_id[0], nonce_session_id[1],
+                        encryptionSession.session_id[0], encryptionSession.session_id[1]);
         }
-        if (already_seen) {
-            od_log_error("ERROR: Nonce counter already seen (replay detected)");
-            return false;
-        }
+        return NONCE_BAD_SESSION;
     }
-    if (nonce_counter > encryptionSession.last_seen_counter) {
-        encryptionSession.last_seen_counter = nonce_counter;
-    }
-    static uint8_t replay_window_index = 0;
-    encryptionSession.replay_window[replay_window_index] = nonce_counter;
-    replay_window_index = (replay_window_index + 1) % 64;
-    return true;
+    return od_nonce_check(encryptionSession.replay_bitmap,
+                          encryptionSession.last_seen_counter, nonce_counter);
+}
+
+// Records a counter as consumed. Called from exactly one place: as the FIRST
+// statement of decryptCommand's success arm, i.e. only after aes_ccm_decrypt
+// has verified the tag (the D2 fix).
+static void nonceCommit(uint64_t counter) {
+    od_nonce_commit(encryptionSession.replay_bitmap,
+                    &encryptionSession.last_seen_counter, counter);
 }
 
 void getCurrentNonce(uint8_t* nonce) {
@@ -207,14 +229,11 @@ void clearEncryptionSession() {
     memset(encryptionSession.server_nonce, 0, 16);
     memset(encryptionSession.pending_server_nonce, 0, 16);
     encryptionSession.authenticated = false;
-    encryptionSession.nonce_counter = 0;
-    encryptionSession.last_seen_counter = 0;
-    encryptionSession.integrity_failures = 0;
+    resetNonceState();
     encryptionSession.session_start_time = 0;
     encryptionSession.last_activity = 0;
     encryptionSession.auth_attempts = 0;
     encryptionSession.server_nonce_time = 0;
-    memset(encryptionSession.replay_window, 0, sizeof(encryptionSession.replay_window));
     od_log_info("Encryption session cleared");
 }
 
@@ -652,12 +671,9 @@ bool handleAuthenticate(uint8_t* data, uint16_t len) {
             return false;
         }
         encryptionSession.authenticated = true;
-        encryptionSession.nonce_counter = 0;
-        encryptionSession.last_seen_counter = 0;
-        encryptionSession.integrity_failures = 0;
+        resetNonceState();
         encryptionSession.session_start_time = currentTime;
         encryptionSession.last_activity = currentTime;
-        memset(encryptionSession.replay_window, 0, sizeof(encryptionSession.replay_window));
         memset(encryptionSession.pending_server_nonce, 0, 16);
         encryptionSession.server_nonce_time = 0;
         uint8_t server_response[16];
@@ -686,13 +702,30 @@ bool handleAuthenticate(uint8_t* data, uint16_t len) {
 }
 
 bool decryptCommand(uint8_t* ciphertext, uint16_t ciphertext_len, uint8_t* plaintext,
-                    uint16_t* plaintext_len, uint8_t* nonce_full, uint8_t* auth_tag, uint16_t command_header) {
+                    uint16_t* plaintext_len, uint8_t* nonce_full, uint8_t* auth_tag, uint16_t command_header,
+                    NonceResult* reason_out) {
+    // reason_out reports WHY the frame was rejected so the caller can tell a
+    // nonce rejection (ordinary packet loss) from a CCM tag failure (tamper
+    // evidence). NONCE_OK means "not rejected for a nonce reason" — every
+    // non-nonce failure path below leaves it at NONCE_OK. See Step 4b.
+    if (reason_out != nullptr) *reason_out = NONCE_OK;
     if (!isAuthenticated()) return false;
-    if (!verifyNonceReplay(nonce_full)) {
-        encryptionSession.integrity_failures++;
-        if (encryptionSession.integrity_failures >= 3) {
-            od_log_warn("Too many integrity failures, clearing session");
-            clearEncryptionSession();
+
+    // Nonce failures are evidence of a LOSSY LINK, not of tampering, so they do
+    // NOT touch integrity_failures (the D1 fix). Only the CCM tag is a tamper
+    // oracle. [L7]: routing NONCE_BAD_SESSION here too is a deliberate policy
+    // change — a session-id mismatch is what a stale client sends after the
+    // device re-authenticated. See Step 4.
+    uint64_t nonce_counter = 0;
+    NonceResult nr = nonceCheck(nonce_full, &nonce_counter);
+    if (nr != NONCE_OK) {
+        if (reason_out != nullptr) *reason_out = nr;
+        if (nr != NONCE_BAD_SESSION && nonceLogAllowed()) {
+            od_log_warn("Nonce %s (counter=%llu last_seen=%llu fwd=%llu) - frame dropped, session kept",
+                        (nr == NONCE_REPLAY) ? "replay" : "out-of-window",
+                        (unsigned long long)nonce_counter,
+                        (unsigned long long)encryptionSession.last_seen_counter,
+                        (unsigned long long)(nonce_counter - encryptionSession.last_seen_counter));
         }
         return false;
     }
@@ -715,6 +748,12 @@ bool decryptCommand(uint8_t* ciphertext, uint16_t ciphertext_len, uint8_t* plain
                                    ad, 2, ciphertext, encrypted_len,
                                    decrypted_with_length, auth_tag, ENCRYPTION_TAG_SIZE);
     if (success) {
+        // [L2] FIRST statement of the success arm — deliberately ahead of the
+        // early return for a malformed payload_length below. That frame is
+        // *authentic* (it passed the CCM tag) and today's unconditional commit
+        // does record it; committing after the early return would silently
+        // leave an authentic frame replayable.
+        nonceCommit(nonce_counter);
         uint8_t payload_length = decrypted_with_length[0];
         if (payload_length > encrypted_len - 1) {
             od_log_error("ERROR: Invalid payload length in decrypted data");

--- a/src/encryption.cpp
+++ b/src/encryption.cpp
@@ -126,14 +126,19 @@ static void resetNonceState(void) {
     memset(encryptionSession.replay_bitmap, 0, sizeof(encryptionSession.replay_bitmap));
 }
 
-// Rate limiter for the two nonce-rejection logs. Once nonce failures stop
+// Rate limiters for the two nonce-rejection logs. Once nonce failures stop
 // counting toward integrity_failures ([L7]) nothing else throttles a peer that
 // drives these lines, and out-of-window now fires routinely on a lossy link.
-static uint32_t nonce_log_last_ms = 0;
-static bool nonceLogAllowed(void) {
+//
+// One budget PER SITE, deliberately, not one shared budget: a stale client
+// spamming session-id mismatches must not be able to silence the out-of-window
+// line, which is the condition Step 5's hardware tests 0-2 exist to observe.
+static uint32_t nonce_log_badsession_ms = 0;
+static uint32_t nonce_log_window_ms = 0;
+static bool nonceLogAllowed(uint32_t* last_ms) {
     uint32_t now = millis();
-    if (nonce_log_last_ms != 0 && (uint32_t)(now - nonce_log_last_ms) < 5000u) return false;
-    nonce_log_last_ms = now;
+    if (*last_ms != 0 && (uint32_t)(now - *last_ms) < 5000u) return false;
+    *last_ms = now;
     return true;
 }
 
@@ -144,6 +149,15 @@ static bool nonceLogAllowed(void) {
 //
 // File-static by design (Decision C): nothing outside decryptCommand should be
 // able to reach the commit side. The pure logic lives in src/nonce_window.h.
+//
+// Caveat on how strong that is. Decision C says linkage enforces the rule, and
+// for nonceCheck/nonceCommit it does. But encryption_state.h must include
+// nonce_window.h for OD_NONCE_BITMAP_WORDS, and main.h includes
+// encryption_state.h — so od_nonce_commit(), a static-inline header primitive,
+// is visible in every TU alongside the extern encryptionSession. Nothing stops
+// a determined caller from committing state directly. That is unavoidable while
+// the struct needs the width macro; the rule is enforced by linkage for the
+// session-aware wrappers and by convention for the raw primitive.
 static NonceResult nonceCheck(const uint8_t* nonce, uint64_t* counter_out) {
     uint8_t nonce_session_id[8];
     uint64_t nonce_counter = 0;
@@ -158,7 +172,7 @@ static NonceResult nonceCheck(const uint8_t* nonce, uint64_t* counter_out) {
         // is gone: a mismatched session id is usually a stale client talking to
         // a device that re-authenticated, i.e. confusion rather than attack.
         // The CCM tag remains the only tamper oracle.
-        if (nonceLogAllowed()) {
+        if (nonceLogAllowed(&nonce_log_badsession_ms)) {
             od_log_warn("Nonce session_id mismatch (%02X%02X.. vs %02X%02X..) - frame dropped, session kept",
                         nonce_session_id[0], nonce_session_id[1],
                         encryptionSession.session_id[0], encryptionSession.session_id[1]);
@@ -720,12 +734,20 @@ bool decryptCommand(uint8_t* ciphertext, uint16_t ciphertext_len, uint8_t* plain
     NonceResult nr = nonceCheck(nonce_full, &nonce_counter);
     if (nr != NONCE_OK) {
         if (reason_out != nullptr) *reason_out = nr;
-        if (nr != NONCE_BAD_SESSION && nonceLogAllowed()) {
-            od_log_warn("Nonce %s (counter=%llu last_seen=%llu fwd=%llu) - frame dropped, session kept",
-                        (nr == NONCE_REPLAY) ? "replay" : "out-of-window",
+        if (nr != NONCE_BAD_SESSION && nonceLogAllowed(&nonce_log_window_ms)) {
+            // A replayed counter is normally BEHIND last_seen, where the wrapping
+            // fwd delta prints as a 20-digit number. Report the distance in the
+            // direction that is actually small, so the line is readable in the
+            // case it fires in.
+            const bool behind = (nr == NONCE_REPLAY);
+            od_log_warn("Nonce %s (counter=%llu last_seen=%llu %s=%llu) - frame dropped, session kept",
+                        behind ? "replay" : "out-of-window",
                         (unsigned long long)nonce_counter,
                         (unsigned long long)encryptionSession.last_seen_counter,
-                        (unsigned long long)(nonce_counter - encryptionSession.last_seen_counter));
+                        behind ? "back" : "fwd",
+                        (unsigned long long)(behind
+                            ? (encryptionSession.last_seen_counter - nonce_counter)
+                            : (nonce_counter - encryptionSession.last_seen_counter)));
         }
         return false;
     }

--- a/src/encryption.h
+++ b/src/encryption.h
@@ -3,6 +3,7 @@
 
 #include <Arduino.h>
 #include <stdint.h>
+#include "nonce_window.h"
 
 bool deriveSessionKey(const uint8_t* master_key, const uint8_t* client_nonce,
                       const uint8_t* server_nonce, uint8_t* session_key);
@@ -14,12 +15,17 @@ bool isAuthenticated();
 void clearEncryptionSession();
 bool checkEncryptionSessionTimeout();
 void updateEncryptionSessionActivity();
-bool verifyNonceReplay(uint8_t* nonce);
 void getCurrentNonce(uint8_t* nonce);
 void incrementNonceCounter();
 bool handleAuthenticate(uint8_t* data, uint16_t len);
+/// Decrypt one CCM-enveloped command. On failure, *reason_out (if non-null)
+/// reports whether the frame was rejected for a NONCE reason — ordinary packet
+/// loss, which the caller must NOT answer with a fatal NACK on the pipe path
+/// (Step 4b) — or is NONCE_OK, meaning the failure was a tag failure or a
+/// malformed frame, which keeps today's NACK.
 bool decryptCommand(uint8_t* ciphertext, uint16_t ciphertext_len, uint8_t* plaintext,
-                    uint16_t* plaintext_len, uint8_t* nonce, uint8_t* auth_tag, uint16_t command_header);
+                    uint16_t* plaintext_len, uint8_t* nonce, uint8_t* auth_tag, uint16_t command_header,
+                    NonceResult* reason_out);
 bool encryptResponse(uint8_t* plaintext, uint16_t plaintext_len, uint8_t* ciphertext,
                      uint16_t* ciphertext_len, uint8_t* nonce, uint8_t* auth_tag);
 /// Derive the 16-byte TLS-PSK for the LAN TLS channel from the configured master

--- a/src/encryption_state.h
+++ b/src/encryption_state.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "structs.h"
+#include "nonce_window.h"
 #ifdef TARGET_ESP32
 #include "mbedtls/ccm.h"
 #endif
@@ -18,7 +19,13 @@ struct EncryptionSession {
 #endif
     uint64_t nonce_counter;
     uint64_t last_seen_counter;
-    uint64_t replay_window[64];
+    // Anti-replay: bit i == "counter (last_seen_counter - i) has been consumed".
+    // Bit 0 is last_seen_counter itself. The backward window is implicitly
+    // OD_NONCE_BACKWARD_BITS - 1; there is no separate window constant to keep
+    // in step, and no insertion index to reset. Replaces a uint64_t[64] value
+    // ring (512 B -> 32 B). See src/nonce_window.h and
+    // docs/PLAN_PHASE1_NONCE_REPLAY_2026-07-26.md Step 1 / Decision B.
+    uint64_t replay_bitmap[OD_NONCE_BITMAP_WORDS];
     uint32_t last_activity;
     uint8_t integrity_failures;
     uint32_t session_start_time;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -422,6 +422,10 @@ void loop() {
         }
     }
     flushResponseQueueToBle();
+    // Deliberately AFTER the flush: the guard's final 00 xx FE is already in the
+    // response ring when the drop is requested, and dropping the link first would
+    // strand it — leaving the client with no idea why it was disconnected.
+    serviceBleAuthAbuseDisconnect();
     // Service the flag-only BLE callbacks on this (single) task. Cleanup runs
     // before the advertising restart so a disconnected session is fully torn down
     // before the radio re-arms.
@@ -523,6 +527,9 @@ void loop() {
     else{
         idleDelay(500);
     }
+    // nRF notifies responses inline from the command callback, so the guard's
+    // 00 xx FE is already on the air by the time this runs.
+    serviceBleAuthAbuseDisconnect();
     ble_nrf_advertising_tick();
     processButtonEvents();
     processTouchInput();

--- a/src/main.h
+++ b/src/main.h
@@ -271,9 +271,8 @@ void clearEncryptionSession();
 bool checkEncryptionSessionTimeout();
 void updateEncryptionSessionActivity();
 bool handleAuthenticate(uint8_t* data, uint16_t len);
-bool decryptCommand(uint8_t* ciphertext, uint16_t ciphertext_len, uint8_t* plaintext, uint16_t* plaintext_len, uint8_t* nonce, uint8_t* auth_tag, uint16_t command_header);
+bool decryptCommand(uint8_t* ciphertext, uint16_t ciphertext_len, uint8_t* plaintext, uint16_t* plaintext_len, uint8_t* nonce, uint8_t* auth_tag, uint16_t command_header, NonceResult* reason_out);
 bool encryptResponse(uint8_t* plaintext, uint16_t plaintext_len, uint8_t* ciphertext, uint16_t* ciphertext_len, uint8_t* nonce, uint8_t* auth_tag);
-bool verifyNonceReplay(uint8_t* nonce);
 void incrementNonceCounter();
 void getCurrentNonce(uint8_t* nonce);
 

--- a/src/nonce_window.h
+++ b/src/nonce_window.h
@@ -22,6 +22,7 @@
 // fresh session (last_seen = 0, all-zero bitmap) accepts counter 0 exactly once
 // with no has_seen_counter flag.
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -106,12 +107,22 @@ static inline void od_nonce_bitmap_shift_left(uint64_t* bm, uint64_t shift) {
 // Records `counter` as consumed. MUST only be called after the frame carrying
 // it has been authenticated (CCM tag verified) — that is the D2 fix.
 //
-// Total for every input, including inputs od_nonce_check() would have rejected:
-// the host test calls it directly, and a future OD_NONCE_FORWARD_CAP increase
-// must not be able to produce an over-wide shift. The wholesale-clear path is
-// unreachable through od_nonce_check() today (cap 128 < 256 bits) but is still
-// correct when it fires: every counter it discards is then >= 256 behind and is
-// rejected on width, never mis-reported as unseen.
+// Defined (never UB) for every input, including inputs od_nonce_check() would
+// have rejected: the host test calls it directly, and a future
+// OD_NONCE_FORWARD_CAP increase must not be able to produce an over-wide shift.
+// The wholesale-clear path is unreachable through od_nonce_check() today (cap
+// 128 < 256 bits) but is still correct when it fires on a FORWARD jump: every
+// counter it discards is then >= 256 behind and is rejected on width, never
+// mis-reported as unseen.
+//
+// Sharp edge, stated rather than hidden: a counter more than
+// OD_NONCE_BACKWARD_BITS *behind* last_seen also lands in the forward branch
+// (fwd and back are complements, so its fwd is enormous), clearing the bitmap
+// and RE-WINDING last_seen to that counter — un-seeing everything. That is
+// unreachable through od_nonce_check(), which returns NONCE_OUT_OF_WINDOW for
+// such a counter so it is never committed, and the contract above is that
+// commit runs only for frames that both checked OK and authenticated. It is the
+// edge to watch if a future caller ever commits without checking first.
 static inline void od_nonce_commit(uint64_t* bm, uint64_t* last_seen, uint64_t counter) {
     const uint64_t fwd = counter - *last_seen;
     const uint64_t back = *last_seen - counter;

--- a/src/nonce_window.h
+++ b/src/nonce_window.h
@@ -1,0 +1,136 @@
+#ifndef NONCE_WINDOW_H
+#define NONCE_WINDOW_H
+
+// Anti-replay sliding window — pure state machine, ZERO dependencies.
+//
+// This header deliberately includes nothing from Arduino, mbedtls, or the
+// firmware logging layer, and it touches no global state. Everything here
+// operates on plain values passed in by the caller, so the whole state machine
+// can be compiled and exercised on a host under UBSan/ASan by
+// tools/test_nonce_window.cpp. See docs/PLAN_PHASE1_NONCE_REPLAY_2026-07-26.md
+// Decision D.
+//
+// Representation (RFC 4303 / RFC 6347 "shifting" style, as opposed to the
+// circular RFC 6479 / WireGuard style — see Decision B):
+//
+//   bit i of the bitmap == "counter (last_seen - i) has been consumed".
+//   bit 0 is last_seen itself.
+//
+// The backward window is therefore implicitly OD_NONCE_BACKWARD_BITS - 1; there
+// is no separate window constant to keep in step, and no insertion index to
+// reset. "Not seen" is a clear bit rather than a reserved sentinel value, so a
+// fresh session (last_seen = 0, all-zero bitmap) accepts counter 0 exactly once
+// with no has_seen_counter flag.
+
+#include <stdint.h>
+#include <string.h>
+
+// Width of the backward (out-of-order tolerance) window, in bits.
+// uint64_t[4] = 32 B. Kept strictly greater than OD_NONCE_FORWARD_CAP so that a
+// legal forward slide can never exceed the bitmap width — that keeps the
+// wholesale-clear branch in od_nonce_commit() off the normal path.
+#define OD_NONCE_BACKWARD_BITS 256
+
+// Largest forward jump that is accepted. This is a HEURISTIC, not an invariant
+// firmware can prove: the real bound lives in the client's retransmit budget
+// (max_retx = max(3*W, n/2)) and its blocks_per_ack setting, both of which live
+// in another repo and one of which is a user-facing Home Assistant option. See
+// Decision A in docs/PLAN_PHASE1_NONCE_REPLAY_2026-07-26.md.
+#define OD_NONCE_FORWARD_CAP 128
+
+#define OD_NONCE_BITMAP_WORDS (OD_NONCE_BACKWARD_BITS / 64)
+
+enum NonceResult {
+    NONCE_OK = 0,
+    NONCE_BAD_SESSION,
+    NONCE_OUT_OF_WINDOW,
+    NONCE_REPLAY
+};
+
+static inline bool od_nonce_bit_test(const uint64_t* bm, uint64_t bit) {
+    return ((bm[(size_t)(bit >> 6)] >> (unsigned)(bit & 63u)) & 1ull) != 0ull;
+}
+
+static inline void od_nonce_bit_set(uint64_t* bm, uint64_t bit) {
+    bm[(size_t)(bit >> 6)] |= (1ull << (unsigned)(bit & 63u));
+}
+
+// Pure: decides whether `counter` may be accepted. Writes nothing.
+//
+// The four tests are ORDERED and the order is load-bearing. fwd and back sum to
+// zero mod 2^64, so they cannot both be small: with the current constants
+// fwd <= 128 && back < 256 would require fwd + back <= 384 == 0 (mod 2^64),
+// true only when both are zero — the case the first test already consumed. A
+// counter far from the window in either direction leaves both huge and falls
+// through to NONCE_OUT_OF_WINDOW. Do not reorder.
+//
+// Unsigned wrapping arithmetic only: the counter is parsed off the wire BEFORE
+// the CCM tag is verified, so an unauthenticated attacker controls both
+// operands. Converting a uint64_t >= 2^63 to int64_t is implementation-defined
+// before C++20, the signed subtraction can overflow, and negating INT64_MIN is
+// UB — three ways to be undefined on attacker-chosen input. Unsigned overflow
+// is defined as modular arithmetic, making this total over all 2^64 inputs.
+static inline NonceResult od_nonce_check(const uint64_t* bm, uint64_t last_seen, uint64_t counter) {
+    const uint64_t fwd = counter - last_seen;   /* wraps; 0 when equal             */
+    const uint64_t back = last_seen - counter;  /* wraps; fwd + back == 0 mod 2^64 */
+
+    if (fwd == 0u) return od_nonce_bit_test(bm, 0) ? NONCE_REPLAY : NONCE_OK;
+    if (fwd <= OD_NONCE_FORWARD_CAP) return NONCE_OK; /* ahead: cannot have been seen */
+    if (back < OD_NONCE_BACKWARD_BITS) return od_nonce_bit_test(bm, back) ? NONCE_REPLAY : NONCE_OK;
+    return NONCE_OUT_OF_WINDOW;
+}
+
+// Shift the bitmap left by `shift` bits (bit i -> bit i + shift), clearing the
+// vacated low bits. Handles shift == 0 and shift >= 64 explicitly: `x << 64` is
+// undefined behaviour in C/C++ and is the classic bug in this pattern.
+static inline void od_nonce_bitmap_shift_left(uint64_t* bm, uint64_t shift) {
+    if (shift == 0u) return;
+    if (shift >= OD_NONCE_BACKWARD_BITS) {
+        memset(bm, 0, sizeof(uint64_t) * OD_NONCE_BITMAP_WORDS);
+        return;
+    }
+    const size_t word_shift = (size_t)(shift >> 6);
+    const unsigned bit_shift = (unsigned)(shift & 63u);
+    for (size_t i = OD_NONCE_BITMAP_WORDS; i-- > 0;) {
+        uint64_t v = 0u;
+        if (i >= word_shift) {
+            v = bm[i - word_shift] << bit_shift;
+            if (bit_shift != 0u && i > word_shift) {
+                v |= bm[i - word_shift - 1] >> (64u - bit_shift);
+            }
+        }
+        bm[i] = v;
+    }
+}
+
+// Records `counter` as consumed. MUST only be called after the frame carrying
+// it has been authenticated (CCM tag verified) — that is the D2 fix.
+//
+// Total for every input, including inputs od_nonce_check() would have rejected:
+// the host test calls it directly, and a future OD_NONCE_FORWARD_CAP increase
+// must not be able to produce an over-wide shift. The wholesale-clear path is
+// unreachable through od_nonce_check() today (cap 128 < 256 bits) but is still
+// correct when it fires: every counter it discards is then >= 256 behind and is
+// rejected on width, never mis-reported as unseen.
+static inline void od_nonce_commit(uint64_t* bm, uint64_t* last_seen, uint64_t counter) {
+    const uint64_t fwd = counter - *last_seen;
+    const uint64_t back = *last_seen - counter;
+
+    if (fwd == 0u) {
+        od_nonce_bit_set(bm, 0);
+        return;
+    }
+    if (back < OD_NONCE_BACKWARD_BITS) {
+        /* backward, inside the window: last_seen does not move.
+           Unambiguous: fwd and back are complements mod 2^64, so back < 256
+           forces fwd >= 2^64 - 255 — they can never both be small. */
+        od_nonce_bit_set(bm, back);
+        return;
+    }
+    /* forward */
+    od_nonce_bitmap_shift_left(bm, fwd);
+    *last_seen = counter;
+    od_nonce_bit_set(bm, 0);
+}
+
+#endif  // NONCE_WINDOW_H

--- a/tools/test_nonce_window.cpp
+++ b/tools/test_nonce_window.cpp
@@ -1,0 +1,702 @@
+// Host test for src/nonce_window.h — standalone, no test framework.
+//
+// Build and run from the repo root:
+//
+//   g++ -std=c++17 -Wall -Wextra -Werror -O1 -fsanitize=undefined,address
+//       tools/test_nonce_window.cpp -o /tmp/test_nonce_window
+//   /tmp/test_nonce_window
+//
+// This file is as much a written-down statement of the intended semantics of the
+// anti-replay window as it is a test. Each block names the coverage item from
+// docs/PLAN_PHASE1_NONCE_REPLAY_2026-07-26.md, Decision D, that it discharges.
+//
+// The representation under test (see the header):
+//   bit i of the bitmap == "counter (last_seen - i) has been consumed"
+//   bit 0 == last_seen itself
+// so the backward window is OD_NONCE_BACKWARD_BITS wide (indices 0..255) and the
+// forward acceptance window is OD_NONCE_FORWARD_CAP wide.
+
+#include "../src/nonce_window.h"
+
+#include <cinttypes>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <set>
+
+// ---------------------------------------------------------------------------
+// Make UBSan reports fatal
+//
+// UBSan defaults to "print and keep going", so a regression that reintroduces
+// signed counter arithmetic would emit a runtime-error line and still exit 0 —
+// invisible to CI. __ubsan_on_report is the sanitizer's weak notification hook;
+// overriding it turns any report into a nonzero exit without needing the caller
+// to remember UBSAN_OPTIONS=halt_on_error=1.
+//
+// Defined unconditionally: libubsan declares it weak, so this overrides it when
+// the sanitizer is linked in, and is simply unreferenced when it is not. (It
+// cannot be guarded on a macro — GCC only started defining __SANITIZE_UNDEFINED__
+// in GCC 14, and this must work on older CI runners.)
+// ---------------------------------------------------------------------------
+
+extern "C" void __ubsan_on_report(void);
+extern "C" void __ubsan_on_report(void) {
+    std::fputs("FAIL: undefined behaviour reported by UBSan (see the runtime error above)\n",
+               stderr);
+    std::fflush(stderr);
+    std::_Exit(EXIT_FAILURE);
+}
+
+// ---------------------------------------------------------------------------
+// Minimal check harness
+// ---------------------------------------------------------------------------
+
+static unsigned long g_checks = 0;
+static unsigned long g_failures = 0;
+
+// Free-form context describing the enclosing loop iteration, printed on failure
+// so that a failing case inside a data-driven loop is identifiable.
+static char g_context[256] = "";
+
+static void set_context(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
+
+static void set_context(const char* fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(g_context, sizeof(g_context), fmt, ap);
+    va_end(ap);
+}
+
+static void clear_context(void) { g_context[0] = '\0'; }
+
+static const char* res_name(NonceResult r) {
+    switch (r) {
+        case NONCE_OK: return "NONCE_OK";
+        case NONCE_BAD_SESSION: return "NONCE_BAD_SESSION";
+        case NONCE_OUT_OF_WINDOW: return "NONCE_OUT_OF_WINDOW";
+        case NONCE_REPLAY: return "NONCE_REPLAY";
+    }
+    return "NONCE_<invalid>";
+}
+
+static void report_failure(const char* file, int line, const char* expr) {
+    ++g_failures;
+    if (g_context[0] != '\0') {
+        std::printf("FAIL %s:%d [%s]: %s\n", file, line, g_context, expr);
+    } else {
+        std::printf("FAIL %s:%d: %s\n", file, line, expr);
+    }
+}
+
+#define CHECK(expr)                                        \
+    do {                                                   \
+        ++g_checks;                                        \
+        if (!(expr)) report_failure(__FILE__, __LINE__, #expr); \
+    } while (0)
+
+// Compares two NonceResult values and prints both symbolic names on mismatch.
+#define CHECK_RES(actual, expected)                                            \
+    do {                                                                       \
+        ++g_checks;                                                            \
+        const NonceResult check_a_ = (actual);                                 \
+        const NonceResult check_e_ = (expected);                               \
+        if (check_a_ != check_e_) {                                            \
+            ++g_failures;                                                      \
+            if (g_context[0] != '\0') {                                        \
+                std::printf("FAIL %s:%d [%s]: %s -> got %s, want %s\n",        \
+                            __FILE__, __LINE__, g_context, #actual,            \
+                            res_name(check_a_), res_name(check_e_));           \
+            } else {                                                           \
+                std::printf("FAIL %s:%d: %s -> got %s, want %s\n", __FILE__,   \
+                            __LINE__, #actual, res_name(check_a_),             \
+                            res_name(check_e_));                               \
+            }                                                                  \
+        }                                                                      \
+    } while (0)
+
+// ---------------------------------------------------------------------------
+// State container
+// ---------------------------------------------------------------------------
+
+struct NonceState {
+    uint64_t bm[OD_NONCE_BITMAP_WORDS];
+    uint64_t last_seen;
+};
+
+// All members are uint64_t, so the struct has no padding and can be compared
+// byte-for-byte by the purity test below.
+static_assert(sizeof(NonceState) == sizeof(uint64_t) * (OD_NONCE_BITMAP_WORDS + 1),
+              "NonceState must be padding-free for the byte-identical purity check");
+
+static void state_reset(NonceState* s, uint64_t last_seen) {
+    std::memset(s->bm, 0, sizeof(s->bm));
+    s->last_seen = last_seen;
+}
+
+static NonceResult check(const NonceState* s, uint64_t counter) {
+    return od_nonce_check(s->bm, s->last_seen, counter);
+}
+
+static void commit(NonceState* s, uint64_t counter) {
+    od_nonce_commit(s->bm, &s->last_seen, counter);
+}
+
+// Accept-and-record, the way firmware uses the pair: check, and only commit if
+// the frame would be accepted (and, in firmware, only after the CCM tag verifies).
+static NonceResult check_and_commit(NonceState* s, uint64_t counter) {
+    const NonceResult r = check(s, counter);
+    if (r == NONCE_OK) commit(s, counter);
+    return r;
+}
+
+// ---------------------------------------------------------------------------
+// Decision D coverage: fresh session (last_seen = 0, empty bitmap)
+//
+// "Not seen" is a clear bit, not a reserved sentinel, so counter 0 on a virgin
+// state is accepted exactly once with no has_seen_counter flag anywhere.
+// ---------------------------------------------------------------------------
+
+static void test_fresh_session(void) {
+    NonceState s;
+    state_reset(&s, 0);
+
+    CHECK_RES(check(&s, 0), NONCE_OK);
+    commit(&s, 0);
+    CHECK_RES(check(&s, 0), NONCE_REPLAY);
+
+    // last_seen has not moved: committing at fwd == 0 only sets bit 0.
+    CHECK(s.last_seen == 0);
+    CHECK(od_nonce_bit_test(s.bm, 0));
+
+    // Counter 1 is one ahead and cannot have been seen.
+    CHECK_RES(check(&s, 1), NONCE_OK);
+
+    // Counter UINT64_MAX is one *behind* 0 under modular arithmetic (back == 1),
+    // inside the backward window, and its bit is clear.
+    CHECK_RES(check(&s, UINT64_MAX), NONCE_OK);
+
+    // ...and 256 behind is off the end of the window.
+    CHECK_RES(check(&s, 0u - (uint64_t)OD_NONCE_BACKWARD_BITS), NONCE_OUT_OF_WINDOW);
+    CHECK_RES(check(&s, 0u - (uint64_t)(OD_NONCE_BACKWARD_BITS - 1)), NONCE_OK);
+}
+
+// ---------------------------------------------------------------------------
+// Decision D coverage: D3 — re-presenting a committed counter is REPLAY,
+// including at fwd == 0, the case today's firmware exempts.
+// ---------------------------------------------------------------------------
+
+static void test_d3_same_counter_replay(void) {
+    const uint64_t base = 1000000u;
+
+    // fwd == 0: the exempted case.
+    {
+        NonceState s;
+        state_reset(&s, base);
+        CHECK_RES(check(&s, base), NONCE_OK);  // virgin bit 0
+        commit(&s, base);
+        CHECK_RES(check(&s, base), NONCE_REPLAY);
+        CHECK_RES(check(&s, base), NONCE_REPLAY);  // and it stays REPLAY
+    }
+
+    // Forward acceptance then immediate re-presentation: the accepted counter
+    // becomes the new last_seen, so the replay lands on fwd == 0 again.
+    {
+        NonceState s;
+        state_reset(&s, base);
+        commit(&s, base);
+        CHECK_RES(check_and_commit(&s, base + 5), NONCE_OK);
+        CHECK(s.last_seen == base + 5);
+        CHECK_RES(check(&s, base + 5), NONCE_REPLAY);
+        // The old last_seen is now 5 behind and still recorded.
+        CHECK_RES(check(&s, base), NONCE_REPLAY);
+        // A gap counter between them was never committed.
+        CHECK_RES(check(&s, base + 3), NONCE_OK);
+    }
+
+    // Backward, in-window acceptance then re-presentation.
+    {
+        NonceState s;
+        state_reset(&s, base);
+        commit(&s, base);
+        CHECK_RES(check_and_commit(&s, base - 100), NONCE_OK);
+        CHECK(s.last_seen == base);  // backward commits never move last_seen
+        CHECK_RES(check(&s, base - 100), NONCE_REPLAY);
+        CHECK_RES(check(&s, base - 99), NONCE_OK);
+        CHECK_RES(check(&s, base - 101), NONCE_OK);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decision D coverage: purity of od_nonce_check (D2)
+//
+// THE most important assertion in this file. "The tag is the only thing that may
+// advance replay state" rests entirely on od_nonce_check writing nothing, so a
+// pre-authentication call on attacker-controlled input cannot poison the window.
+// Every result class is exercised against one snapshot and the whole state is
+// compared byte-for-byte afterwards.
+// ---------------------------------------------------------------------------
+
+static void test_check_is_pure(void) {
+    const uint64_t base = 500000u;
+
+    NonceState s;
+    state_reset(&s, base);
+    // Build a non-trivial bitmap: bits at word boundaries and in between.
+    commit(&s, base);
+    const uint64_t seen_offsets[] = {1, 2, 63, 64, 65, 127, 128, 191, 192, 254, 255};
+    for (size_t i = 0; i < sizeof(seen_offsets) / sizeof(seen_offsets[0]); ++i) {
+        commit(&s, base - seen_offsets[i]);
+    }
+
+    unsigned char snapshot[sizeof(NonceState)];
+    std::memcpy(snapshot, &s, sizeof(snapshot));
+
+    // One input per result class produced by od_nonce_check.
+    struct Case {
+        uint64_t counter;
+        NonceResult expected;
+        const char* what;
+    };
+    const Case cases[] = {
+        {base, NONCE_REPLAY, "fwd == 0, bit 0 set -> REPLAY"},
+        {base + 1, NONCE_OK, "forward by 1 -> OK"},
+        {base + OD_NONCE_FORWARD_CAP, NONCE_OK, "forward at the cap -> OK"},
+        {base - 3, NONCE_OK, "backward, unseen -> OK"},
+        {base - 64, NONCE_REPLAY, "backward, seen -> REPLAY"},
+        {base + OD_NONCE_FORWARD_CAP + 1, NONCE_OUT_OF_WINDOW, "past the forward cap"},
+        {base - OD_NONCE_BACKWARD_BITS, NONCE_OUT_OF_WINDOW, "past the backward window"},
+        {base + (1ull << 62), NONCE_OUT_OF_WINDOW, "far ahead"},
+        {base - (1ull << 62), NONCE_OUT_OF_WINDOW, "far behind"},
+    };
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
+        set_context("purity case: %s", cases[i].what);
+        CHECK_RES(check(&s, cases[i].counter), cases[i].expected);
+    }
+    clear_context();
+
+    CHECK(std::memcmp(snapshot, &s, sizeof(snapshot)) == 0);
+
+    // The fwd == 0 OK class needs a state where bit 0 is clear; check purity there too.
+    NonceState fresh;
+    state_reset(&fresh, base);
+    unsigned char fresh_snapshot[sizeof(NonceState)];
+    std::memcpy(fresh_snapshot, &fresh, sizeof(fresh_snapshot));
+    CHECK_RES(check(&fresh, base), NONCE_OK);
+    CHECK(std::memcmp(fresh_snapshot, &fresh, sizeof(fresh_snapshot)) == 0);
+
+    // Repeated calls on every input class, in bulk, still change nothing.
+    for (int rep = 0; rep < 4; ++rep) {
+        for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
+            (void)check(&s, cases[i].counter);
+        }
+    }
+    CHECK(std::memcmp(snapshot, &s, sizeof(snapshot)) == 0);
+}
+
+// ---------------------------------------------------------------------------
+// Decision D coverage: shift edges
+//
+// For each forward delta d, seed a window with a spread of previously consumed
+// counters, slide forward by d, and then require:
+//   - every seeded counter whose new distance (d + i) is < OD_NONCE_BACKWARD_BITS
+//     is still reported REPLAY (the bit moved with the window, it did not fall
+//     off early and it did not land on the wrong index), and
+//   - every seeded counter whose new distance is >= OD_NONCE_BACKWARD_BITS is
+//     reported OUT_OF_WINDOW, never REPLAY.
+//
+// d = 0, 1, 63, 64, 65, 127, 128 are reachable through od_nonce_check (capped by
+// OD_NONCE_FORWARD_CAP). d = 129, 191, 192, 255, 256, 257 are driven directly
+// against od_nonce_commit to cover the word boundaries and the wholesale-clear
+// guard, which no reachable input can hit while the cap stays below the width.
+// ---------------------------------------------------------------------------
+
+static const uint64_t kSeedOffsets[] = {0, 1, 2, 63, 64, 65, 127, 128, 129, 191, 192, 254, 255};
+static const size_t kSeedCount = sizeof(kSeedOffsets) / sizeof(kSeedOffsets[0]);
+
+static void seed_window(NonceState* s, uint64_t base) {
+    state_reset(s, base);
+    for (size_t i = 0; i < kSeedCount; ++i) {
+        commit(s, base - kSeedOffsets[i]);
+    }
+    // Sanity: everything seeded reads back as consumed, before any slide.
+    for (size_t i = 0; i < kSeedCount; ++i) {
+        CHECK_RES(check(s, base - kSeedOffsets[i]), NONCE_REPLAY);
+    }
+    CHECK(s->last_seen == base);
+}
+
+static void run_shift_edge(uint64_t d, bool reachable_through_check) {
+    const uint64_t base = 1000000u;
+    NonceState s;
+    seed_window(&s, base);
+
+    set_context("shift edge d=%" PRIu64, d);
+
+    if (reachable_through_check) {
+        // d == 0 lands on the fwd == 0 branch, whose bit is already set by the seed.
+        CHECK_RES(check(&s, base + d), d == 0 ? NONCE_REPLAY : NONCE_OK);
+        commit(&s, base + d);
+    } else {
+        // Beyond the forward cap: od_nonce_check rejects it, so drive commit directly.
+        CHECK_RES(check(&s, base + d), NONCE_OUT_OF_WINDOW);
+        commit(&s, base + d);
+    }
+
+    CHECK(s.last_seen == base + d);
+    // The newly committed counter is always recorded.
+    CHECK_RES(check(&s, base + d), NONCE_REPLAY);
+
+    for (size_t i = 0; i < kSeedCount; ++i) {
+        const uint64_t counter = base - kSeedOffsets[i];
+        const uint64_t new_back = d + kSeedOffsets[i];
+        const bool wholesale_clear = (d >= OD_NONCE_BACKWARD_BITS);
+        set_context("shift edge d=%" PRIu64 ", seeded offset %" PRIu64
+                    " (new back %" PRIu64 ")",
+                    d, kSeedOffsets[i], new_back);
+        if (new_back < OD_NONCE_BACKWARD_BITS && !wholesale_clear) {
+            CHECK_RES(check(&s, counter), NONCE_REPLAY);
+        } else {
+            CHECK_RES(check(&s, counter), NONCE_OUT_OF_WINDOW);
+        }
+    }
+
+    // Counters that were never seeded and are still inside the backward window
+    // must read as unseen, not as bits smeared by the shift.
+    for (uint64_t back = 1; back < OD_NONCE_BACKWARD_BITS; ++back) {
+        const uint64_t counter = (base + d) - back;
+        // Is this counter one of the seeded ones (or the pre-slide last_seen)?
+        bool seeded = false;
+        for (size_t i = 0; i < kSeedCount; ++i) {
+            if (counter == base - kSeedOffsets[i]) seeded = true;
+        }
+        const bool expect_replay = seeded && (d < OD_NONCE_BACKWARD_BITS);
+        set_context("shift edge d=%" PRIu64 ", back=%" PRIu64, d, back);
+        CHECK_RES(check(&s, counter), expect_replay ? NONCE_REPLAY : NONCE_OK);
+    }
+
+    // Exactly at the window edge and beyond it: rejected on width.
+    set_context("shift edge d=%" PRIu64 ", window edge", d);
+    CHECK_RES(check(&s, (base + d) - OD_NONCE_BACKWARD_BITS), NONCE_OUT_OF_WINDOW);
+    CHECK_RES(check(&s, (base + d) - (OD_NONCE_BACKWARD_BITS + 1)), NONCE_OUT_OF_WINDOW);
+
+    clear_context();
+}
+
+static void test_shift_edges(void) {
+    const uint64_t reachable[] = {0, 1, 63, 64, 65, 127, 128};
+    for (size_t i = 0; i < sizeof(reachable) / sizeof(reachable[0]); ++i) {
+        run_shift_edge(reachable[i], true);
+    }
+    const uint64_t direct[] = {129, 191, 192, 255, 256, 257};
+    for (size_t i = 0; i < sizeof(direct) / sizeof(direct[0]); ++i) {
+        run_shift_edge(direct[i], false);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decision D coverage: wholesale slide
+//
+// A forward jump of at least OD_NONCE_BACKWARD_BITS clears the bitmap outright
+// (x << 64 is UB, and shifting a 256-bit map by >= 256 has no surviving bits).
+// Everything previously consumed must then come back OUT_OF_WINDOW, NOT REPLAY.
+// Both reject, so conflating them is invisible in behaviour — and would hide a
+// genuine slide bug where the map was cleared when it should not have been.
+// ---------------------------------------------------------------------------
+
+static void test_wholesale_slide(void) {
+    const uint64_t base = 1000000u;
+    const uint64_t jumps[] = {OD_NONCE_BACKWARD_BITS, OD_NONCE_BACKWARD_BITS + 1, 300, 100000,
+                              (1ull << 40)};
+
+    for (size_t j = 0; j < sizeof(jumps) / sizeof(jumps[0]); ++j) {
+        const uint64_t d = jumps[j];
+        NonceState s;
+        seed_window(&s, base);
+        set_context("wholesale slide d=%" PRIu64, d);
+
+        commit(&s, base + d);
+        CHECK(s.last_seen == base + d);
+
+        // Bitmap holds exactly one bit: the counter just committed.
+        CHECK(s.bm[0] == 1ull);
+        for (size_t w = 1; w < OD_NONCE_BITMAP_WORDS; ++w) {
+            CHECK(s.bm[w] == 0ull);
+        }
+
+        for (size_t i = 0; i < kSeedCount; ++i) {
+            CHECK_RES(check(&s, base - kSeedOffsets[i]), NONCE_OUT_OF_WINDOW);
+        }
+        // The whole new backward window is unseen except bit 0.
+        CHECK_RES(check(&s, base + d), NONCE_REPLAY);
+        for (uint64_t back = 1; back < OD_NONCE_BACKWARD_BITS; ++back) {
+            CHECK_RES(check(&s, (base + d) - back), NONCE_OK);
+        }
+    }
+    clear_context();
+}
+
+// ---------------------------------------------------------------------------
+// Decision D coverage: bit index correctness after a forward commit
+//
+// Direct statement of the shift invariant, below the od_nonce_check layer: the
+// bit that denoted counter (L - i) under last_seen = L must denote exactly the
+// same counter under L' = L + d, i.e. it must sit at index i + d. Bits pushed to
+// index >= OD_NONCE_BACKWARD_BITS are gone.
+// ---------------------------------------------------------------------------
+
+static void test_bit_indices_after_shift(void) {
+    const uint64_t base = 1000000u;
+    const uint64_t deltas[] = {1, 63, 64, 65, 127};
+
+    for (size_t k = 0; k < sizeof(deltas) / sizeof(deltas[0]); ++k) {
+        const uint64_t d = deltas[k];
+        NonceState s;
+        seed_window(&s, base);
+
+        bool before[OD_NONCE_BACKWARD_BITS];
+        for (uint64_t i = 0; i < OD_NONCE_BACKWARD_BITS; ++i) {
+            before[i] = od_nonce_bit_test(s.bm, i);
+        }
+
+        commit(&s, base + d);
+
+        for (uint64_t i = 0; i < OD_NONCE_BACKWARD_BITS; ++i) {
+            set_context("bit index d=%" PRIu64 ", old index %" PRIu64, d, i);
+            if (i + d < OD_NONCE_BACKWARD_BITS) {
+                // Same counter, new index.
+                CHECK(od_nonce_bit_test(s.bm, i + d) == before[i]);
+            }
+            // The vacated low bits are all clear except bit 0, which the commit set.
+            if (i < d) {
+                CHECK(od_nonce_bit_test(s.bm, i) == (i == 0));
+            }
+        }
+        clear_context();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decision D coverage: counter arithmetic [M1]
+//
+// Expectations here are derived from the modular definition in the header, not
+// from intuition about "before" and "after":
+//   fwd  = counter - last_seen  (mod 2^64)
+//   back = last_seen - counter  (mod 2^64)
+// and the ordered tests fwd == 0, fwd <= CAP, back < BITS, else OUT_OF_WINDOW.
+// UBSan makes the whole file self-checking against the signed formulation, in
+// which these same inputs are undefined (int64_t conversion of values >= 2^63,
+// signed overflow, negating INT64_MIN).
+// ---------------------------------------------------------------------------
+
+static void test_counter_arithmetic_extremes(void) {
+    const uint64_t two63 = 1ull << 63;
+
+    // counter = 2^63, last_seen = 1. The input that makes the signed form UB.
+    //   fwd  = 2^63 - 1  -> > CAP
+    //   back = 1 - 2^63  = 2^63 + 1 -> >= BITS
+    // so it is out of the window in both directions, which is the only sane
+    // answer for a counter half the space away.
+    {
+        NonceState s;
+        state_reset(&s, 1);
+        CHECK(two63 - 1u > (uint64_t)OD_NONCE_FORWARD_CAP);
+        CHECK(1u - two63 == two63 + 1u);
+        CHECK_RES(check(&s, two63), NONCE_OUT_OF_WINDOW);
+    }
+    // The mirror image: last_seen = 2^63, counter = 1.
+    {
+        NonceState s;
+        state_reset(&s, two63);
+        CHECK_RES(check(&s, 1), NONCE_OUT_OF_WINDOW);
+    }
+    // And 2^63 apart in the other direction, from a high last_seen.
+    {
+        NonceState s;
+        state_reset(&s, UINT64_MAX);
+        CHECK_RES(check(&s, UINT64_MAX + two63), NONCE_OUT_OF_WINDOW);
+        CHECK_RES(check(&s, UINT64_MAX - two63), NONCE_OUT_OF_WINDOW);
+    }
+
+    // Near UINT64_MAX, including the wrap past it. last_seen = UINT64_MAX - 2.
+    {
+        const uint64_t L = UINT64_MAX - 2u;
+        NonceState s;
+        state_reset(&s, L);
+
+        CHECK_RES(check(&s, L), NONCE_OK);  // fwd == 0, bit 0 clear
+        commit(&s, L);
+        CHECK_RES(check(&s, L), NONCE_REPLAY);
+
+        // Forward, no wrap yet.
+        CHECK_RES(check(&s, UINT64_MAX - 1u), NONCE_OK);  // fwd == 1
+        CHECK_RES(check(&s, UINT64_MAX), NONCE_OK);       // fwd == 2
+        // Forward, wrapping past UINT64_MAX. fwd = 0 - (2^64 - 3) = 3.
+        CHECK(0u - L == 3u);
+        CHECK_RES(check(&s, 0), NONCE_OK);
+        CHECK(1u - L == 4u);
+        CHECK_RES(check(&s, 1), NONCE_OK);
+        // Still forward at the cap, wrapped.
+        CHECK_RES(check(&s, L + (uint64_t)OD_NONCE_FORWARD_CAP), NONCE_OK);
+        CHECK_RES(check(&s, L + (uint64_t)OD_NONCE_FORWARD_CAP + 1u), NONCE_OUT_OF_WINDOW);
+        // Backward across the low end of the space: L - 1 == UINT64_MAX - 3.
+        CHECK_RES(check(&s, L - 1u), NONCE_OK);
+        CHECK_RES(check(&s, L - (uint64_t)(OD_NONCE_BACKWARD_BITS - 1)), NONCE_OK);
+        CHECK_RES(check(&s, L - (uint64_t)OD_NONCE_BACKWARD_BITS), NONCE_OUT_OF_WINDOW);
+
+        // Accept a wrapped counter and slide the window across the wrap point.
+        CHECK_RES(check_and_commit(&s, 1), NONCE_OK);
+        CHECK(s.last_seen == 1u);
+
+        // The pre-wrap counter L is now back = 1 - L = 4 behind, and is recorded.
+        CHECK(1u - L == 4u);
+        CHECK_RES(check(&s, L), NONCE_REPLAY);
+        // Its never-committed neighbours across the wrap are unseen.
+        CHECK_RES(check(&s, UINT64_MAX - 1u), NONCE_OK);  // back == 3
+        CHECK_RES(check(&s, UINT64_MAX), NONCE_OK);       // back == 2
+        CHECK_RES(check(&s, 0), NONCE_OK);                // back == 1
+        CHECK_RES(check(&s, 1), NONCE_REPLAY);            // fwd == 0, committed
+
+        // The backward window reaches BITS-1 below zero and stops there.
+        CHECK_RES(check(&s, 1u - (uint64_t)(OD_NONCE_BACKWARD_BITS - 1)), NONCE_OK);
+        CHECK_RES(check(&s, 1u - (uint64_t)OD_NONCE_BACKWARD_BITS), NONCE_OUT_OF_WINDOW);
+
+        // Commit a backward, wrapped counter and read it back.
+        CHECK_RES(check_and_commit(&s, UINT64_MAX), NONCE_OK);
+        CHECK(s.last_seen == 1u);  // backward commits do not move last_seen
+        CHECK_RES(check(&s, UINT64_MAX), NONCE_REPLAY);
+        CHECK_RES(check(&s, UINT64_MAX - 1u), NONCE_OK);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decision D coverage: differential / property test against a naive oracle
+//
+// The oracle is the obvious-but-unshippable implementation: the exact set of
+// counters consumed, plus last_seen. It reproduces od_nonce_check's decision
+// directly from the definition, and prunes counters that have fallen out of the
+// backward window when last_seen advances — that pruning is what makes it agree
+// on REPLAY versus OUT_OF_WINDOW rather than only on accept versus reject.
+//
+// Counters stay far from 0 and from 2^64 so the oracle needs no wrap handling;
+// the wrap cases are covered exhaustively by test_counter_arithmetic_extremes().
+// ---------------------------------------------------------------------------
+
+struct Oracle {
+    std::set<uint64_t> seen;
+    uint64_t last_seen;
+};
+
+static NonceResult oracle_check(const Oracle& o, uint64_t counter) {
+    const uint64_t fwd = counter - o.last_seen;
+    const uint64_t back = o.last_seen - counter;
+    if (fwd == 0u) return o.seen.count(counter) ? NONCE_REPLAY : NONCE_OK;
+    if (fwd <= (uint64_t)OD_NONCE_FORWARD_CAP) return NONCE_OK;
+    if (back < (uint64_t)OD_NONCE_BACKWARD_BITS) {
+        return o.seen.count(counter) ? NONCE_REPLAY : NONCE_OK;
+    }
+    return NONCE_OUT_OF_WINDOW;
+}
+
+static void oracle_commit(Oracle* o, uint64_t counter) {
+    const uint64_t fwd = counter - o->last_seen;
+    const uint64_t back = o->last_seen - counter;
+    if (fwd == 0u) {
+        o->seen.insert(counter);
+        return;
+    }
+    if (back < (uint64_t)OD_NONCE_BACKWARD_BITS) {
+        o->seen.insert(counter);
+        return;
+    }
+    // Forward: the window slides, and everything now at or past the far edge is
+    // forgotten — exactly the bits the shift pushes off the end of the bitmap.
+    o->last_seen = counter;
+    o->seen.insert(counter);
+    while (!o->seen.empty() &&
+           (o->last_seen - *o->seen.begin()) >= (uint64_t)OD_NONCE_BACKWARD_BITS) {
+        o->seen.erase(o->seen.begin());
+    }
+}
+
+static void test_differential_against_oracle(void) {
+    std::mt19937_64 rng(0xD15EA5EULL);  // fixed seed: this test must be reproducible
+
+    const int kSequences = 40;
+    const int kStepsPerSequence = 200;
+
+    for (int seq = 0; seq < kSequences; ++seq) {
+        const uint64_t base = (1ull << 40) + (uint64_t)seq * 4096u;
+
+        NonceState s;
+        state_reset(&s, base);
+        Oracle o;
+        o.last_seen = base;
+
+        for (int step = 0; step < kStepsPerSequence; ++step) {
+            const unsigned bucket = (unsigned)(rng() % 100u);
+            uint64_t counter;
+            if (bucket < 40u) {
+                // Forward inside the cap, including fwd == 0 (a replay probe).
+                counter = s.last_seen + (rng() % (uint64_t)(OD_NONCE_FORWARD_CAP + 1));
+            } else if (bucket < 60u) {
+                // Forward past the cap: a gap too large to accept.
+                counter = s.last_seen + (uint64_t)OD_NONCE_FORWARD_CAP + 1u +
+                          (rng() % 1000u);
+            } else if (bucket < 90u) {
+                // Backward inside or just outside the window.
+                counter = s.last_seen - (1u + rng() % (uint64_t)(OD_NONCE_BACKWARD_BITS + 64));
+            } else {
+                // Far behind.
+                counter = s.last_seen - (uint64_t)OD_NONCE_BACKWARD_BITS -
+                          (rng() % 100000u);
+            }
+
+            set_context("differential seq=%d step=%d counter=%" PRIu64
+                        " last_seen=%" PRIu64,
+                        seq, step, counter, s.last_seen);
+
+            const NonceResult got = check(&s, counter);
+            const NonceResult want = oracle_check(o, counter);
+            CHECK_RES(got, want);
+            CHECK(o.last_seen == s.last_seen);
+
+            if (got == NONCE_OK) {
+                commit(&s, counter);
+                oracle_commit(&o, counter);
+                CHECK(o.last_seen == s.last_seen);
+            }
+        }
+
+        // End of sequence: sweep the entire backward window and compare, so that
+        // any bit the two models disagree about is caught even if the random
+        // walk never probed it.
+        for (uint64_t back = 0; back < (uint64_t)OD_NONCE_BACKWARD_BITS + 8u; ++back) {
+            const uint64_t counter = s.last_seen - back;
+            set_context("differential sweep seq=%d back=%" PRIu64, seq, back);
+            CHECK_RES(check(&s, counter), oracle_check(o, counter));
+        }
+    }
+    clear_context();
+}
+
+// ---------------------------------------------------------------------------
+
+int main(void) {
+    test_fresh_session();
+    test_d3_same_counter_replay();
+    test_check_is_pure();
+    test_shift_edges();
+    test_wholesale_slide();
+    test_bit_indices_after_shift();
+    test_counter_arithmetic_extremes();
+    test_differential_against_oracle();
+
+    if (g_failures != 0u) {
+        std::printf("FAILED %lu of %lu checks\n", g_failures, g_checks);
+        return EXIT_FAILURE;
+    }
+    std::printf("PASSED %lu checks\n", g_checks);
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Phase 1 of the freeze-proofing work: nonce/replay correctness on the BLE session layer, plus a guard against a client that floods gated commands into a dead session.

## Nonce / replay

- **Sliding-window replay detection.** Replaces the 512 B ring of seen nonce values with a 32 B sliding bitmap (`src/nonce_window.h`). Same coverage, 16x less RAM, and it no longer degrades into false rejections when frames arrive out of order.
- **Check split from commit.** `nonceCheck()` is pure and writes nothing to the session; only a frame that passes the CCM tag advances replay state. Previously an unverified frame could move the window.
- **Packet loss is no longer treated as tampering.** Nonce rejections (out-of-window, replay, bad session) no longer count toward `integrity_failures`. Only a CCM tag failure is tamper evidence. On a lossy link the old behaviour cleared the session after three dropped frames.
- **A nonce-dropped `0x0081` pipe frame is answered with silence, not a fatal NACK.** The pipe spec reserves NACKs for unrecoverable conditions and makes an `0x0081` NACK unconditionally fatal; answering one for ordinary loss killed the whole upload on the first dropped frame. The seq simply falls out of the next SACK mask and the client retransmits.
- **A session-id mismatch is answered with `RESP_AUTH_REQUIRED`, not a fatal NACK.** A stale client and a device that re-authenticated cannot resolve the disagreement by retrying — only by re-authenticating. Previously the device answered `0xFF` forever while the client fell back to plaintext uploads.
- Rate-limited, readable nonce logging, with separate budgets per site so a stale client spamming session-id mismatches cannot silence the out-of-window line.

Host test for the window state machine (`tools/test_nonce_window.cpp`) plus a separate CI job to run it.

Code only — the working design/investigation notes that drove this work are kept out of the branch.

## Unauthenticated-command guard

The encryption gate answers every gated frame sent without a usable session with `RESP_AUTH_REQUIRED` and had no counter of its own, so a client that ignores `0xFE` drove one response plus one unrate-limited error line per frame, indefinitely. Observed in the field: a client took `00 70 FE` for a `DIRECT_WRITE_START` and streamed its `0x0071` image data anyway, ~100 ms apart, until it ran out of image.

Ten consecutive `0xFE` answers now drop the BLE link, forcing a fresh connect + `CMD_AUTHENTICATE` handshake.

- **Ten, not three** — a legitimate client may probe several gated commands before it authenticates (the trace above shows `0x0040`, `0x0044`, `0x0070` first), and ten matches the existing 10-per-60s cap on `CMD_AUTHENTICATE`. It is a count, not a rate.
- **Consecutive** — any frame that clears the gate resets it, as does a successful handshake.
- **BLE only** — `encryptionSession` is one global shared with LAN, so counting a LAN peer's rejections would let it cost an unrelated BLE client its link.
- **Per-target teardown strategy.** On ESP32 the drop is deferred to `loop()` and runs after the response queue drains, so the final `0xFE` is not stranded. On nRF the dispatch *is* the Bluefruit event-task write callback, which outranks the Arduino loop task — measured on hardware, `loop()` is not scheduled at all while a client floods frames mid-transfer, so the drop happens inline there. nRF notifies responses directly with no ring to drain, and `Bluefruit.disconnect()` only asks the SoftDevice to tear down, so the callback is not unwound underneath us.

## Testing

- All twelve PlatformIO environments build clean.
- Host test for the nonce window passes.
- Guard verified on nRF52840 and ESP32 hardware: the link drops mid-burst, and the client recovers by reconnecting and re-authenticating.

## Note

PR #84 (`balloob:fix/aes-ccm-nonce-direction-and-replay`) touches the same subsystem. These will need to be reconciled — this branch does not include the nonce direction-bit change.
