### PR TITLE
ci: build release targets from a shared matrix manifest

### DIFF
--- a/.github/firmware-targets.json
+++ b/.github/firmware-targets.json
@@ -1,0 +1,115 @@
+{
+  "$comment": [
+    "Single source of truth for the firmware build targets.",
+    "Consumed by both .github/workflows/main.yaml (CI) and .github/workflows/release.yml",
+    "(release artifacts) via fromJSON, so the two can never disagree about which targets",
+    "exist or how they are packaged.",
+    "",
+    "Adding a board = adding an entry here. Nothing else needs to change.",
+    "",
+    "Fields (esp32 family):",
+    "  chip              - esptool --chip value. NOT derivable from the env name.",
+    "  flash_size        - esptool --flash_size; matches board_upload.flash_size in platformio.ini.",
+    "  flash_mode/freq   - baked into the merged image header by esptool merge_bin.",
+    "  bootloader_offset - 0x0000 on S3/C3/C6; 0x1000 on the classic ESP32.",
+    "",
+    "Debug-only envs in platformio.ini (e.g. esp32-s3-N16R8-extuart-debug) are deliberately",
+    "absent: this file lists what ships."
+  ],
+  "targets": [
+    {
+      "env": "nrf52840custom",
+      "family": "nrf52"
+    },
+    {
+      "env": "esp32-s3-N16R8",
+      "family": "esp32",
+      "chip": "esp32-s3",
+      "flash_size": "16MB",
+      "flash_mode": "dio",
+      "flash_freq": "80m",
+      "bootloader_offset": "0x0000"
+    },
+    {
+      "env": "esp32-s3-N16R8-extuart",
+      "family": "esp32",
+      "chip": "esp32-s3",
+      "flash_size": "16MB",
+      "flash_mode": "dio",
+      "flash_freq": "80m",
+      "bootloader_offset": "0x0000"
+    },
+    {
+      "env": "esp32-s3-N8R8",
+      "family": "esp32",
+      "chip": "esp32-s3",
+      "flash_size": "8MB",
+      "flash_mode": "dio",
+      "flash_freq": "80m",
+      "bootloader_offset": "0x0000"
+    },
+    {
+      "env": "esp32-s3-N32R8",
+      "family": "esp32",
+      "chip": "esp32-s3",
+      "flash_size": "32MB",
+      "flash_mode": "dio",
+      "flash_freq": "80m",
+      "bootloader_offset": "0x0000"
+    },
+    {
+      "env": "esp32-s3-N32R8-extuart",
+      "family": "esp32",
+      "chip": "esp32-s3",
+      "flash_size": "32MB",
+      "flash_mode": "dio",
+      "flash_freq": "80m",
+      "bootloader_offset": "0x0000"
+    },
+    {
+      "env": "esp32-s3-E1004",
+      "family": "esp32",
+      "chip": "esp32-s3",
+      "flash_size": "32MB",
+      "flash_mode": "dio",
+      "flash_freq": "80m",
+      "bootloader_offset": "0x0000"
+    },
+    {
+      "env": "esp32-c6-N4",
+      "family": "esp32",
+      "chip": "esp32-c6",
+      "flash_size": "4MB",
+      "flash_mode": "dio",
+      "flash_freq": "80m",
+      "bootloader_offset": "0x0000"
+    },
+    {
+      "env": "esp32-c3-N4",
+      "family": "esp32",
+      "chip": "esp32-c3",
+      "flash_size": "4MB",
+      "flash_mode": "dio",
+      "flash_freq": "80m",
+      "bootloader_offset": "0x0000"
+    },
+    {
+      "env": "esp32-c3-N16",
+      "family": "esp32",
+      "chip": "esp32-c3",
+      "flash_size": "16MB",
+      "flash_mode": "dio",
+      "flash_freq": "80m",
+      "bootloader_offset": "0x0000"
+    },
+    {
+      "env": "esp32-N4",
+      "family": "esp32",
+      "chip": "esp32",
+      "flash_size": "4MB",
+      "flash_mode": "dio",
+      "flash_freq": "40m",
+      "bootloader_offset": "0x1000"
+    }
+  ]
+}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,24 +4,36 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
-  build:
+  # The environment list lives in .github/firmware-targets.json, shared with
+  # release.yml. Keeping one list means CI can't build a target the release
+  # forgets to ship (which is how esp32-N4 went unreleased) or vice versa.
+  targets:
+    name: Load targets
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      environments: ${{ steps.load.outputs.environments }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: load
+        run: |
+          set -euo pipefail
+          envs=$(jq -c '[.targets[].env]' .github/firmware-targets.json)
+          echo "environments=${envs}" >> "${GITHUB_OUTPUT}"
+          echo "Building: $(echo "${envs}" | jq -r 'join(", ")')"
+
+  build:
+    needs: targets
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        environment:
-          - nrf52840custom
-          - esp32-s3-N16R8
-          - esp32-s3-N8R8
-          - esp32-s3-N32R8
-          - esp32-s3-N32R8-extuart
-          - esp32-s3-N16R8-extuart
-          - esp32-s3-E1004
-          - esp32-c3-N4
-          - esp32-c3-N16
-          - esp32-c6-N4
-          - esp32-N4
+        environment: ${{ fromJSON(needs.targets.outputs.environments) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -37,8 +49,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      # Pinned to the same Core version release.yml uses. Unpinned here, CI can
+      # pass on a different Core than the one that builds the release — the
+      # exact split that broke the C3/C6 builds when the ESP platform was
+      # floating on `stable` (see the 55.03.39 pin in platformio.ini).
+      # Bump deliberately, together with release.yml.
       - name: Install PlatformIO Core
-        run: pip install --upgrade platformio
+        run: pip install platformio==6.1.19
 
       - name: Build ${{ matrix.environment }}
         run: platformio run --environment ${{ matrix.environment }}

--- a/.github/workflows/release-legacy.yml
+++ b/.github/workflows/release-legacy.yml
@@ -1,0 +1,206 @@
+# ARM A of the Phase A A/B test — TEMPORARY, delete before merging.
+#
+# This is release.yml exactly as it stands on OpenDisplay/Firmware @ 2.25.1,
+# with three mechanical changes so it can be dispatched against the same source
+# and the same version string as the new matrix workflow:
+#   1. workflow_dispatch(tag) instead of only release:published
+#   2. checkout pinned to that tag
+#   3. BUILD_VERSION from that tag instead of github.ref_name
+#      (github.ref_name would be the branch under dispatch, which would bake a
+#       different version string into the binaries and invalidate the diff)
+# Nothing else is touched — no pins, no caching, no chip/flash parameters.
+name: Release Firmware (legacy, A/B arm A)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build"
+        required: true
+        type: string
+
+jobs:
+  build-and-upload:
+    name: Build & Upload Firmware
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Install PlatformIO & Tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install platformio
+          pip install esptool
+          pip install --upgrade intelhex
+          pip install adafruit-nrfutil
+          curl -L https://raw.githubusercontent.com/microsoft/uf2/master/utils/uf2conv.py -o uf2conv.py
+          curl -L https://raw.githubusercontent.com/microsoft/uf2/master/utils/uf2families.json -o uf2families.json
+          chmod +x uf2conv.py
+
+      - name: Build & Package NRF Firmware
+        run: |
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ inputs.tag }}\" -D SHA=$GITHUB_SHA"
+          pio run --environment nrf52840custom 
+          mkdir firmware_output
+          cp .pio/build/nrf52840custom/firmware.hex firmware_output/NRF52840.hex
+          TAG_NAME=${{ inputs.tag }}
+          adafruit-nrfutil dfu genpkg --dev-type 0x0052 --application firmware_output/NRF52840.hex firmware_output/NRF52840.zip
+          python uf2conv.py firmware_output/NRF52840.hex --family 0xADA52840 --output firmware_output/NRF52840.uf2
+
+      - name: Build & Package esp32-s3-N16R8 Firmware
+        run: |
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ inputs.tag }}\" -D SHA=$GITHUB_SHA"
+          pioenv=esp32-s3-N16R8
+          pio run --environment ${pioenv}
+          mkdir ${pioenv}
+          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
+          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
+          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
+          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
+          cd ${pioenv}
+          esptool.py --chip esp32-s3 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 16MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
+          cd ..
+          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
+          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
+
+      - name: Build & Package esp32-s3-N16R8-extuart Firmware
+        run: |
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ inputs.tag }}\" -D SHA=$GITHUB_SHA"
+          pioenv=esp32-s3-N16R8-extuart
+          pio run --environment ${pioenv}
+          mkdir ${pioenv}
+          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
+          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
+          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
+          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
+          cd ${pioenv}
+          esptool.py --chip esp32-s3 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 16MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
+          cd ..
+          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
+          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
+
+      - name: Build & Package esp32-s3-N8R8 Firmware
+        run: |
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ inputs.tag }}\" -D SHA=$GITHUB_SHA"
+          pioenv=esp32-s3-N8R8
+          pio run --environment ${pioenv}
+          mkdir ${pioenv}
+          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
+          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
+          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
+          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
+          cd ${pioenv}
+          esptool.py --chip esp32-s3 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 8MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
+          cd ..
+          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
+          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
+
+      - name: Build & Package esp32-s3-N32R8 Firmware
+        run: |
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ inputs.tag }}\" -D SHA=$GITHUB_SHA"
+          pioenv=esp32-s3-N32R8
+          pio run --environment ${pioenv}
+          mkdir ${pioenv}
+          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
+          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
+          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
+          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
+          cd ${pioenv}
+          esptool.py --chip esp32-s3 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 32MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
+          cd ..
+          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
+          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
+
+      - name: Build & Package esp32-s3-N32R8-extuart Firmware
+        run: |
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ inputs.tag }}\" -D SHA=$GITHUB_SHA"
+          pioenv=esp32-s3-N32R8-extuart
+          pio run --environment ${pioenv}
+          mkdir ${pioenv}
+          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
+          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
+          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
+          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
+          cd ${pioenv}
+          esptool.py --chip esp32-s3 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 32MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
+          cd ..
+          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
+          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
+
+      - name: Build & Package esp32-s3-E1004 Firmware
+        run: |
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ inputs.tag }}\" -D SHA=$GITHUB_SHA"
+          pioenv=esp32-s3-E1004
+          pio run --environment ${pioenv}
+          mkdir ${pioenv}
+          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
+          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
+          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
+          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
+          cd ${pioenv}
+          esptool.py --chip esp32-s3 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 32MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
+          cd ..
+          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
+          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
+          
+      - name: Build & Package esp32-c6-N4 Firmware
+        run: |
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ inputs.tag }}\" -D SHA=$GITHUB_SHA"
+          pioenv=esp32-c6-N4
+          pio run --environment ${pioenv}
+          mkdir ${pioenv}
+          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
+          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
+          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
+          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
+          cd ${pioenv}
+          esptool.py --chip esp32-c6 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 4MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
+          cd ..
+          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
+          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
+
+      - name: Build & Package esp32-c3-N4 Firmware
+        run: |
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ inputs.tag }}\" -D SHA=$GITHUB_SHA"
+          pioenv=esp32-c3-N4
+          pio run --environment ${pioenv}
+          mkdir ${pioenv}
+          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
+          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
+          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
+          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
+          cd ${pioenv}
+          esptool.py --chip esp32-c6 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 4MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
+          cd ..
+          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
+          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
+          
+      - name: Build & Package esp32-c3-N16 Firmware
+        run: |
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ inputs.tag }}\" -D SHA=$GITHUB_SHA"
+          pioenv=esp32-c3-N16
+          pio run --environment ${pioenv}
+          mkdir ${pioenv}
+          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
+          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
+          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
+          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
+          cd ${pioenv}
+          esptool.py --chip esp32-c3 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 16MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
+          cd ..
+          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
+          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
+
+      # A/B change: emit artifacts instead of publishing to a release, so arm A
+      # produces a downloadable set to diff against arm B without touching any
+      # release on the fork.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: armA-legacy
+          path: firmware_output/*
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,186 +3,230 @@ name: Release Firmware
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build and attach assets to (e.g. 2.25.1)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ inputs.tag || github.event.release.tag_name }}
+  cancel-in-progress: false
 
 jobs:
-  build-and-upload:
-    name: Build & Upload Firmware
+  prepare:
+    name: Resolve tag & targets
     runs-on: ubuntu-latest
-
+    timeout-minutes: 5
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      esp32: ${{ steps.targets.outputs.esp32 }}
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-
-      - name: Install PlatformIO & Tools
+      - name: Resolve tag
+        id: tag
+        env:
+          # `release` and `workflow_dispatch` carry the tag in different places.
+          # Resolve it once here so no downstream job has to care which fired.
+          TAG: ${{ inputs.tag || github.event.release.tag_name }}
         run: |
+          set -euo pipefail
+          if [[ -z "${TAG}" ]]; then
+            echo "::error::No tag could be resolved from the triggering event"
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+          echo "Building tag ${TAG}"
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - name: Load esp32 targets
+        id: targets
+        run: |
+          set -euo pipefail
+          esp32=$(jq -c '[.targets[] | select(.family == "esp32")]' .github/firmware-targets.json)
+          echo "esp32=${esp32}" >> "${GITHUB_OUTPUT}"
+          echo "esp32 targets: $(echo "${esp32}" | jq -r '[.[].env] | join(", ")')"
+
+  build-nrf52840:
+    name: Build nrf52840custom
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio-nrf52840custom-${{ hashFiles('platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pio-nrf52840custom-
+            ${{ runner.os }}-pio-
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # Versions are pinned so two builds of the same tag produce the same
+      # binaries. Unpinned, a toolchain release silently changes shipped
+      # firmware between a release and a later re-run of it.
+      - name: Install toolchain
+        run: |
+          set -euo pipefail
           python -m pip install --upgrade pip
-          pip install platformio
-          pip install esptool
-          pip install --upgrade intelhex
-          pip install adafruit-nrfutil
-          curl -L https://raw.githubusercontent.com/microsoft/uf2/master/utils/uf2conv.py -o uf2conv.py
-          curl -L https://raw.githubusercontent.com/microsoft/uf2/master/utils/uf2families.json -o uf2families.json
+          pip install platformio==6.1.19 adafruit-nrfutil==0.5.3.post16 intelhex==2.3.0
+
+      - name: Fetch uf2conv
+        env:
+          # Pinned to a commit: this runs in the release path, and `master` is
+          # someone else's branch.
+          UF2_REF: 90e9741f217f5a40c98ba74d663e408041037578
+        run: |
+          set -euo pipefail
+          base="https://raw.githubusercontent.com/microsoft/uf2/${UF2_REF}/utils"
+          curl -fsSL "${base}/uf2conv.py" -o uf2conv.py
+          curl -fsSL "${base}/uf2families.json" -o uf2families.json
           chmod +x uf2conv.py
 
-      - name: Build & Package NRF Firmware
+      - name: Build & package
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
         run: |
-          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ github.ref_name }}\" -D SHA=$GITHUB_SHA"
-          pio run --environment nrf52840custom 
-          mkdir firmware_output
+          set -euo pipefail
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${TAG}\" -D SHA=${GITHUB_SHA}"
+          pio run --environment nrf52840custom
+          mkdir -p firmware_output
           cp .pio/build/nrf52840custom/firmware.hex firmware_output/NRF52840.hex
-          TAG_NAME=${{ github.event.release.tag_name }}
-          adafruit-nrfutil dfu genpkg --dev-type 0x0052 --application firmware_output/NRF52840.hex firmware_output/NRF52840.zip
-          python uf2conv.py firmware_output/NRF52840.hex --family 0xADA52840 --output firmware_output/NRF52840.uf2
+          adafruit-nrfutil dfu genpkg --dev-type 0x0052 \
+            --application firmware_output/NRF52840.hex firmware_output/NRF52840.zip
+          python uf2conv.py firmware_output/NRF52840.hex \
+            --family 0xADA52840 --output firmware_output/NRF52840.uf2
 
-      - name: Build & Package esp32-s3-N16R8 Firmware
-        run: |
-          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ github.ref_name }}\" -D SHA=$GITHUB_SHA"
-          pioenv=esp32-s3-N16R8
-          pio run --environment ${pioenv}
-          mkdir ${pioenv}
-          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
-          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
-          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
-          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
-          cd ${pioenv}
-          esptool.py --chip esp32-s3 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 16MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
-          cd ..
-          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
-          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
+      - uses: actions/upload-artifact@v4
+        with:
+          name: firmware-nrf52840custom
+          path: firmware_output/*
+          retention-days: 7
+          if-no-files-found: error
 
-      - name: Build & Package esp32-s3-N16R8-extuart Firmware
-        run: |
-          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ github.ref_name }}\" -D SHA=$GITHUB_SHA"
-          pioenv=esp32-s3-N16R8-extuart
-          pio run --environment ${pioenv}
-          mkdir ${pioenv}
-          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
-          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
-          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
-          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
-          cd ${pioenv}
-          esptool.py --chip esp32-s3 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 16MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
-          cd ..
-          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
-          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
+  build-esp32:
+    name: Build ${{ matrix.target.env }}
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.prepare.outputs.esp32) }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
 
-      - name: Build & Package esp32-s3-N8R8 Firmware
-        run: |
-          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ github.ref_name }}\" -D SHA=$GITHUB_SHA"
-          pioenv=esp32-s3-N8R8
-          pio run --environment ${pioenv}
-          mkdir ${pioenv}
-          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
-          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
-          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
-          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
-          cd ${pioenv}
-          esptool.py --chip esp32-s3 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 8MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
-          cd ..
-          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
-          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio-${{ matrix.target.env }}-${{ hashFiles('platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pio-${{ matrix.target.env }}-
+            ${{ runner.os }}-pio-
 
-      - name: Build & Package esp32-s3-N32R8 Firmware
-        run: |
-          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ github.ref_name }}\" -D SHA=$GITHUB_SHA"
-          pioenv=esp32-s3-N32R8
-          pio run --environment ${pioenv}
-          mkdir ${pioenv}
-          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
-          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
-          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
-          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
-          cd ${pioenv}
-          esptool.py --chip esp32-s3 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 32MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
-          cd ..
-          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
-          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
 
-      - name: Build & Package esp32-s3-N32R8-extuart Firmware
+      - name: Install toolchain
         run: |
-          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ github.ref_name }}\" -D SHA=$GITHUB_SHA"
-          pioenv=esp32-s3-N32R8-extuart
-          pio run --environment ${pioenv}
-          mkdir ${pioenv}
-          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
-          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
-          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
-          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
-          cd ${pioenv}
-          esptool.py --chip esp32-s3 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 32MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
-          cd ..
-          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
-          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          pip install platformio==6.1.19 esptool==5.3.1
 
-      - name: Build & Package esp32-s3-E1004 Firmware
+      - name: Build ${{ matrix.target.env }}
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+          PIOENV: ${{ matrix.target.env }}
         run: |
-          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ github.ref_name }}\" -D SHA=$GITHUB_SHA"
-          pioenv=esp32-s3-E1004
-          pio run --environment ${pioenv}
-          mkdir ${pioenv}
-          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
-          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
-          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
-          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
-          cd ${pioenv}
-          esptool.py --chip esp32-s3 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 32MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
-          cd ..
-          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
-          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
-          
-      - name: Build & Package esp32-c6-N4 Firmware
-        run: |
-          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ github.ref_name }}\" -D SHA=$GITHUB_SHA"
-          pioenv=esp32-c6-N4
-          pio run --environment ${pioenv}
-          mkdir ${pioenv}
-          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
-          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
-          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
-          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
-          cd ${pioenv}
-          esptool.py --chip esp32-c6 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 4MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
-          cd ..
-          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
-          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
+          set -euo pipefail
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${TAG}\" -D SHA=${GITHUB_SHA}"
+          pio run --environment "${PIOENV}"
 
-      - name: Build & Package esp32-c3-N4 Firmware
+      - name: Package ${{ matrix.target.env }}
+        env:
+          PIOENV: ${{ matrix.target.env }}
+          CHIP: ${{ matrix.target.chip }}
+          FLASH_SIZE: ${{ matrix.target.flash_size }}
+          FLASH_MODE: ${{ matrix.target.flash_mode }}
+          FLASH_FREQ: ${{ matrix.target.flash_freq }}
+          BOOTLOADER_OFFSET: ${{ matrix.target.bootloader_offset }}
         run: |
-          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ github.ref_name }}\" -D SHA=$GITHUB_SHA"
-          pioenv=esp32-c3-N4
-          pio run --environment ${pioenv}
-          mkdir ${pioenv}
-          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
-          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
-          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
-          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
-          cd ${pioenv}
-          esptool.py --chip esp32-c6 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 4MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
-          cd ..
-          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
-          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
-          
-      - name: Build & Package esp32-c3-N16 Firmware
-        run: |
-          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ github.ref_name }}\" -D SHA=$GITHUB_SHA"
-          pioenv=esp32-c3-N16
-          pio run --environment ${pioenv}
-          mkdir ${pioenv}
-          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
-          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
-          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
-          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
-          cd ${pioenv}
-          esptool.py --chip esp32-c3 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 16MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
-          cd ..
-          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
-          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
+          set -euo pipefail
+          build=".pio/build/${PIOENV}"
+          boot_app0="${HOME}/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin"
 
-      - name: Upload Release Assets
-        uses: svenstaro/upload-release-action@v2
+          mkdir -p staging firmware_output
+          cp "${boot_app0}"            staging/boot_app0.bin
+          cp "${build}/firmware.bin"   staging/firmware.bin
+          cp "${build}/bootloader.bin" staging/bootloader.bin
+          cp "${build}/partitions.bin" staging/partitions.bin
+
+          # merge_bin bakes flash mode/freq/size into the image header and places
+          # the bootloader at a chip-specific offset — 0x1000 on the classic
+          # ESP32, 0x0000 on S3/C3/C6. Both come from firmware-targets.json.
+          ( cd staging && esptool.py --chip "${CHIP}" merge_bin \
+              -o merged-firmware.bin \
+              --flash_mode "${FLASH_MODE}" \
+              --flash_freq "${FLASH_FREQ}" \
+              --flash_size "${FLASH_SIZE}" \
+              "${BOOTLOADER_OFFSET}" bootloader.bin \
+              0x8000 partitions.bin \
+              0xe000 boot_app0.bin \
+              0x10000 firmware.bin )
+
+          cp staging/firmware.bin        "firmware_output/${PIOENV}.bin"
+          cp staging/merged-firmware.bin "firmware_output/${PIOENV}_full.bin"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: firmware-${{ matrix.target.env }}
+          path: firmware_output/*
+          retention-days: 7
+          if-no-files-found: error
+
+  upload:
+    name: Upload release assets
+    needs: [prepare, build-nrf52840, build-esp32]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      # Depending on both build jobs means this runs only when every target
+      # succeeded, so a release can never end up with a partial asset set.
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: firmware-*
+          merge-multiple: true
+          path: firmware_output
+
+      - name: List assets
+        run: ls -la firmware_output
+
+      - uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: firmware_output/*
-          tag: ${{ github.ref }}
+          tag: ${{ needs.prepare.outputs.tag }}
           file_glob: true
           overwrite: true


### PR DESCRIPTION
Replaces the ten copy-pasted per-target build blocks in `release.yml` with a single matrix job driven by a new `.github/firmware-targets.json`, shared with `main.yaml` so CI and the release can no longer disagree about which targets exist or how they are packaged.

## Why: the duplication had already drifted twice

**`esp32-c3-N4` merged images were built with the wrong chip.** `release.yml` set `pioenv=esp32-c3-N4` but ran `esptool.py --chip esp32-c6 merge_bin`. That is not just a mislabel — byte `0x3` of the ESP32 image header packs flash size and flash *frequency*, and the frequency encoding is chip-specific:

| file | before | after |
|---|---|---|
| `esp32-c3-N4_full.bin` | `0x20` (4MB, **40 MHz**) | `0x2f` (4MB, 80 MHz) |
| `esp32-c3-N16_full.bin` | `0x4f` | `0x4f` (unchanged) |

So C3-N4 boards flashed with `_full.bin` have been running their SPI flash at half speed. The correct value now matches the sibling `esp32-c3-N16` target. Only the merged image was affected; the plain `.bin` comes straight from `pio run`.

**`esp32-N4` was never released.** It is in `platformio.ini` and in `main.yaml`, but `release.yml` built only 10 of the 11 targets, so plain ESP32-N4 boards got no release binaries at all. It is not a copy-paste of the others either: it is a classic ESP32, whose bootloader sits at **0x1000** rather than the 0x0000 used by S3/C3/C6, so `bootloader_offset` had to become per-target data.

## Also in here

- **Caching** of `~/.platformio/.cache` and `~/.cache/pip`, matching `main.yaml`; `release.yml` had none.
- **Pinned toolchain** — `platformio==6.1.19`, `esptool==5.3.1`, `adafruit-nrfutil`, `intelhex`, and `uf2conv.py` at a commit. Each is the version an unpinned install resolved to on the day 2.25.1 was built, so this preserves the current toolchain rather than moving it. `main.yaml` is pinned to the same Core so CI predicts the release.
- **`permissions`, `timeout-minutes`,** `actions/checkout@v6`.
- **Asset upload is gated on every target succeeding**, so a failed build can no longer leave a release with a partial asset set.

## Verification

A/B tested on a fork: the old workflow and the new matrix were run against the same commit, in the same window, and their artifacts diffed.

- Identical file sets apart from the new `esp32-N4` pair; identical sizes throughout; `NRF52840.hex` and `.uf2` byte-identical.
- Every ESP32 binary differs in ~68 bytes of ~1.5 MB (0.004%), confined to three regions: the `esp_app_desc_t` `time`/`date` fields, a short string, and `app_elf_sha256`. That is ESP-IDF build-timestamp non-determinism, not this change. In each `_full.bin` those regions sit at the `.bin` offsets +0x10000, confirming `merge_bin` is a faithful concatenation.
- `esp32-c3-N4_full.bin` is the sole file with *extra* differing regions — the header fix above.
- `esp32-N4_full.bin` verified structurally: `0xFF` padding through `0x0-0xFFF`, bootloader magic `0xE9` at `0x1000`.

Wall clock went from 11m25s (serial) to 3m45s (parallel), while building one more target.

## Not changed, deliberately

Six envs set `board_build.flash_mode=qio` in `platformio.ini`, but the workflow has always passed `--flash_mode dio`. That is preserved as-is: changing it would alter bytes for six targets with no hardware validation. Worth a separate look.

`esp32-N4` has never been flashed to hardware — its parameters are correct by documentation, but it deserves one test flash before a release ships it.