### PR TITLE
Add support for Inkplate 5V2 and 10 parallel boards

### DIFF
--- a/include/opendisplay_structs.h
+++ b/include/opendisplay_structs.h
@@ -671,7 +671,9 @@ enum PanelIC {
     OD_PANEL_IC_SSD1619_022_LITE_BW      = 1029, /**< @doc "SSD1619 M3 Lite 2.2\" 250x128 B/W" */
     OD_PANEL_IC_SSD1619_022_LITE_BWR     = 1030, /**< @doc "SSD1619 M3 Lite 2.2\" 250x128 B/W/R" */
     OD_PANEL_IC_ED103TC2_1872X1404       = 3000, /**< @doc "E Ink ED103TC2 + IT8951 (10.3\", 1872x1404, 1bpp; FastEPD IT8951 path, values 3000+)" */
-    OD_PANEL_IC_ED103TC2_1872X1404_4GRAY = 3001 /**< @doc "same panel as 3000; 4bpp (16-level gray via FastEPD)" */
+    OD_PANEL_IC_ED103TC2_1872X1404_4GRAY = 3001, /**< @doc "same panel as 3000; 4bpp (16-level gray via FastEPD)" */
+    OD_PANEL_IC_INKPLATE5V2_1280X720     = 3002, /**< @doc "Soldered Inkplate 5 V2 (ED050WROW, 1280x720, 1bpp; FastEPD native parallel path)" */
+    OD_PANEL_IC_INKPLATE10_1200X825      = 3003  /**< @doc "Soldered Inkplate 10 (ED097TC2, 1200x825, 1bpp; FastEPD native parallel path)" */
 };
 
 /* DisplayConfig.transmission_modes @bits TransmissionModes (bits 5-6 reserved --

--- a/platformio.ini
+++ b/platformio.ini
@@ -243,6 +243,32 @@ board_upload.maximum_ram_size = 327680
 board_upload.flash_size = 16MB
 monitor_speed = 115200
 
+[env:esp32-wrover-e-N4R8]
+platform = espressif32
+framework = arduino
+lib_deps =
+  ${env.lib_deps}
+  bitbank2/FastEPD@^2.2.0
+build_flags =
+  -DTARGET_ESP32
+  -DPIPE_SMALL_DRAM_WINDOW
+  -DOPENDISPLAY_ZLIB_USE_HEAP_WINDOW=1
+  -DBOARD_HAS_PSRAM
+  -mfix-esp32-psram-cache-issue
+  -mfix-esp32-psram-cache-strategy=memw
+  -DCONFIG_FREERTOS_WATCHDOG_TIMEOUT_S=120
+  -DOPENDISPLAY_FASTEPD
+  -Wl,--allow-multiple-definition
+board_build.filesystem = littlefs
+board = esp-wrover-kit
+board_build.partitions = huge_app.csv
+board_build.flash_mode = dio
+board_build.flash_size = 4MB
+board_upload.flash_size = 4MB
+board_upload.maximum_size = 4194304
+board_upload.maximum_ram_size = 327680
+monitor_speed = 115200
+
 [env:esp32-N4]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
 framework = arduino

--- a/src/display_fastepd.cpp
+++ b/src/display_fastepd.cpp
@@ -25,6 +25,21 @@ public:
     FASTEPDSTATE* state() { return &_state; }
 };
 
+// OpenDisplay panel_ic_type -> FastEPD native parallel panel id (-1 if not a
+// parallel panel). FastEPD owns the Inkplate bus/PMIC/IO-expanders internally.
+static int fastepd_parallel_panel(uint16_t panel_ic_type) {
+    switch (panel_ic_type) {
+        case OD_PANEL_IC_INKPLATE5V2_1280X720:   return BB_PANEL_INKPLATE5V2;
+        case OD_PANEL_IC_INKPLATE10_1200X825:    return BB_PANEL_INKPLATE10;
+        default:                                 return -1;
+    }
+}
+
+static bool fastepd_is_parallel(void) {
+    if (globalConfig.display_count < 1) return false;
+    return fastepd_parallel_panel(globalConfig.displays[0].panel_ic_type) >= 0;
+}
+
 static int8_t fastepd_aux_pin(uint8_t p, int8_t default_gpio) {
     if (p == 0 || p == 0xFF) {
         return default_gpio;
@@ -86,9 +101,12 @@ static uint32_t s_partial_plane_size;
 static uint32_t s_partial_bytes_written;
 static uint32_t s_partial_expected;
 
+// True when the framebuffer is 4bpp (16-level gray): ED103TC2 gray or GRAY16.
 static bool fastepd_panel_is_4gray(void) {
     if (globalConfig.display_count < 1) return false;
-    return globalConfig.displays[0].panel_ic_type == OD_PANEL_IC_ED103TC2_1872X1404_4GRAY;
+    const struct DisplayConfig& d = globalConfig.displays[0];
+    if (d.panel_ic_type == OD_PANEL_IC_ED103TC2_1872X1404_4GRAY) return true;
+    return d.color_scheme == OD_COLOR_SCHEME_GRAY16;
 }
 
 static size_t fb_byte_size(void) {
@@ -192,6 +210,27 @@ void fastepd_epaper_begin(void) {
     s_init_failed = false;
     initOrRestoreWireForOpenDisplay();
 
+    // Native parallel panels (Inkplate): initPanel() sets up the bus/PMIC and
+    // allocates the buffers. Guard on currentBuffer() — initPanel() re-allocs
+    // without freeing, so a warm re-init would leak; deInit() keeps the bus up.
+    int parallel = fastepd_parallel_panel(globalConfig.displays[0].panel_ic_type);
+    if (parallel >= 0) {
+        if (!g_epd.currentBuffer()) {
+            int prc = g_epd.initPanel(parallel);
+            if (prc != BBEP_SUCCESS || !g_epd.currentBuffer()) {
+                s_init_failed = true;
+                s_hw_initialized = false;
+                return;
+            }
+            g_epd.setMode(fastepd_panel_is_4gray() ? BB_MODE_4BPP : BB_MODE_1BPP);
+            g_epd.setPreviousMode((uint8_t)g_epd.getMode());
+        } else {
+            g_epd.einkPower(1);
+        }
+        s_hw_initialized = true;
+        return;
+    }
+
     int rc = g_epd.initIT8951((uint8_t)s_mosi, (uint8_t)s_miso, (uint8_t)s_sclk,
                               (uint8_t)s_cs, (uint8_t)s_busy, (uint8_t)s_rst,
                               (uint8_t)s_en, (uint8_t)s_ite_en);
@@ -219,9 +258,16 @@ void fastepd_epaper_begin(void) {
     s_hw_initialized = true;
 }
 
+// REFRESH_FULL: parallel panels flash-clear to flush ghosting; IT8951 clears
+// internally (ignores the mode) so it stays CLEAR_NONE.
+static void fastepd_full_refresh_impl(void) {
+    int clear = fastepd_is_parallel() ? CLEAR_FAST : CLEAR_NONE;
+    g_epd.fullUpdate(clear, true, NULL);
+}
+
 void fastepd_full_update(void) {
     if (!g_epd.currentBuffer()) return;
-    g_epd.fullUpdate(CLEAR_NONE, true, NULL);
+    fastepd_full_refresh_impl();
     g_epd.backupPlane();
 }
 
@@ -276,9 +322,16 @@ void fastepd_direct_write_chunk(const uint8_t* data, uint32_t len) {
 void fastepd_direct_refresh(int refresh_mode) {
     if (!g_epd.currentBuffer()) return;
     if (refresh_mode == 1) {
-        it8951_fullscreen_du();
+        // FAST: parallel 1bpp uses native diff; IT8951 uses its DU waveform.
+        // 4bpp has no fast path (fastUpdate is 1bpp-only) -> fall back to full.
+        if (fastepd_is_parallel()) {
+            if (fastepd_panel_is_4gray()) fastepd_full_refresh_impl();
+            else g_epd.fastUpdate(true);
+        } else {
+            it8951_fullscreen_du();
+        }
     } else {
-        g_epd.fullUpdate(CLEAR_NONE, true, NULL);
+        fastepd_full_refresh_impl();
     }
     g_epd.backupPlane();
 }
@@ -347,7 +400,11 @@ bool fastepd_partial_refresh(int refresh_mode) {
     if (!g_epd.currentBuffer()) return false;
 
     if (refresh_mode == 0) {
-        g_epd.fullUpdate(CLEAR_NONE, true, NULL);
+        fastepd_full_refresh_impl();
+    } else if (fastepd_is_parallel()) {
+        // Rect already blitted into the framebuffer; 4bpp has no fast path.
+        if (fastepd_panel_is_4gray()) fastepd_full_refresh_impl();
+        else g_epd.fastUpdate(true);
     } else {
         // Region rect is still applied to the framebuffer via blit; refresh is
         // full-screen DU (IT8951 region DU had persistent edge alignment issues).

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -693,8 +693,13 @@ bool fastepd_driver_used(void) {
 #else
     if (globalConfig.display_count < 1) return false;
     const struct DisplayConfig& d = globalConfig.displays[0];
-    if (d.panel_ic_type != OD_PANEL_IC_ED103TC2_1872X1404 &&
-        d.panel_ic_type != OD_PANEL_IC_ED103TC2_1872X1404_4GRAY) return false;
+    // FastEPD IT8951 (SPI) path: E Ink ED103TC2 (Seeed reTerminal).
+    const bool it8951 = (d.panel_ic_type == OD_PANEL_IC_ED103TC2_1872X1404 ||
+                         d.panel_ic_type == OD_PANEL_IC_ED103TC2_1872X1404_4GRAY);
+    // FastEPD native parallel path: Soldered Inkplate 5V2 / 10.
+    const bool inkplate = (d.panel_ic_type == OD_PANEL_IC_INKPLATE5V2_1280X720 ||
+                           d.panel_ic_type == OD_PANEL_IC_INKPLATE10_1200X825);
+    if (!it8951 && !inkplate) return false;
     if (d.display_technology != 0 && d.display_technology != 1) return false;
     return true;
 #endif
@@ -1536,7 +1541,7 @@ void initDisplay(){
 #if defined(TARGET_ESP32) && defined(OPENDISPLAY_FASTEPD)
     if (fastepd_driver_used()) {
         pwrmgm(true);
-        writeSerial("Display: FastEPD IT8951 (panel_ic " + String(globalConfig.displays[0].panel_ic_type) + ", " +
+        writeSerial("Display: FastEPD (panel_ic " + String(globalConfig.displays[0].panel_ic_type) + ", " +
                     String(globalConfig.displays[0].pixel_width) + "x" + String(globalConfig.displays[0].pixel_height) + ", " +
                     String(getBitsPerPixel()) + " bpp)", true);
         fastepd_epaper_begin();
@@ -1632,6 +1637,7 @@ int getBitsPerPixel() {
 #endif
     if (globalConfig.displays[0].color_scheme == OD_COLOR_SCHEME_BWGBRY ||
         globalConfig.displays[0].color_scheme == OD_COLOR_SCHEME_BWGBRY_SPLIT) return 4;
+    if (globalConfig.displays[0].color_scheme == OD_COLOR_SCHEME_GRAY16) return 4;
     if (globalConfig.displays[0].color_scheme == OD_COLOR_SCHEME_BWRY) return 2;
     if (globalConfig.displays[0].color_scheme == OD_COLOR_SCHEME_GRAY4) return 2;
     return 1;


### PR DESCRIPTION
# What was added
- Using the newly added FastEPD library support, implements the Soldered Inkplate 5V2 and 10 panels
- Adds build for the esp32-wrover-e MCU used on said boards

# Tests done
- Implementation was tested on both of the models, using the following configs:
**Inkplate10.json:**
```
{
  "version": 1,
  "minor_version": 1,
  "packets": [
    {
      "id": "1",
      "name": "system_config",
      "fields": {
        "ic_type": "0",
        "communication_modes": "0x1",
        "device_flags": "0x0",
        "pwr_pin": "0xff",
        "pwr_pin_2": "0xff",
        "pwr_pin_3": "0xff",
        "reserved": "0x0"
      }
    },
    {
      "id": "2",
      "name": "manufacturer_data",
      "fields": {
        "manufacturer_id": "9286",
        "board_type": "0",
        "board_revision": "0x0",
        "simple_config_driver_index": "0",
        "simple_config_display_index": "0",
        "simple_config_power_index": "0",
        "simple_config_configured_at": "0",
        "reserved": "0x0"
      }
    },
    {
      "id": "4",
      "name": "power_option",
      "fields": {
        "power_mode": "0",
        "battery_capacity_mah": "0x0",
        "sleep_timeout_ms": "0xea60",
        "tx_power": "0x0",
        "sleep_flags": "0x0",
        "battery_sense_pin": "0xff",
        "battery_sense_enable_pin": "0xff",
        "battery_sense_flags": "0x0",
        "capacity_estimator": "1",
        "voltage_scaling_factor": "0x0",
        "deep_sleep_current_ua": "0x0",
        "deep_sleep_time_seconds": "0x0",
        "charge_enable_pin": "0xff",
        "charge_state_pin": "0xff",
        "charger_flags": "0x0",
        "min_wake_time_seconds": "0x0",
        "screen_timeout_seconds": "0x0",
        "reserved": "0x00000000"
      }
    },
    {
      "id": "32",
      "name": "display",
      "fields": {
        "instance_number": "0x0",
        "display_technology": "1",
        "panel_ic_type": "3003",
        "pixel_width": "0x4b0",
        "pixel_height": "0x339",
        "active_width_mm": "0x0",
        "active_height_mm": "0x0",
        "legacy_tagtype": "0x0",
        "rotation": "0",
        "reset_pin": "0xff",
        "busy_pin": "0xff",
        "dc_pin": "0xff",
        "cs_pin": "0xff",
        "data_pin": "0xff",
        "partial_update_support": "0",
        "color_scheme": "6",
        "transmission_modes": "0x3",
        "clk_pin": "0xff",
        "reserved_pin_2": "0xff",
        "reserved_pin_3": "0xff",
        "reserved_pin_4": "0xff",
        "reserved_pin_5": "0xff",
        "reserved_pin_6": "0xff",
        "reserved_pin_7": "0xff",
        "reserved_pin_8": "0xff",
        "full_update_mC": "0x0",
        "reserved": "0x00000000000000000000000000"
      }
    }
  ],
  "exported_at": "2026-07-28T07:04:34.140Z",
  "exported_by": "py-opendisplay"
}
```

**Inkplate 5V2:**
```
{
  "version": 1,
  "minor_version": 1,
  "packets": [
    {
      "id": "1",
      "name": "system_config",
      "fields": {
        "ic_type": "0",
        "communication_modes": "0x1",
        "device_flags": "0x0",
        "pwr_pin": "0xff",
        "pwr_pin_2": "0xff",
        "pwr_pin_3": "0xff",
        "reserved": "0x0"
      }
    },
    {
      "id": "2",
      "name": "manufacturer_data",
      "fields": {
        "manufacturer_id": "9286",
        "board_type": "0",
        "board_revision": "0x0",
        "simple_config_driver_index": "0",
        "simple_config_display_index": "0",
        "simple_config_power_index": "0",
        "simple_config_configured_at": "0",
        "reserved": "0x0"
      }
    },
    {
      "id": "4",
      "name": "power_option",
      "fields": {
        "power_mode": "0",
        "battery_capacity_mah": "0x0",
        "sleep_timeout_ms": "0xea60",
        "tx_power": "0x0",
        "sleep_flags": "0x0",
        "battery_sense_pin": "0xff",
        "battery_sense_enable_pin": "0xff",
        "battery_sense_flags": "0x0",
        "capacity_estimator": "1",
        "voltage_scaling_factor": "0x0",
        "deep_sleep_current_ua": "0x0",
        "deep_sleep_time_seconds": "0x0",
        "charge_enable_pin": "0xff",
        "charge_state_pin": "0xff",
        "charger_flags": "0x0",
        "min_wake_time_seconds": "0x0",
        "screen_timeout_seconds": "0x0",
        "reserved": "0x00000000"
      }
    },
    {
      "id": "32",
      "name": "display",
      "fields": {
        "instance_number": "0x0",
        "display_technology": "1",
        "panel_ic_type": "3002",
        "pixel_width": "0x500",
        "pixel_height": "0x2d0",
        "active_width_mm": "0x0",
        "active_height_mm": "0x0",
        "legacy_tagtype": "0x0",
        "rotation": "0",
        "reset_pin": "0xff",
        "busy_pin": "0xff",
        "dc_pin": "0xff",
        "cs_pin": "0xff",
        "data_pin": "0xff",
        "partial_update_support": "0",
        "color_scheme": "6",
        "transmission_modes": "0x3",
        "clk_pin": "0xff",
        "reserved_pin_2": "0xff",
        "reserved_pin_3": "0xff",
        "reserved_pin_4": "0xff",
        "reserved_pin_5": "0xff",
        "reserved_pin_6": "0xff",
        "reserved_pin_7": "0xff",
        "reserved_pin_8": "0xff",
        "full_update_mC": "0x0",
        "reserved": "0x00000000000000000000000000"
      }
    }
  ],
  "exported_at": "2026-07-28T07:04:34.139Z",
  "exported_by": "py-opendisplay"
}
```

- The above configs were able to produce the splash screen as well as being able to render images uploaded using the [BLE Tester](https://opendisplay.org/firmware/display/index.html)
