### PR TITLE
perf(mem): free ~16.5 KB internal DRAM on S3 (PSRAM relocation + String-free LAN logging)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,6 +12,31 @@ extra_configs =
 ; nrf52840-bootdiag, nrf52840-reformat, esp32-s3-N16R8-extuart-debug.
 ; Build them with an explicit `pio run -e <env>`. See each env's own header for
 ; why it must never ship.
+;
+; DO NOT ADD -DCONFIG_BT_NIMBLE_MEM_ALLOC_MODE_EXTERNAL=1. IT IS INERT HERE.
+; It looks like the way to move the NimBLE HOST pools (msys mbufs, ACL-from-LL,
+; HCI event buffers, ~14 KB) out of internal DRAM, and NimBLE-Arduino does compile
+; from source, so unlike the WiFi/lwIP/mDNS allocations it looks reachable. It is
+; not. Chain, verified 2026-08-03 by disassembling nimble_platform_mem_calloc:
+;   1. exp_nimble_mem.c tests #ifdef CONFIG_BT_NIMBLE_MEM_ALLOC_MODE_INTERNAL
+;      FIRST, and only #elif ..._EXTERNAL after it.
+;   2. nimconfig.h guards its own ..._INTERNAL define with
+;      #ifndef ..._EXTERNAL -- which would work, except that
+;   3. nimconfig.h includes sdkconfig.h first, and the Arduino prebuilt
+;      sdkconfig.h (qio_opi/include/sdkconfig.h:589) defines
+;      CONFIG_BT_NIMBLE_MEM_ALLOC_MODE_INTERNAL 1 unconditionally.
+; So INTERNAL is always defined by the time the shim is compiled and the -D
+; changes nothing. The built code still calls
+; heap_caps_calloc(..., MALLOC_CAP_INTERNAL|MALLOC_CAP_8BIT) -- confirmed
+; identical on an env with the flag and one without (a12 = 4 + 0x800 = 0x804).
+; A command-line -U cannot help: sdkconfig.h re-defines it after any -D/-U.
+; This is the undiagnosed "I tried to uncomment, but there is no effect" in
+; h2zero/NimBLE-Arduino#496. Only a rebuilt Arduino lib set would change it.
+;
+; If it were reachable it would ALSO require -DBOARD_HAS_PSRAM: the shim has NO
+; fallback, so a part without PSRAM loses BLE entirely
+; (h2zero/NimBLE-Arduino#317, espressif/esp-idf#8020 -- the proposed
+; heap_caps_malloc_prefer fix was never merged).
 default_envs =
 	nrf52840custom
 	esp32-s3-N16R8

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -507,7 +507,7 @@ void handleReadConfig() {
     // path, so no other consumer can claim the scratch while we hold it.
     uint8_t* configData = getConfigScratch();
     uint32_t configLen = MAX_CONFIG_SIZE;
-    if (loadConfig(configData, &configLen)) {
+    if (configData != nullptr && loadConfig(configData, &configLen)) {
         uint32_t remaining = configLen;
         uint32_t offset = 0;
         uint16_t chunkNumber = 0;
@@ -554,6 +554,16 @@ void handleReadConfig() {
 
 void handleWriteConfig(uint8_t* data, uint16_t len) {
     if (len == 0) return;
+#if OD_CONFIG_BUFFERS_IN_PSRAM
+    // Fail closed if odConfigReserveBuffers() could not reserve the chunk buffer.
+    // Refusing here covers the chunked path too: handleWriteConfigChunk() only ever
+    // runs after this function has set chunkedWriteState.active.
+    if (chunkedWriteState.buffer == nullptr) {
+        uint8_t errorResponse[] = {RESP_NACK, RESP_CONFIG_WRITE, 0x00, 0x00};
+        sendResponse(errorResponse, sizeof(errorResponse));
+        return;
+    }
+#endif
     if (isEncryptionEnabled() && !isAuthenticated()) {
         bool rewriteAllowed = (securityConfig.flags & (1 << 0)) != 0;
         if (!rewriteAllowed) {

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -507,7 +507,7 @@ void handleReadConfig() {
     // path, so no other consumer can claim the scratch while we hold it.
     uint8_t* configData = getConfigScratch();
     uint32_t configLen = MAX_CONFIG_SIZE;
-    if (configData != nullptr && loadConfig(configData, &configLen)) {
+    if (loadConfig(configData, &configLen)) {
         uint32_t remaining = configLen;
         uint32_t offset = 0;
         uint16_t chunkNumber = 0;
@@ -554,16 +554,6 @@ void handleReadConfig() {
 
 void handleWriteConfig(uint8_t* data, uint16_t len) {
     if (len == 0) return;
-#if OD_CONFIG_BUFFERS_IN_PSRAM
-    // Fail closed if odConfigReserveBuffers() could not reserve the chunk buffer.
-    // Refusing here covers the chunked path too: handleWriteConfigChunk() only ever
-    // runs after this function has set chunkedWriteState.active.
-    if (chunkedWriteState.buffer == nullptr) {
-        uint8_t errorResponse[] = {RESP_NACK, RESP_CONFIG_WRITE, 0x00, 0x00};
-        sendResponse(errorResponse, sizeof(errorResponse));
-        return;
-    }
-#endif
     if (isEncryptionEnabled() && !isAuthenticated()) {
         bool rewriteAllowed = (securityConfig.flags & (1 << 0)) != 0;
         if (!rewriteAllowed) {

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -109,13 +109,13 @@ uint8_t* getConfigScratch(void) {
 }
 
 #if OD_CONFIG_BUFFERS_IN_PSRAM
-// PSRAM only, with NO internal-DRAM fallback. This gate is only reached on envs
-// built -DBOARD_HAS_PSRAM, and a board whose PSRAM is missing or dead cannot run
-// this firmware anyway: FastEPD's framebuffer is a single 2.6 MB allocation, so
-// the panel is dead long before the config path matters. A fallback here would
-// only take 4 KB of the scarcest memory on the part at the moment it is scarcest,
-// to serve a case that cannot occur -- so it fails closed instead and the
-// consumers refuse their commands.
+// PSRAM only, with NO internal-DRAM fallback and no null handling at the
+// consumers. This gate is only reached on envs built -DBOARD_HAS_PSRAM, the
+// allocation runs at boot with a pristine heap, and a board whose PSRAM is missing
+// or dead cannot run this firmware anyway: FastEPD's framebuffer is a single
+// 2.6 MB allocation, so the panel is dead long before the config path matters.
+// That makes a failure here defective hardware, not a runtime condition -- log it
+// so it is named at boot, and carry no degraded mode for it.
 //
 // Never freed: both buffers must be available for the whole uptime (the scratch on
 // every config read, the chunk buffer across a multi-command upload), and an
@@ -290,9 +290,7 @@ bool hasValidStoredConfig(void) {
     }
 #endif
     uint32_t len = MAX_CONFIG_SIZE;
-    uint8_t* scratch = getConfigScratch();
-    if (scratch == nullptr) return false;   // see odConfigReserveBuffers()
-    return loadConfig(scratch, &len);
+    return loadConfig(getConfigScratch(), &len);
 }
 
 static uint16_t crc16_ccitt_feed(uint16_t crc, uint8_t b) {
@@ -354,11 +352,6 @@ bool loadGlobalConfig(){
     globalConfig.data_extended_loaded = false;
     uint8_t* configData = getConfigScratch();
     uint32_t configLen = MAX_CONFIG_SIZE;
-    if (configData == nullptr) {   // see odConfigReserveBuffers()
-        od_log_error("ERROR: config scratch unavailable, cannot load configuration");
-        globalConfig.loaded = false;
-        return false;
-    }
     if (!loadConfig(configData, &configLen)) {
         globalConfig.loaded = false;
         return false;

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -97,10 +97,52 @@ void formatConfigStorage(){
 // See getConfigScratch() in config_parser.h for the sharing contract. Replaces a
 // per-consumer 4 KB buffer each in loadGlobalConfig (static), hasValidStoredConfig
 // (static) and handleReadConfig (stack -- a 4 KB spike on the loop task).
+#if OD_CONFIG_BUFFERS_IN_PSRAM
+static uint8_t* configScratch = nullptr;
+extern chunked_write_state_t chunkedWriteState;   // defined in main.h
+#else
 static uint8_t configScratch[MAX_CONFIG_SIZE];
+#endif
 
 uint8_t* getConfigScratch(void) {
     return configScratch;
+}
+
+#if OD_CONFIG_BUFFERS_IN_PSRAM
+// PSRAM only, with NO internal-DRAM fallback. This gate is only reached on envs
+// built -DBOARD_HAS_PSRAM, and a board whose PSRAM is missing or dead cannot run
+// this firmware anyway: FastEPD's framebuffer is a single 2.6 MB allocation, so
+// the panel is dead long before the config path matters. A fallback here would
+// only take 4 KB of the scarcest memory on the part at the moment it is scarcest,
+// to serve a case that cannot occur -- so it fails closed instead and the
+// consumers refuse their commands.
+//
+// Never freed: both buffers must be available for the whole uptime (the scratch on
+// every config read, the chunk buffer across a multi-command upload), and an
+// on-demand allocation would fail precisely when someone is trying to reconfigure
+// a device that is already short of memory.
+static uint8_t* reserveConfigBuffer(const char* what) {
+    uint8_t* p = (uint8_t*)heap_caps_calloc(1, MAX_CONFIG_SIZE,
+                                            MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (p == nullptr) {
+        od_log_error("ERROR: config buffer '%s' PSRAM reservation failed -- config commands will be refused", what);
+    }
+    return p;
+}
+#endif
+
+void odConfigReserveBuffers(void) {
+#if OD_CONFIG_BUFFERS_IN_PSRAM
+    if (configScratch == nullptr) {
+        configScratch = reserveConfigBuffer("scratch");
+    }
+    if (chunkedWriteState.buffer == nullptr) {
+        chunkedWriteState.buffer = reserveConfigBuffer("chunked-write");
+    }
+    od_log_info("Config buffers: 2 x %u B reserved, internal free=%u",
+                (unsigned)MAX_CONFIG_SIZE,
+                (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL));
+#endif
 }
 
 bool saveConfig(uint8_t* configData, uint32_t len){
@@ -248,7 +290,9 @@ bool hasValidStoredConfig(void) {
     }
 #endif
     uint32_t len = MAX_CONFIG_SIZE;
-    return loadConfig(getConfigScratch(), &len);
+    uint8_t* scratch = getConfigScratch();
+    if (scratch == nullptr) return false;   // see odConfigReserveBuffers()
+    return loadConfig(scratch, &len);
 }
 
 static uint16_t crc16_ccitt_feed(uint16_t crc, uint8_t b) {
@@ -310,6 +354,11 @@ bool loadGlobalConfig(){
     globalConfig.data_extended_loaded = false;
     uint8_t* configData = getConfigScratch();
     uint32_t configLen = MAX_CONFIG_SIZE;
+    if (configData == nullptr) {   // see odConfigReserveBuffers()
+        od_log_error("ERROR: config scratch unavailable, cannot load configuration");
+        globalConfig.loaded = false;
+        return false;
+    }
     if (!loadConfig(configData, &configLen)) {
         globalConfig.loaded = false;
         return false;

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -122,11 +122,11 @@ uint8_t* getConfigScratch(void);
 // MUST be called before full_config_init(): loadGlobalConfig() is the first
 // consumer of the scratch buffer and runs there.
 //
-// PSRAM only -- no internal-DRAM fallback, deliberately. See reserveConfigBuffer()
-// in config_parser.cpp: a board that reaches this code with dead PSRAM cannot drive
-// its panel either, so the fallback would spend 4 KB of the scarcest memory on a
-// case that cannot occur. On failure the pointers stay null and the consumers
-// refuse their commands rather than dereferencing them.
+// PSRAM only -- no internal-DRAM fallback and no null handling, deliberately. A
+// failure here means defective PSRAM: the allocation runs at boot with a pristine
+// heap, and a board that cannot hold 4 KB cannot hold FastEPD's 2.6 MB framebuffer
+// either, so the panel is dead regardless. reserveConfigBuffer() logs the fault so
+// it is named at boot; there is no degraded mode worth carrying code for.
 void odConfigReserveBuffers(void);
 
 #endif

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -6,6 +6,31 @@
 #define CONFIG_FILE_PATH "/config.bin"
 #define MAX_CONFIG_SIZE 4096
 
+// Where the two 4 KB config buffers live. 1 = reserved in PSRAM at boot and
+// reached through a pointer; 0 = plain .bss arrays, exactly as before.
+//
+// Gated on WiFi *and* PSRAM, because both halves are load-bearing:
+//   - PSRAM: there is nowhere else to put them. A part without it would only be
+//     trading .bss for an identical amount of internal heap, plus a failure path.
+//   - WiFi: only the WiFi/LAN/TLS surface creates the internal-DRAM shortage this
+//     relieves. esp32-N4 uses 77 KB of 327 KB; it does not need this, and leaving
+//     it on .bss keeps its ELF unchanged. Same reasoning as #140 leaving
+//     nrf52840custom byte-identical.
+// That resolves to the seven S3 envs and nothing else -- notably NOT
+// esp32-wrover-e-N4R8, which has PSRAM but no WiFi.
+//
+// Written against the raw -D flags rather than OPENDISPLAY_HAS_WIFI (wifi_service.h)
+// ON PURPOSE: this gate changes the LAYOUT of chunked_write_state_t below, so every
+// translation unit that sees this header must evaluate it identically. Command-line
+// -D flags are visible everywhere; a macro from another header is only visible if
+// that header was included first, and one TU disagreeing about a struct layout is an
+// ODR violation that links cleanly and corrupts memory at runtime.
+#if defined(TARGET_ESP32) && defined(OPENDISPLAY_ENABLE_WIFI) && defined(BOARD_HAS_PSRAM)
+#define OD_CONFIG_BUFFERS_IN_PSRAM 1
+#else
+#define OD_CONFIG_BUFFERS_IN_PSRAM 0
+#endif
+
 // Sentinel in the first 4 bytes of /config.bin. Cheap provenance gate checked
 // before data_len is trusted or the CRC is computed: erased flash, a truncated
 // write, or a file from other firmware fails here in 4 bytes.
@@ -41,7 +66,14 @@ typedef struct {
     bool active;
     uint32_t totalSize;
     uint32_t receivedSize;
+#if OD_CONFIG_BUFFERS_IN_PSRAM
+    // Reserved once by odConfigReserveBuffers(); never freed. NOT sizeof-able --
+    // every bound is MAX_CONFIG_SIZE, which is what handleWriteConfigChunk()
+    // already checks against.
+    uint8_t* buffer;
+#else
     uint8_t buffer[MAX_CONFIG_SIZE];
+#endif
     uint32_t expectedChunks;
     uint32_t receivedChunks;
 } chunked_write_state_t;
@@ -83,5 +115,18 @@ void full_config_init();
 // until they return. Do NOT use this for chunkedWriteState -- that buffer stays
 // live across BLE commands while other config work can run.
 uint8_t* getConfigScratch(void);
+
+// Reserve the two 4 KB config buffers (configScratch and chunkedWriteState.buffer)
+// in PSRAM. No-op unless OD_CONFIG_BUFFERS_IN_PSRAM, and idempotent.
+//
+// MUST be called before full_config_init(): loadGlobalConfig() is the first
+// consumer of the scratch buffer and runs there.
+//
+// PSRAM only -- no internal-DRAM fallback, deliberately. See reserveConfigBuffer()
+// in config_parser.cpp: a board that reaches this code with dead PSRAM cannot drive
+// its panel either, so the fallback would spend 4 KB of the scarcest memory on a
+// case that cannot occur. On failure the pointers stay null and the consumers
+// refuse their commands rather than dereferencing them.
+void odConfigReserveBuffers(void);
 
 #endif

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -675,7 +675,56 @@ static bool imageWriteFramesMayStillArrive(void);
 // early so the quiet-logging predicates below can consult pipeState.active. The
 // reorder array is a file static (not in the struct) so both targets pay it once.
 static PipeWriteState pipeState = {};
+
+// The reorder queue is 33 slots x 252 B = 8,316 B on the S3 envs -- the second
+// largest app-owned .bss item -- and it is dead memory except during a PIPE
+// transfer. Where there is PSRAM to hold it and a WiFi surface creating the
+// internal-DRAM pressure, reserve it there at boot instead. Same gate and same
+// reasoning as OD_CONFIG_BUFFERS_IN_PSRAM (config_parser.h); written against the
+// raw -D flags for the same reason.
+//
+// Unlike the config buffers this needs NO ODR care: PipeReorderSlot itself is
+// unchanged, only this file-static array becomes a pointer, and it is private to
+// this translation unit.
+//
+// Safe to relocate: touched only on the loop task via the BLE command dispatch,
+// never from an ISR, and never handed to DMA -- pipeConsumePayload() copies out of
+// it into the decompressor or the panel sink. Access is at BLE frame rate.
+#if defined(TARGET_ESP32) && defined(OPENDISPLAY_ENABLE_WIFI) && defined(BOARD_HAS_PSRAM)
+#define OD_PIPE_REORDER_IN_PSRAM 1
+#else
+#define OD_PIPE_REORDER_IN_PSRAM 0
+#endif
+
+#if OD_PIPE_REORDER_IN_PSRAM
+static PipeReorderSlot* pipeReorder = nullptr;
+#else
 static PipeReorderSlot pipeReorder[PIPE_REORDER_SLOTS];
+#endif
+
+void odDisplayReserveBuffers(void) {
+#if OD_PIPE_REORDER_IN_PSRAM
+    if (pipeReorder != nullptr) return;   // idempotent
+    // PSRAM only, no internal fallback -- see reserveConfigBuffer() in
+    // config_parser.cpp for why a fallback here would serve a case that cannot
+    // occur on a board this code runs on.
+    pipeReorder = (PipeReorderSlot*)heap_caps_calloc(PIPE_REORDER_SLOTS,
+                                                     sizeof(PipeReorderSlot),
+                                                     MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    // No null handling beyond this line, deliberately: a board whose PSRAM
+    // allocation fails at boot, with the heap pristine, is defective hardware --
+    // and one that cannot hold 8 KB cannot hold FastEPD's 2.6 MB framebuffer
+    // either, so the panel is dead regardless. The log line exists to name the
+    // fault at boot rather than to enable a degraded mode.
+    if (pipeReorder == nullptr) {
+        od_log_error("ERROR: PIPE reorder queue PSRAM reservation failed -- defective PSRAM?");
+        return;
+    }
+    od_log_info("PIPE reorder queue: %u slots x %u B reserved in PSRAM, internal free=%u",
+                (unsigned)PIPE_REORDER_SLOTS, (unsigned)sizeof(PipeReorderSlot),
+                (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL));
+#endif
+}
 
 // Shared by both watchdogs below. Measured from START, not from the last accepted
 // frame, so it bounds the whole transfer rather than a stall -- see the residual

--- a/src/display_service.h
+++ b/src/display_service.h
@@ -62,6 +62,12 @@ void handlePipeWriteStart(uint8_t* data, uint16_t len);
 void handlePipeWriteData(uint8_t* data, uint16_t len);
 void handlePipeWriteEnd(uint8_t* data, uint16_t len);
 void resetPipeWriteState(void);
+
+// Reserve the PIPE reorder queue (33 x 252 B on S3) in PSRAM. No-op unless the
+// target has both a WiFi surface and PSRAM; idempotent; never freed. Call from
+// setup() before BLE accepts commands. A failure here is defective hardware and is
+// logged, not handled -- see odDisplayReserveBuffers() in display_service.cpp.
+void odDisplayReserveBuffers(void);
 // True while a PIPE_WRITE stream is active (mid-transfer log suppression, resets).
 bool pipeWriteActive(void);
 // True while ANY transfer (DIRECT / PIPE / PARTIAL) is streaming. Use this for

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -160,6 +160,11 @@ void setup() {
     }
     #endif
     od_log_info("Starting setup...");
+    // Before full_config_init(): loadGlobalConfig() is the first consumer of the
+    // config scratch buffer. No-op unless OD_CONFIG_BUFFERS_IN_PSRAM. Unlike
+    // od_tls_reserve_records()/odLanReserveRxBuffer() below, this one takes no
+    // internal DRAM at all, so it has no ordering relationship with them.
+    odConfigReserveBuffers();
     if (is_deep_sleep_wake) { od_log_info("[wake] >> full_config_init"); od_log_flush(); }
 #if defined(TARGET_NRF) && defined(OPENDISPLAY_BOOT_DIAG)
     Serial.println("[BOOTDIAG] before full_config_init()");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -165,6 +165,7 @@ void setup() {
     // od_tls_reserve_records()/odLanReserveRxBuffer() below, this one takes no
     // internal DRAM at all, so it has no ordering relationship with them.
     odConfigReserveBuffers();
+    odDisplayReserveBuffers();   // PIPE reorder queue; same gate, also PSRAM-only
     if (is_deep_sleep_wake) { od_log_info("[wake] >> full_config_init"); od_log_flush(); }
 #if defined(TARGET_NRF) && defined(OPENDISPLAY_BOOT_DIAG)
     Serial.println("[BOOTDIAG] before full_config_init()");

--- a/src/wifi_service.cpp
+++ b/src/wifi_service.cpp
@@ -780,6 +780,30 @@ void initWiFi(bool waitForConnection) {
         wifiInitialized = false;
         return;
     }
+    // Bound the WiFi driver's TX memory to a fixed pool. Arduino's default
+    // (_wifiUseStaticBuffers = false) REPLACES the IDF buffer profile inside
+    // wifiLowLevelInit() with a demand-driven one: static_tx_buf_num 0 /
+    // dynamic_tx_buf_num 32 / cache_tx_buf_num 4 / static_rx_buf_num 4. Setting this
+    // skips that override, so esp_wifi_init() gets WIFI_INIT_CONFIG_DEFAULT() --
+    // static_tx 8, dynamic_tx 0, cache_tx 0, static_rx 8 (sdkconfig).
+    //
+    // At the documented ~1.6 KB per WiFi buffer that trades ~13 KB more resident
+    // internal DRAM for ~38 KB off the peak: TX becomes 12.8 KB always instead of up
+    // to 51.2 KB whenever traffic asks. The right trade here because this part dies on
+    // transients, not on baseline -- a 2026-08-03 coredump caught the tcpip task with a
+    // NULL from the mDNS allocator during an inbound query burst, and the OOM error log
+    // then aborted in lock_init_generic. RX is unchanged: dynamic_rx_buf_num is 32 in
+    // both profiles and Arduino exposes no knob for it.
+    //
+    // cache_tx_buf_num 0 is correct here, not the "can't be zero!" case in Arduino's
+    // dynamic path: cache TX buffers exist to copy dynamic TX buffers out of PSRAM into
+    // DMA-capable memory, and static TX buffers are already internal and DMA-capable.
+    //
+    // MUST precede every WiFi call -- wifiLowLevelInit() reads the flag once and latches
+    // lowLevelInitDone. Set later it only logs a warning and takes effect after a
+    // WiFi.mode(WIFI_MODE_NULL). Nothing touches the WiFi API before this point: the
+    // WiFi.status() call sites in main.cpp/config_parser.cpp all run after setup().
+    WiFi.useStaticBuffers(true);
     // Do not log the SSID or password (credentials); log only presence/length.
     lanLog("WiFi: connecting to configured SSID (len " + String(strlen(wifiSsid)) + ")");
     registerWiFiDiagEvents();

--- a/src/wifi_service.cpp
+++ b/src/wifi_service.cpp
@@ -42,23 +42,14 @@ extern bool wifiServerConnected;
 // above) so the pointer type is checked against its definition in main.h.
 extern uint8_t msd_payload[16];
 
-// This file builds its log lines with Arduino String concatenation, while the rest
-// of the firmware logs printf-style through od_log_*. Rather than reflow 60-odd
-// call sites into format strings, funnel them through one adapter and route by the
-// message's own ERROR:/WARNING: prefix so the intended level survives. The String
-// is built by the caller either way, so this adds no allocation the call sites did
-// not already make -- and the EVENT-CONTEXT RULE below still forbids calling it
-// from a WiFi event callback.
-static void lanLog(const String& message, bool newLine = true) {
-    (void)newLine;
-    if (message.startsWith("ERROR")) {
-        od_log_error("%s", message.c_str());
-    } else if (message.startsWith("WARNING")) {
-        od_log_warn("%s", message.c_str());
-    } else {
-        od_log_info("%s", message.c_str());
-    }
-}
+// Logging here is printf-style through od_log_*, like the rest of the firmware.
+// The String-taking lanLog adapter this replaces existed only to avoid reflowing
+// the call sites; with them reflowed it bought nothing and cost a heap allocation
+// per line (Arduino String has SSO up to 14 chars, and essentially every line here
+// is longer), plus a startsWith() level sniff. Calling the macros directly also
+// makes OD_LOG_LEVEL a real compile-time gate: a gated-out line no longer formats
+// its arguments. The EVENT-CONTEXT RULE below still applies -- these are cheaper
+// now, not free.
 
 // Command origin marker (F4): the shared dispatcher (imageDataWritten) reads this
 // to decide whether to run the app-layer AES-CCM gate. Defined in communication.cpp;
@@ -110,6 +101,14 @@ static mbedtls_entropy_context  tlsEntropy;
 // BLE client) had since taken.
 static uint16_t s_lanEpoch = 0;
 
+// WiFi.BSSIDstr() returns a String by value; format the raw bytes instead. Matches
+// its output, including the empty string when the driver has no BSSID yet.
+static void lanFormatBssid(char* out, size_t outSize, const uint8_t* b) {
+    if (b == nullptr) { if (outSize) out[0] = '\0'; return; }
+    snprintf(out, outSize, "%02X:%02X:%02X:%02X:%02X:%02X",
+             b[0], b[1], b[2], b[3], b[4], b[5]);
+}
+
 static uint16_t lanBasePort(void) {
     return (wifiServerPort != 0) ? wifiServerPort : (uint16_t)OD_LAN_TCP_PORT;
 }
@@ -144,11 +143,21 @@ static int tls_bio_recv(void* ctx, unsigned char* buf, size_t len) {
 // (CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN=16384, asymmetric length not set), which is the
 // dominant failure mode once WiFi + BLE coex and the static buffers have taken their cut.
 // Append this to any TLS failure so the log says whether it was OOM and by how much.
-static String tlsFailNote(int ret) {
-    const String code = (ret < 0) ? ("-0x" + String((unsigned)(-ret), HEX)) : String(ret);
-    return String(" (ret=") + code +
-           ", internal free=" + String((unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL)) +
-           ", largest block=" + String((unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL)) + ")";
+// Writes into a caller-supplied buffer rather than returning a String: these are
+// failure paths, so one stack buffer at the call site costs nothing and keeps the
+// allocator out of a path that may be failing *because* of the allocator.
+// OD_TLS_FAIL_NOTE_LEN covers the longest form: two 10-digit sizes plus the text.
+#define OD_TLS_FAIL_NOTE_LEN 80
+static void tlsFailNote(int ret, char* out, size_t outSize) {
+    const unsigned freeB = (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+    const unsigned maxB  = (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
+    if (ret < 0) {
+        snprintf(out, outSize, " (ret=-0x%x, internal free=%u, largest block=%u)",
+                 (unsigned)(-ret), freeB, maxB);
+    } else {
+        snprintf(out, outSize, " (ret=%d, internal free=%u, largest block=%u)",
+                 ret, freeB, maxB);
+    }
 }
 
 // -------------------------------------------- TLS record pre-reservation ---
@@ -164,8 +173,10 @@ static String tlsFailNote(int ret) {
 // second has nowhere to go -- short by under 2 KB.
 //
 // Worse, ssl_setup runs on EVERY LAN client connect and ssl_free releases on every
-// disconnect, so TLS cycles 33 KB through the heap per connection while String logging
-// churns small blocks in between: the odds degrade the longer the device stays up.
+// disconnect, so TLS cycles 33 KB through the heap per connection: the odds degrade
+// the longer the device stays up. This file's String-based logging used to churn
+// small blocks in between, widening the window; that is gone as of the printf-style
+// conversion, but the 33 KB cycle itself is what the reservation below removes.
 //
 // Fix: reserve the two slots ONCE at boot -- from setup(), right after full_config_init()
 // and BEFORE BleTransport::begin()/initWiFi() take their ~100 KB -- when the heap is still
@@ -204,9 +215,9 @@ static void* od_tls_calloc(size_t n, size_t size) {
         static bool warned = false;
         if (!warned) {
             warned = true;
-            lanLog("WARNING: TLS alloc " + String((unsigned)total) +
-                        " B not served from the reserved pool (slot " +
-                        String((unsigned)OD_TLS_RECORD_SLOT_SIZE) + " B) -- falling back to heap");
+            od_log_warn("WARNING: TLS alloc %u B not served from the reserved pool "
+                        "(slot %u B) -- falling back to heap",
+                        (unsigned)total, (unsigned)OD_TLS_RECORD_SLOT_SIZE);
         }
     }
     return heap_caps_calloc(n, size, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
@@ -227,7 +238,7 @@ void od_tls_reserve_records(void) {
     if (s_tlsAllocHooked) return;
     // Gate on config: a device without encryption must not hold 34 KB it never uses.
     if (!isEncryptionEnabled()) {
-        lanLog("TLS: encryption disabled, no record buffers reserved");
+        od_log_info("TLS: encryption disabled, no record buffers reserved");
         return;
     }
     int got = 0;
@@ -241,12 +252,13 @@ void od_tls_reserve_records(void) {
     // and od_tls_calloc falls back to the heap for the rest.
     mbedtls_platform_set_calloc_free(od_tls_calloc, od_tls_free);
     s_tlsAllocHooked = true;
-    lanLog("TLS: reserved " + String(got) + "/" + String((int)OD_TLS_RECORD_SLOTS) +
-                " record slots of " + String((unsigned)OD_TLS_RECORD_SLOT_SIZE) + " B" +
-                ", internal free=" + String((unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL)) +
-                ", largest block=" + String((unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL)));
+    od_log_info("TLS: reserved %d/%d record slots of %u B"
+                ", internal free=%u, largest block=%u",
+                got, (int)OD_TLS_RECORD_SLOTS, (unsigned)OD_TLS_RECORD_SLOT_SIZE,
+                (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
+                (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));
     if (got < OD_TLS_RECORD_SLOTS) {
-        lanLog("WARNING: TLS record reservation incomplete -- ssl_setup may still fail");
+        od_log_warn("WARNING: TLS record reservation incomplete -- ssl_setup may still fail");
     }
 }
 
@@ -263,17 +275,18 @@ void odLanReserveRxBuffer(void) {
                                                       MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
     }
     if (tcpReceiveBuffer == nullptr) {
-        lanLog("ERROR: LAN RX buffer reservation failed -- LAN transport will not start");
+        od_log_error("ERROR: LAN RX buffer reservation failed -- LAN transport will not start");
         return;
     }
-    lanLog("LAN: reserved RX buffer " + String((unsigned)OD_LAN_RX_BUFFER_SIZE) + " B in " +
-                String(inPsram ? "PSRAM" : "DRAM") +
-                ", internal free=" + String((unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL)) +
-                ", largest block=" + String((unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL)));
+    od_log_info("LAN: reserved RX buffer %u B in %s"
+                ", internal free=%u, largest block=%u",
+                (unsigned)OD_LAN_RX_BUFFER_SIZE, inPsram ? "PSRAM" : "DRAM",
+                (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
+                (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));
     if (!inPsram) {
         // The only signal that this board's PSRAM is absent or dead:
         // CONFIG_SPIRAM_IGNORE_NOTFOUND=1 lets it boot silently. No reclaim here.
-        lanLog("WARNING: LAN RX buffer fell back to internal DRAM -- no PSRAM on this board?");
+        od_log_warn("WARNING: LAN RX buffer fell back to internal DRAM -- no PSRAM on this board?");
     }
 }
 
@@ -285,7 +298,7 @@ static bool tlsEnsureConfig(void) {
     od_tls_reserve_records();
     if (tlsInited) return true;
     if (!deriveTlsPsk(tlsPsk)) {
-        lanLog("ERROR: TLS PSK derivation failed (no master key)");
+        od_log_error("ERROR: TLS PSK derivation failed (no master key)");
         return false;
     }
     mbedtls_ssl_config_init(&tlsConf);
@@ -295,14 +308,18 @@ static bool tlsEnsureConfig(void) {
     int rc = mbedtls_ctr_drbg_seed(&tlsDrbg, mbedtls_entropy_func, &tlsEntropy,
                                    reinterpret_cast<const unsigned char*>(pers), strlen(pers));
     if (rc != 0) {
-        lanLog("ERROR: TLS RNG seed failed" + tlsFailNote(rc));
+        char note[OD_TLS_FAIL_NOTE_LEN];
+        tlsFailNote(rc, note, sizeof(note));
+        od_log_error("ERROR: TLS RNG seed failed%s", note);
         return false;
     }
     rc = mbedtls_ssl_config_defaults(&tlsConf, MBEDTLS_SSL_IS_SERVER,
                                      MBEDTLS_SSL_TRANSPORT_STREAM,
                                      MBEDTLS_SSL_PRESET_DEFAULT);
     if (rc != 0) {
-        lanLog("ERROR: TLS config defaults failed" + tlsFailNote(rc));
+        char note[OD_TLS_FAIL_NOTE_LEN];
+        tlsFailNote(rc, note, sizeof(note));
+        od_log_error("ERROR: TLS config defaults failed%s", note);
         return false;
     }
     mbedtls_ssl_conf_rng(&tlsConf, mbedtls_ctr_drbg_random, &tlsDrbg);
@@ -311,7 +328,9 @@ static bool tlsEnsureConfig(void) {
                               reinterpret_cast<const unsigned char*>(kTlsPskIdentity),
                               strlen(kTlsPskIdentity));
     if (rc != 0) {
-        lanLog("ERROR: TLS conf_psk failed" + tlsFailNote(rc));
+        char note[OD_TLS_FAIL_NOTE_LEN];
+        tlsFailNote(rc, note, sizeof(note));
+        od_log_error("ERROR: TLS conf_psk failed%s", note);
         return false;
     }
     tlsInited = true;
@@ -334,7 +353,9 @@ static bool tlsBeginSession(void) {
     if (rc != 0) {
         // -0x7F00 == MBEDTLS_ERR_SSL_ALLOC_FAILED: the record buffers did not fit in
         // internal DRAM. Compare "largest block" against ~16.4 KB in the note above.
-        lanLog("ERROR: TLS ssl_setup failed" + tlsFailNote(rc));
+        char note[OD_TLS_FAIL_NOTE_LEN];
+        tlsFailNote(rc, note, sizeof(note));
+        od_log_error("ERROR: TLS ssl_setup failed%s", note);
         mbedtls_ssl_free(&tlsSsl);
         return false;
     }
@@ -367,10 +388,10 @@ void opendisplay_lan_send_frame(const uint8_t* payload, uint16_t len) {
         const uint16_t total = (uint16_t)(len + 2u);
         if (tlsMode) {
             if (mbedtls_ssl_write(&tlsSsl, lanTxFrame, total) < 0) {
-                lanLog("ERROR: TLS LAN response write failed", true);
+                od_log_error("ERROR: TLS LAN response write failed");
             }
         } else if (wifiClient.write(lanTxFrame, total) != total) {
-            lanLog("ERROR: LAN response write incomplete", true);
+            od_log_error("ERROR: LAN response write incomplete");
         }
         return;
     }
@@ -381,12 +402,12 @@ void opendisplay_lan_send_frame(const uint8_t* payload, uint16_t len) {
     if (tlsMode) {
         if (mbedtls_ssl_write(&tlsSsl, hdr, 2) < 0 ||
             mbedtls_ssl_write(&tlsSsl, payload, len) < 0) {
-            lanLog("ERROR: TLS LAN response write failed", true);
+            od_log_error("ERROR: TLS LAN response write failed");
         }
         return;
     }
     if (wifiClient.write(hdr, 2) != 2 || wifiClient.write(payload, len) != len) {
-        lanLog("ERROR: LAN response write incomplete", true);
+        od_log_error("ERROR: LAN response write incomplete");
     }
 }
 
@@ -436,11 +457,11 @@ static String advertisedBleMacLower(void) {
 static void restartLanService(void) {
     String deviceName = "OD" + getChipIdHex();
     if (!MDNS.begin(deviceName.c_str())) {
-        lanLog("ERROR: mDNS responder failed");
+        od_log_error("ERROR: mDNS responder failed");
         return;
     }
     uint16_t port = lanActivePort();
-    lanLog("mDNS: " + deviceName + ".local");
+    od_log_info("mDNS: %s.local", deviceName.c_str());
     MDNS.addService("opendisplay", "tcp", port);
     // F1 -- identity/capability TXT keys (SECTION 9 rule 6, ADDITIVE to `msd`).
     String mac = advertisedBleMacLower();
@@ -460,8 +481,8 @@ static void restartLanService(void) {
     snprintf(idhex, sizeof(idhex), "%02x%02x%02x%02x", did[0], did[1], did[2], did[3]);
     MDNS.addServiceTxt("opendisplay", "tcp", "id", static_cast<const char*>(idhex));  // OPTIONAL
     MDNS.addServiceTxt("opendisplay", "tcp", "pv", OD_PROTOCOL_VERSION_STR); // OPTIONAL
-    lanLog("mDNS: _opendisplay._tcp port " + String(port) +
-                " tls=" + (isEncryptionEnabled() ? "1" : "0") + " mac=" + mac);
+    od_log_info("mDNS: _opendisplay._tcp port %u tls=%s mac=%s",
+                (unsigned)port, isEncryptionEnabled() ? "1" : "0", mac.c_str());
     opendisplay_mdns_update_msd_txt();
 }
 
@@ -470,14 +491,14 @@ static void startLanServer(void) {
     // every caller, and it is better than accepting a socket the parser cannot serve.
     // BLE and the display path are unaffected.
     if (tcpReceiveBuffer == nullptr) {
-        lanLog("ERROR: LAN RX buffer unavailable -- LAN transport disabled");
+        od_log_error("ERROR: LAN RX buffer unavailable -- LAN transport disabled");
         return;
     }
     tlsMode = isEncryptionEnabled();
     uint16_t port = lanActivePort();
     wifiServer.begin(port);
-    lanLog(String(tlsMode ? "TLS-PSK" : "Plaintext") +
-                " LAN server listening on port " + String(port));
+    od_log_info("%s LAN server listening on port %u",
+                tlsMode ? "TLS-PSK" : "Plaintext", (unsigned)port);
     restartLanService();
 }
 
@@ -565,7 +586,7 @@ static void lanApplyBestApSelection(void) {
 
 static void lanCacheInvalidate(const char* why) {
     if (s_cachedValid) {
-        lanLog(String("WiFi: AP cache cleared (") + why + ") -- next connect will scan");
+        od_log_info("WiFi: AP cache cleared (%s) -- next connect will scan", why);
     }
     s_cachedValid = false;
     s_cachedChannel = 0;
@@ -589,13 +610,13 @@ static void lanBeginConnect(void) {
         snprintf(b, sizeof(b), "%02X:%02X:%02X:%02X:%02X:%02X",
                  s_cachedBssid[0], s_cachedBssid[1], s_cachedBssid[2],
                  s_cachedBssid[3], s_cachedBssid[4], s_cachedBssid[5]);
-        lanLog("WiFi: connecting to cached AP " + String(b) +
-                    " ch " + String((int)s_cachedChannel) + " (no scan)");
+        od_log_info("WiFi: connecting to cached AP %s ch %d (no scan)",
+                    b, (int)s_cachedChannel);
         WiFi.begin(wifiSsid, wifiPassword, (int32_t)s_cachedChannel, s_cachedBssid);
         return;
     }
     usingCachedAp = false;
-    lanLog("WiFi: scanning all channels for the strongest AP");
+    od_log_info("WiFi: scanning all channels for the strongest AP");
     lanApplyBestApSelection();
     WiFi.begin(wifiSsid, wifiPassword);
 }
@@ -616,12 +637,12 @@ static void ensureRoamEventRegistered(void) {
                                               &onWifiRssiLow, NULL);
     if (rc == ESP_OK) {
         roamEventRegistered = true;
-        lanLog("WiFi: roaming armed (RSSI-low handler registered)");
+        od_log_info("WiFi: roaming armed (RSSI-low handler registered)");
         return;
     }
     // Always report the code -- "could not register" with no reason is undiagnosable.
-    lanLog(String("WiFi: RSSI-low handler register failed (") + esp_err_to_name(rc) +
-                "); will retry on next association");
+    od_log_info("WiFi: RSSI-low handler register failed (%s); will retry on next association",
+                esp_err_to_name(rc));
 }
 
 // One-shot: re-arm after every event and after every association.
@@ -629,17 +650,19 @@ static void lanArmRssiThreshold(void) {
     ensureRoamEventRegistered();   // no point arming a threshold nothing listens for
     esp_err_t rc = esp_wifi_set_rssi_threshold(OD_LAN_ROAM_RSSI_THRESHOLD);
     if (rc != ESP_OK) {
-        lanLog("WiFi: RSSI threshold arm failed (" + String((int)rc) + ")");
+        od_log_info("WiFi: RSSI threshold arm failed (%d)", (int)rc);
     }
 }
 
 // EVENT-CONTEXT RULE (learned the hard way -- this handler previously panicked the
 // device): callbacks here run on tiny stacks -- the raw esp_event handler on the system
 // event task, and the Arduino callbacks on "arduino_events" with a 4096-byte stack
-// (ARDUINO_NETWORK_EVENT_TASK_STACK_SIZE). Arduino String concatenation plus
-// lanLog(String) BY VALUE, plus esp_wifi_*/esp_event_* calls, is far too much for
-// that budget. So handlers ONLY set flags; every String, log, and esp_* call happens in
-// serviceWifiEventFollowUp() on the loop task. Keep it that way.
+// (ARDUINO_NETWORK_EVENT_TASK_STACK_SIZE). Logging plus esp_wifi_*/esp_event_* calls
+// is far too much for that budget. So handlers ONLY set flags; every log and esp_*
+// call happens in serviceWifiEventFollowUp() on the loop task. Keep it that way.
+// Note this rule predates the printf-style logging: the old String concatenation made
+// it worse (a heap allocation per line), but od_log_* still formats into a 256-byte
+// stack buffer, which alone is 6% of this task's stack. The rule stands.
 static void onWifiRssiLow(void* arg, esp_event_base_t base, int32_t id, void* data) {
     (void)arg; (void)base; (void)id;
     const wifi_event_bss_rssi_low_t* e = (const wifi_event_bss_rssi_low_t*)data;
@@ -648,8 +671,8 @@ static void onWifiRssiLow(void* arg, esp_event_base_t base, int32_t id, void* da
     rssiLowNoticePending = true;
 }
 
-// Flags only -- see the EVENT-CONTEXT RULE above. No String, no lanLog, no esp_*
-// calls: this runs on the 4096-byte "arduino_events" task.
+// Flags only -- see the EVENT-CONTEXT RULE above. No logging and no esp_* calls:
+// this runs on the 4096-byte "arduino_events" task.
 static void onWiFiDiagEvent(arduino_event_id_t event, arduino_event_info_t info) {
     switch (event) {
         case ARDUINO_EVENT_WIFI_STA_CONNECTED:
@@ -696,11 +719,11 @@ static void registerWiFiDiagEvents(void) {
 static void serviceWifiEventFollowUp(void) {
     if (assocNoticePending) {
         assocNoticePending = false;
-        lanLog("WiFi event: associated (channel " + String((int)s_lastAssocChannel) + ")");
+        od_log_info("WiFi event: associated (channel %d)", (int)s_lastAssocChannel);
     }
     if (disconnectNoticePending) {
         disconnectNoticePending = false;
-        lanLog("WiFi event: disconnected, reason " + String((int)s_lastDisconnectReason));
+        od_log_info("WiFi event: disconnected, reason %d", (int)s_lastDisconnectReason);
     }
     if (cacheFailPending) {
         cacheFailPending = false;
@@ -708,15 +731,18 @@ static void serviceWifiEventFollowUp(void) {
     }
     if (rssiLowNoticePending) {
         rssiLowNoticePending = false;
-        lanLog("WiFi: RSSI " + String((int)s_lastRssiLowDbm) + " dBm below " +
-                    String(OD_LAN_ROAM_RSSI_THRESHOLD) + " dBm -- roam queued (deferred to idle)");
+        od_log_info("WiFi: RSSI %d dBm below %d dBm -- roam queued (deferred to idle)",
+                    (int)s_lastRssiLowDbm, (int)OD_LAN_ROAM_RSSI_THRESHOLD);
         lanArmRssiThreshold();   // one-shot: re-arm so a deferred roam still re-triggers
     }
     if (gotIpPending) {
         gotIpPending = false;
-        lanLog("WiFi event: got IP " + IPAddress((uint32_t)s_lastGotIp).toString() +
-                    ", RSSI " + String(WiFi.RSSI()) + " dBm, ch " + String(WiFi.channel()) +
-                    ", BSSID " + WiFi.BSSIDstr());
+        const IPAddress gotIp((uint32_t)s_lastGotIp);
+        char bssid[18];
+        lanFormatBssid(bssid, sizeof(bssid), WiFi.BSSID());
+        od_log_info("WiFi event: got IP %u.%u.%u.%u, RSSI %d dBm, ch %d, BSSID %s",
+                    gotIp[0], gotIp[1], gotIp[2], gotIp[3],
+                    (int)WiFi.RSSI(), (int)WiFi.channel(), bssid);
         lanCacheStoreCurrentAp();   // remember this AP for the next deep-sleep wake
         lanArmRssiThreshold();      // also (re)registers the RSSI-low handler
     }
@@ -729,7 +755,7 @@ void serviceLanRoam(void) {
     // so the driver's bssid_set is cleared and a full scan picks a live AP.
     if (rescanReconnectPending && !wifiConnected) {
         rescanReconnectPending = false;
-        lanLog("WiFi: cached AP unreachable -- falling back to a full scan");
+        od_log_info("WiFi: cached AP unreachable -- falling back to a full scan");
         WiFi.disconnect(false);
         lanBeginConnect();   // cache was invalidated on the disconnect -> scan path
         return;
@@ -744,7 +770,7 @@ void serviceLanRoam(void) {
     if (transferActive()) return;
 
     roamPending = false;
-    lanLog("WiFi: roaming -- re-associating to the strongest AP for this SSID");
+    od_log_info("WiFi: roaming -- re-associating to the strongest AP for this SSID");
     // MUST drop the cache first: the whole point of a roam is to leave this AP, and
     // lanBeginConnect() would otherwise pin us straight back to the one we are escaping.
     lanCacheInvalidate("roaming to a stronger AP");
@@ -758,25 +784,25 @@ void serviceLanRoam(void) {
 }
 
 void initWiFi(bool waitForConnection) {
-    lanLog("=== Initializing WiFi ===");
+    od_log_info("=== Initializing WiFi ===");
 
     // WiFi is NOT gated on power_mode: if COMM_MODE_WIFI is enabled the radio comes
     // up on battery too. Radio cost on battery is managed by the driver's default
     // power-save mode and by deep sleep, not by refusing to associate.
     if (!(globalConfig.system_config.communication_modes & COMM_MODE_WIFI)) {
-        lanLog("WiFi not enabled in communication_modes, skipping");
+        od_log_info("WiFi not enabled in communication_modes, skipping");
         wifiInitialized = false;
         return;
     }
     if (!wifiConfigured) {
-        lanLog("WiFi: system_config has WiFi mode on, but wifi_config TLV (0x26) is not in saved "
+        od_log_info("WiFi: system_config has WiFi mode on, but wifi_config TLV (0x26) is not in saved "
                     "configuration (or failed to parse). Enable Wi-Fi in config, set SSID, and write full "
                     "config to the device.");
         wifiInitialized = false;
         return;
     }
     if (wifiSsid[0] == '\0' || strlen(wifiSsid) == 0) {
-        lanLog("WiFi: wifi_config packet present but SSID field is empty.");
+        od_log_info("WiFi: wifi_config packet present but SSID field is empty.");
         wifiInitialized = false;
         return;
     }
@@ -805,12 +831,12 @@ void initWiFi(bool waitForConnection) {
     // WiFi.status() call sites in main.cpp/config_parser.cpp all run after setup().
     WiFi.useStaticBuffers(true);
     // Do not log the SSID or password (credentials); log only presence/length.
-    lanLog("WiFi: connecting to configured SSID (len " + String(strlen(wifiSsid)) + ")");
+    od_log_info("WiFi: connecting to configured SSID (len %u)", (unsigned)strlen(wifiSsid));
     registerWiFiDiagEvents();
     WiFi.setAutoReconnect(true);
     wifiSsid[32] = '\0';
     wifiPassword[32] = '\0';
-    lanLog("Encryption type: 0x" + String(wifiEncryptionType, HEX));
+    od_log_info("Encryption type: 0x%x", (unsigned)wifiEncryptionType);
     wifiConnected = false;
     wifiInitialized = true;
     // Cached BSSID when RTC memory still holds one (the deep-sleep-wake fast path:
@@ -820,10 +846,10 @@ void initWiFi(bool waitForConnection) {
     // pre-begin() call this replaces failed with ESP_ERR_WIFI_NOT_START.
     WiFi.setTxPower(WIFI_POWER_15dBm);
     if (!waitForConnection) {
-        lanLog("WiFi: STA started (non-blocking; LAN starts when associated)");
+        od_log_info("WiFi: STA started (non-blocking; LAN starts when associated)");
         return;
     }
-    lanLog("Waiting for WiFi connection...");
+    od_log_info("Waiting for WiFi connection...");
     const int maxRetries = 3;
     const unsigned long timeoutPerRetry = 10000;
     bool connected = false;
@@ -833,9 +859,9 @@ void initWiFi(bool waitForConnection) {
         while (WiFi.status() != WL_CONNECTED && (millis() - startAttempt < timeoutPerRetry)) {
             delay(500);
             wl_status_t status = WiFi.status();
-            lanLog("WiFi status: " + String(status));
+            od_log_info("WiFi status: %d", (int)status);
             if (status == WL_CONNECT_FAILED || status == WL_NO_SSID_AVAIL) {
-                lanLog("Connection failed immediately (Status: " + String(status) + ")");
+                od_log_info("Connection failed immediately (Status: %d)", (int)status);
                 abortCurrentRetry = true;
                 break;
             }
@@ -845,7 +871,7 @@ void initWiFi(bool waitForConnection) {
             break;
         }
         if (!abortCurrentRetry) {
-            lanLog("WiFi attempt " + String(retry + 1) + " timed out");
+            od_log_info("WiFi attempt %d timed out", retry + 1);
         }
         if (retry < maxRetries - 1) {
             delay(2000);
@@ -853,12 +879,15 @@ void initWiFi(bool waitForConnection) {
     }
     if (WiFi.status() == WL_CONNECTED) {
         wifiConnected = true;
-        lanLog("=== WiFi connected ===");
-        lanLog("IP: " + WiFi.localIP().toString());
+        od_log_info("=== WiFi connected ===");
+        {
+            const IPAddress ip = WiFi.localIP();
+            od_log_info("IP: %u.%u.%u.%u", ip[0], ip[1], ip[2], ip[3]);
+        }
         startLanServer();
     } else {
         wifiConnected = false;
-        lanLog("=== WiFi connection failed ===");
+        od_log_info("=== WiFi connection failed ===");
     }
 }
 
@@ -873,7 +902,7 @@ void wifiLanDropOwnedSocket(void) {
     // abort's own steps 8 and 3-5. Calling them here would nest the two teardowns.
     tlsCloseSession();
     if (wifiClient.connected()) {
-        lanLog("Closing LAN client (session abort)");
+        od_log_info("Closing LAN client (session abort)");
         wifiClient.stop();
     }
     wifiServerConnected = false;
@@ -887,7 +916,7 @@ void wifiLanDropOwnedSocket(void) {
 void disconnectWiFiServer() {
     tlsCloseSession();
     if (wifiClient.connected()) {
-        lanLog("Closing LAN client");
+        od_log_info("Closing LAN client");
         clearEncryptionSession();
         wifiClient.stop();
     }
@@ -930,7 +959,7 @@ static int lanReadIntoBuffer(void) {
     // and read as a network fault rather than a code bug.
     int space = (int)OD_LAN_RX_BUFFER_SIZE - (int)tcpReceiveBufferPos;
     if (space <= 0) {
-        lanLog("LAN RX buffer full, dropping connection");
+        od_log_info("LAN RX buffer full, dropping connection");
         return -1;
     }
     if (tlsMode) {
@@ -963,7 +992,7 @@ void wifiLanReapClosedSession(void) {
     // point: raising it from inside handleWiFiServer left the accept testing a
     // corpse's token and refusing an ordinary reconnect.
     if (wifiServerConnected && !wifiClient.connected()) {
-        lanLog("LAN: peer closed the socket, reaping the session");
+        od_log_info("LAN: peer closed the socket, reaping the session");
         disconnectWiFiServer();
     }
 }
@@ -997,8 +1026,8 @@ static void admitOrRefuseLanClient(WiFiClient& incoming) {
     // them apart) landed in it.
     const LinkId held = linkOwnerId();
     if (held.who != OWNER_NONE) {
-        lanLog("LAN: refusing new client, slot held by " +
-               String(held.who == OWNER_BLE ? "BLE" : "LAN"));
+        od_log_info("LAN: refusing new client, slot held by %s",
+                    held.who == OWNER_BLE ? "BLE" : "LAN");
         incoming.stop();
         return;
     }
@@ -1026,7 +1055,7 @@ static void admitOrRefuseLanClient(WiFiClient& incoming) {
     // authoritative arbitration point, not this loop-side test (R7d).
     s_lanEpoch = linkNextEpoch();
     if (!linkClaim((LinkId){OWNER_LAN, 0, s_lanEpoch})) {
-        lanLog("LAN: refusing new client, slot claimed concurrently");
+        od_log_info("LAN: refusing new client, slot claimed concurrently");
         s_lanEpoch = 0;
         incoming.stop();
         wifiClient = WiFiClient();
@@ -1034,9 +1063,10 @@ static void admitOrRefuseLanClient(WiFiClient& incoming) {
         return;
     }
 
-    lanLog("LAN client connected from " + wifiClient.remoteIP().toString());
+    const IPAddress peer = wifiClient.remoteIP();
+    od_log_info("LAN client connected from %u.%u.%u.%u", peer[0], peer[1], peer[2], peer[3]);
     if (tlsMode && !tlsBeginSession()) {
-        lanLog("LAN: TLS session start failed, dropping");
+        od_log_info("LAN: TLS session start failed, dropping");
         disconnectWiFiServer();
     }
 }
@@ -1048,15 +1078,20 @@ void handleWiFiServer() {
 
     if (wifiInitialized && WiFi.status() == WL_CONNECTED && !wifiConnected) {
         wifiConnected = true;
-        lanLog("=== WiFi connected ===");
-        lanLog("IP: " + WiFi.localIP().toString() +
-                    ", RSSI " + String(WiFi.RSSI()) + " dBm, ch " + String(WiFi.channel()) +
-                    ", BSSID " + WiFi.BSSIDstr());
+        od_log_info("=== WiFi connected ===");
+        {
+            const IPAddress ip = WiFi.localIP();
+            char bssid[18];
+            lanFormatBssid(bssid, sizeof(bssid), WiFi.BSSID());
+            od_log_info("IP: %u.%u.%u.%u, RSSI %d dBm, ch %d, BSSID %s",
+                        ip[0], ip[1], ip[2], ip[3],
+                        (int)WiFi.RSSI(), (int)WiFi.channel(), bssid);
+        }
         startLanServer();
     }
     if (!wifiConnected || WiFi.status() != WL_CONNECTED) {
         if (wifiServerConnected || wifiClient.connected()) {
-            lanLog("WiFi lost, closing LAN session");
+            od_log_info("WiFi lost, closing LAN session");
             disconnectWiFiServer();
         }
         return;
@@ -1080,7 +1115,7 @@ void handleWiFiServer() {
 
     if (!wifiServerConnected || !wifiClient.connected()) {
         if (wifiServerConnected) {
-            lanLog("LAN client disconnected");
+            od_log_info("LAN client disconnected");
             disconnectWiFiServer();
         }
         return;
@@ -1097,13 +1132,15 @@ void handleWiFiServer() {
             // reclaims the socket -- which is why no separate handshake deadline is
             // needed.
             linkStampOwnerCommand();
-            lanLog("LAN: TLS handshake complete");
+            od_log_info("LAN: TLS handshake complete");
         } else if (hs == MBEDTLS_ERR_SSL_WANT_READ || hs == MBEDTLS_ERR_SSL_WANT_WRITE) {
             // still handshaking; but honor the idle timeout below
         } else {
             // The handshake struct is another internal-DRAM allocation, so annotate the
             // heap here too -- an OOM mid-handshake looks like a protocol error otherwise.
-            lanLog("LAN: TLS handshake failed" + tlsFailNote(hs) + ", dropping");
+            char note[OD_TLS_FAIL_NOTE_LEN];
+            tlsFailNote(hs, note, sizeof(note));
+            od_log_info("LAN: TLS handshake failed%s, dropping", note);
             disconnectWiFiServer();
             return;
         }
@@ -1121,13 +1158,15 @@ void handleWiFiServer() {
         got = lanReadIntoBuffer();
         if (got == OD_LAN_READ_CLOSED) {
             // Normal end of a push: the client finished and sent close_notify.
-            lanLog("LAN: client closed the connection");
+            od_log_info("LAN: client closed the connection");
             disconnectWiFiServer();
             return;
         }
         if (got < 0) {
             // Real fault -- name the mbedTLS code, otherwise this is undiagnosable.
-            lanLog("LAN: channel read error" + tlsFailNote(s_lastLanReadErr) + ", dropping");
+            char note[OD_TLS_FAIL_NOTE_LEN];
+            tlsFailNote(s_lastLanReadErr, note, sizeof(note));
+            od_log_info("LAN: channel read error%s, dropping", note);
             disconnectWiFiServer();
             return;
         }
@@ -1152,7 +1191,7 @@ void handleWiFiServer() {
         while (tcpReceiveBufferPos >= 2) {
             uint16_t flen = (uint16_t)(tcpReceiveBuffer[0] | (tcpReceiveBuffer[1] << 8));
             if (flen == 0 || flen > OD_LAN_MAX_PAYLOAD) {
-                lanLog("LAN: invalid frame length, closing");
+                od_log_info("LAN: invalid frame length, closing");
                 disconnectWiFiServer();
                 return;
             }
@@ -1219,7 +1258,7 @@ void opendisplay_lan_teardown(void) {
         tlsInited = false;
     }
     WiFi.disconnect(true);
-    lanLog("LAN/WiFi torn down before restart", true);
+    od_log_info("LAN/WiFi torn down before restart");
 }
 
 #endif  // OPENDISPLAY_HAS_WIFI

--- a/src/wifi_service.cpp
+++ b/src/wifi_service.cpp
@@ -806,30 +806,6 @@ void initWiFi(bool waitForConnection) {
         wifiInitialized = false;
         return;
     }
-    // Bound the WiFi driver's TX memory to a fixed pool. Arduino's default
-    // (_wifiUseStaticBuffers = false) REPLACES the IDF buffer profile inside
-    // wifiLowLevelInit() with a demand-driven one: static_tx_buf_num 0 /
-    // dynamic_tx_buf_num 32 / cache_tx_buf_num 4 / static_rx_buf_num 4. Setting this
-    // skips that override, so esp_wifi_init() gets WIFI_INIT_CONFIG_DEFAULT() --
-    // static_tx 8, dynamic_tx 0, cache_tx 0, static_rx 8 (sdkconfig).
-    //
-    // At the documented ~1.6 KB per WiFi buffer that trades ~13 KB more resident
-    // internal DRAM for ~38 KB off the peak: TX becomes 12.8 KB always instead of up
-    // to 51.2 KB whenever traffic asks. The right trade here because this part dies on
-    // transients, not on baseline -- a 2026-08-03 coredump caught the tcpip task with a
-    // NULL from the mDNS allocator during an inbound query burst, and the OOM error log
-    // then aborted in lock_init_generic. RX is unchanged: dynamic_rx_buf_num is 32 in
-    // both profiles and Arduino exposes no knob for it.
-    //
-    // cache_tx_buf_num 0 is correct here, not the "can't be zero!" case in Arduino's
-    // dynamic path: cache TX buffers exist to copy dynamic TX buffers out of PSRAM into
-    // DMA-capable memory, and static TX buffers are already internal and DMA-capable.
-    //
-    // MUST precede every WiFi call -- wifiLowLevelInit() reads the flag once and latches
-    // lowLevelInitDone. Set later it only logs a warning and takes effect after a
-    // WiFi.mode(WIFI_MODE_NULL). Nothing touches the WiFi API before this point: the
-    // WiFi.status() call sites in main.cpp/config_parser.cpp all run after setup().
-    WiFi.useStaticBuffers(true);
     // Do not log the SSID or password (credentials); log only presence/length.
     od_log_info("WiFi: connecting to configured SSID (len %u)", (unsigned)strlen(wifiSsid));
     registerWiFiDiagEvents();


### PR DESCRIPTION
## Summary

Reduces resident internal DRAM on ESP32-S3 WiFi targets and removes `String` allocation from the
LAN logging path. Motivated by a coredump taken 2026-08-03 (`esp32-s3-N16R8-extuart-debug`,
reTerminal E1003): the tcpip task got a NULL from the mDNS packet allocator during an inbound
query burst, causing a PANIC (4) reset from internal heap exhaustion.

Net on the seven S3 envs: **`.bss` 95,352 → 78,856 B (−16,496 B)**, returned to the internal
heap. Other targets unchanged.

## Contents

| Commit | Change |
|---|---|
| `194bd7b` | Replace `lanLog(const String&)` with `od_log_*` printf logging across 67 call sites |
| `78ccddb` | Reserve the two 4 KB config buffers (`configScratch`, `chunkedWriteState.buffer`) in PSRAM on S3 |
| `752eb69` | Reserve the 8,316 B PIPE reorder queue in PSRAM on S3 |
| `2fd2684` | Drop the fail-closed null handling from `78ccddb`, for consistency with `752eb69` |

`b0060d1` sets `WiFi.useStaticBuffers(true)` and `c12be6e` reverts it. They cancel out, kept
unsquashed because the revert message documents why the approach was wrong: it bounds the TX
ceiling, but the observed failure is RX-side (`dynamic_rx_buf_num` is 32 in both profiles, and
static mode also doubles `static_rx_buf_num`), leaving RX ~6.4 KB worse resident. Confirmed on
hardware before reverting — min free dropped by roughly the predicted 13 KB.

## Notes

Both relocated buffers are touched only on the loop task via BLE command dispatch — never from an
ISR, never handed to DMA — and accessed at BLE frame rate, far below PSRAM bandwidth. Gated on
`OPENDISPLAY_ENABLE_WIFI && BOARD_HAS_PSRAM`, so only the seven S3 envs change.

A failed reservation is logged at boot and not otherwise handled: it means defective PSRAM, and a
board that cannot allocate 4–8 KB cannot hold FastEPD's 2.6 MB framebuffer either.

## Testing

- Tested on hardware.
- Built all 16 environments.
- `194bd7b` rebuilt with `-Wformat -Wformat-security` explicitly enabled (the project sets no
  `-Wall`, so the `format(printf)` attribute on `_od_log` was not being checked). Zero format
  warnings from the 67 converted sites; two pre-existing `%u`/`uint32_t` warnings in
  `main.cpp:150,159` and a `-Wconversion-null` in `wifi_service.cpp` are untouched.
- Message text and log level unchanged at all 67 converted sites, so old and new field logs stay
  directly comparable.
