### PR TITLE
feat(esp32): add esp32-s3-N4R2 build environment

### DIFF
--- a/.github/firmware-targets.json
+++ b/.github/firmware-targets.json
@@ -49,6 +49,15 @@
       "bootloader_offset": "0x0000"
     },
     {
+      "env": "esp32-s3-N4R2",
+      "family": "esp32",
+      "chip": "esp32-s3",
+      "flash_size": "4MB",
+      "flash_mode": "dio",
+      "flash_freq": "80m",
+      "bootloader_offset": "0x0000"
+    },
+    {
       "env": "esp32-s3-N32R8",
       "family": "esp32",
       "chip": "esp32-s3",

--- a/platformio.ini
+++ b/platformio.ini
@@ -48,6 +48,7 @@ default_envs =
 	esp32-c3-N16
 	esp32-c6-N4
 	esp32-N4
+	esp32-s3-N4R2
 
 [env]
 lib_deps =
@@ -247,6 +248,28 @@ board_build.usb_mode = hardware
 board_upload.maximum_size = 8388608
 board_upload.maximum_ram_size = 327680
 board_upload.flash_size = 8MB
+monitor_speed = 115200
+
+; ESP32-S3 N4R2 -- 4 MB flash + 2 MB quad PSRAM (Waveshare ESP32-S3-Zero and the
+; other S3 mini boards built on ESP32-S3FH4R2).
+[env:esp32-s3-N4R2]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
+framework = arduino
+build_flags =
+  -DTARGET_ESP32
+  -DOPENDISPLAY_ENABLE_WIFI  ; LAN transport + ROM tinfl. Set ONLY on -DBOARD_HAS_PSRAM envs (src/wifi_service.h)
+  -DOPENDISPLAY_ZLIB_USE_HEAP_WINDOW=1
+  -DBOARD_HAS_PSRAM
+  -DARDUINO_USB_MODE=1
+  -DARDUINO_USB_CDC_ON_BOOT=1
+  -DCONFIG_FREERTOS_WATCHDOG_TIMEOUT_S=120
+board_build.filesystem = littlefs
+board = esp32-s3-devkitc-1
+board_build.partitions = huge_app.csv
+board_build.arduino.memory_type = qio_qspi
+board_build.psram_type = qspi
+board_build.usb_mode = hardware
+board_upload.flash_size = 4MB
 monitor_speed = 115200
 
 [env:esp32-s3-N32R8]


### PR DESCRIPTION
## Why

The Waveshare ESP32-S3-Zero and the other S3 mini boards built on the
ESP32-S3FH4R2 have no environment they can use. Every existing S3 env is an R8
part with 8 MB or more of flash, and two of those settings are fatal on an R2:

- **PSRAM is quad, not octal.** The R8 envs set `memory_type = qio_opi` /
  `psram_type = qspi_opi`. An R2 part needs `qio_qspi` / `qspi` or PSRAM never
  comes up.
- **4 MB flash.** `default_4MB`'s paired 1.25 MB app slots are too small — this
  firmware is ~1.5 MB with WiFi + BLE. `huge_app` gives a single 3 MB slot, at
  the cost of OTA.

## What

New `[env:esp32-s3-N4R2]`, modelled on `esp32-s3-N8R8` with those two changes,
plus:

- **FastEPD left out.** It serves only the four large panels on the
  parallel/IT8951 path (ED103TC2 10.3", Inkplate 5 V2, Inkplate 10). Their
  2.6 MB framebuffer does not fit in 2 MB of PSRAM, and the Inkplate ones also
  want a parallel bus this class of board has no pins for. SPI panels go
  through bb_epaper. Worth being precise that this is a PSRAM limit and not a
  flash one: linking FastEPD in builds fine and costs only ~51 KB, 48.5% of the
  slot instead of 46.9%.
- Registered in `.github/firmware-targets.json` and in `default_envs`, so
  neither CI nor a bare `pio run` silently skips it.

## Testing

Built and flashed on a Waveshare ESP32-S3-Zero. The image is 1.47 MB of the
3 MB slot (46.9%), RAM 29.8%. PSRAM comes up and is used — the PIPE reorder
queue and the 16 KB LAN RX buffer both allocate there — and BLE and the
WiFi/LAN transport both work.
