### PR TITLE
fix(boot): fill the boot-screen swatches on BWR/BWY panels

### DIFF
--- a/src/boot_screen.cpp
+++ b/src/boot_screen.cpp
@@ -1019,7 +1019,7 @@ bool writeBootScreenWithQr() {
                     ;
                 if (black) {
                     setBootPixelBlack(row, x_native, pitch, bitsPerPixel, colorScheme);
-                } else if (!useBitplanes) {
+                } else {
                     int si = bootSwatchIndex(lx, ly, swatchY0, swatchY1, swatchW, numSwatches, w_log);
                     if (si >= 0) setBootPixelCode(row, x_native, pitch, bitsPerPixel, swatchCode[si]);
                 }


### PR DESCRIPTION
Fixes #148.

The boot screen's footer swatches skipped their interior fill on B/W/R and
B/W/Y configs, so the black swatch rendered as an empty outlined box.

The fill was gated behind `!useBitplanes`. The guard is unnecessary: swatch
codes go through `setBootPixelCode()`, which at 1 bpp already clears the bit
for code 0 and sets it for code 1 — exactly the black and white the B/W
plane needs. The coloured swatch never reaches this path at all;
`colorPlanePass` paints it on `PLANE_1` and continues.

**Verified on P750057-MF1-A 7.5" B/W/R panel**

<img width="4096" height="3072" alt="IMG_20260810_192910" src="https://github.com/user-attachments/assets/10191658-f865-4871-b10d-f02d713c57cd" />
