### PR TITLE
fix(e1004): reconfigure panel geometry on deep sleep wakeup

### DIFF
--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -144,6 +144,8 @@ struct PartialStreamContext {
 
 void pwrmgm(bool onoff);
 String getChipIdHex();
+int bbepSetPanelType(BBEPDISP *pBBEP, int iPanel);
+void bbepSetRotation(BBEPDISP *pBBEP, int iRotation);
 void bbepInitIO(BBEPDISP *pBBEP, uint8_t u8DC, uint8_t u8RST, uint8_t u8BUSY, uint8_t u8CS, uint8_t u8MOSI, uint8_t u8SCK, uint32_t u32Speed);
 void bbepWakeUp(BBEPDISP *pBBEP);
 void bbepSendCMDSequence(BBEPDISP *pBBEP, const uint8_t *pSeq);
@@ -359,6 +361,28 @@ static void epdAlignCustomPartialRamMode(void) {
     }
 }
 
+// Sets bbep.type/native dims/rotation and (E1004) e1004GeometryOk from globalConfig.
+static void configureBbepPanelGeometry(void) {
+    memset(&bbep, 0, sizeof(BBEPDISP));
+    int panelType = mapEpd(globalConfig.displays[0].panel_ic_type);
+    bbepSetPanelType(&bbep, panelType);
+    int rotation = globalConfig.displays[0].rotation * 90;
+#ifdef BBEP_T133A01
+    e1004GeometryOk = false;
+    if (e1004_panel_used()) {
+        rotation = 0;  // host bakes rotation into packed image
+        if (globalConfig.displays[0].pixel_width != bbep.native_width ||
+            globalConfig.displays[0].pixel_height != bbep.native_height ||
+            globalConfig.displays[0].color_scheme != OD_COLOR_SCHEME_BWGBRY_SPLIT) {
+            od_log_error("ERROR: E1004 requires a 1200x1600 bwgbry_split (8) display config");
+        } else {
+            e1004GeometryOk = true;
+        }
+    }
+#endif
+    bbepSetRotation(&bbep, rotation);
+}
+
 static void initBbepPanelSession() {
     const DisplayConfig& d = globalConfig.displays[0];
 #ifdef BBEP_T133A01
@@ -511,6 +535,7 @@ static bool epdSessionAcquire(bool partialInit) {
         pwrmgm(true);   // -> PWR_ACTIVE (guarded; real transition)
         if (!epdSessionUsesFastepd()) {
             const DisplayConfig& d = globalConfig.displays[0];
+            configureBbepPanelGeometry();
 #ifdef BBEP_T133A01
             if (e1004_panel_used()) {
                 e1004InitPanel();
@@ -1787,24 +1812,7 @@ void initDisplay(){
 #endif
     {
         prepareEpdRailForBoot();
-        memset(&bbep, 0, sizeof(BBEPDISP));
-        int panelType = mapEpd(globalConfig.displays[0].panel_ic_type);
-        bbepSetPanelType(&bbep, panelType);
-        int rotation = globalConfig.displays[0].rotation * 90;
-#ifdef BBEP_T133A01
-        e1004GeometryOk = false;
-        if (e1004_panel_used()) {
-            rotation = 0;  // host bakes rotation into packed image
-            if (globalConfig.displays[0].pixel_width != bbep.native_width ||
-                globalConfig.displays[0].pixel_height != bbep.native_height ||
-                globalConfig.displays[0].color_scheme != OD_COLOR_SCHEME_BWGBRY_SPLIT) {
-                od_log_error("ERROR: E1004 requires a 1200x1600 bwgbry_split (8) display config");
-            } else {
-                e1004GeometryOk = true;
-            }
-        }
-#endif
-        bbepSetRotation(&bbep, rotation);
+        configureBbepPanelGeometry();
         od_log_info("Height: %u", globalConfig.displays[0].pixel_height);
         od_log_info("Width: %u", globalConfig.displays[0].pixel_width);
         initBbepPanelSession();


### PR DESCRIPTION
## Issue

- E1004 waking from deep sleep was logging "E1004 dual-CS plane open failed" and showing static on the screen left half and no update on the right half.

## Fix

- Move geometry configuration from initDisplay to configureBbepPanelGeometry
- Call on deep sleep wake up as well as initDisplay

## Summary
configureBbepPanelGeometry used to live only inline in initDisplay(), which the deep-sleep wake path (main.cpp) skips entirely to save power and keep the panel image. `bbep` is a plain global (not RTC_DATA_ATTR), so a wake reset zeroes it -- leaving e1004GeometryOk false and bbep.type/native_width/native_height unset for the whole boot. On E1004 that makes every e1004_begin_plane() call after wake fail its geometry guard (logged as "E1004 dual-CS plane open failed") and silently drop the panel payload (directWriteSinkBytes only forwards bytes when e1004GeometryOk), which is what produces static on the left half and a stale right half. Calling this from epdSessionAcquire()'s cold bring-up as well as initDisplay() ensures the type/geometry state exists before any panel command sequence runs, whether this is a fresh cold boot or the first push after waking.

