### PR TITLE
fix(epd): run SSD1683 EOPT discharge before the EP42B rail cut

### DIFF
--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -310,6 +310,20 @@ static uint32_t epdKeepAliveWindowMs(void) {
     return (uint32_t)s * 1000;
 }
 
+static constexpr uint8_t SSD1608_END_OPTION = 0x3f;
+
+static void bbepRefreshForFinalCut(int mode, bool cutAfterSuccess) {
+    if (!cutAfterSuccess || mode != REFRESH_FULL || bbep.type != EP42B_400x300 ||
+        globalConfig.system_config.pwr_pin == 0xff) {
+        bbepRefresh(&bbep, mode);
+        return;
+    }
+    bbepSendCMDSequence(&bbep, bbep.pInitFull);
+    bbepCMD2(&bbep, SSD1608_DISP_CTRL2, 0xf7);
+    bbepCMD2(&bbep, SSD1608_END_OPTION, 0x22);
+    bbepWriteCmd(&bbep, SSD1608_MASTER_ACTIVATE);
+}
+
 // Session try-lock, now UNCONTENDED on both targets and kept as defence in depth.
 //
 // It existed because nRF dispatched commands on the Bluefruit write-callback
@@ -529,7 +543,7 @@ static bool refreshBootScreenFull() {
     // panel must not be refreshed with it.
     if (splitPanelUsed() && !splitPanelCloseFrame()) return false;
     odWatchdogFeed();   // reload before entering bb_epaper (may block ~240 s)
-    bbepRefresh(&bbep, REFRESH_FULL);
+    bbepRefreshForFinalCut(REFRESH_FULL, true);
     const bool ok = waitforrefresh(60);
     splitPanelPowerOff();
     return ok;
@@ -2503,7 +2517,7 @@ static void directWriteFinishAndRefresh(uint8_t* data, uint16_t len, uint8_t end
         if (splitPanelUsed() && !splitPanelCloseFrame()) refreshMode = -1;
         if (refreshMode >= 0) {
             odWatchdogFeed();   // reload before entering bb_epaper (may block ~240 s)
-            bbepRefresh(&bbep, refreshMode);
+            bbepRefreshForFinalCut(refreshMode, epdKeepAliveWindowMs() == 0);
             refreshSuccess = waitforrefresh(60);
             splitPanelPowerOff();
         }
@@ -3365,7 +3379,7 @@ static bool partial_trigger_refresh(int refreshMode) {
         return waitforrefresh(60);
     }
     odWatchdogFeed();   // reload before entering bb_epaper (may block ~240 s)
-    bbepRefresh(&bbep, refreshMode);
+    bbepRefreshForFinalCut(refreshMode, epdKeepAliveWindowMs() == 0);
     return waitforrefresh(60);
 }
 


### PR DESCRIPTION
## Symptom

On Ex05 boards (EE05/EN05), a 4.2" EP42B panel renders a correct image — background perfectly white — and then greys out over the following seconds. The degradation is cumulative across updates and gated by **direct sunlight**, not merely warmth. It has been reported both via Home Assistant and via the opendisplay.org web tool.

The "correct at birth, decays afterwards" shape is what points at teardown rather than at the waveform.

## Cause

At the end of a refresh the panel's external boost caps still hold charge — VGH/VGL, VSH/VSL, VCOM. Today's teardown sleeps the controller and then cuts the rail, but the SSD16xx deep-sleep command (`0x10`) only gates clocks; it discharges nothing. VCC therefore disappears while the high-voltage rails are still charged, the gate drivers lose authority, and that charge exits through the pixels as a DC stress on marginally-latched cells.

Sunlight is the gate rather than heat: the backplane is amorphous-silicon TFT, which is strongly photoconductive, and both controller vendors independently document the panel's light sensitivity. In the dark the off-state TFTs mostly block the path; in direct sun they conduct.

**The differentiator is what runs before the cut.** UC81xx panels on the same boards — same rail cut, same pin park, same 50 ms — do *not* grey out, because `bbepSleep()` sends `POFF` and waits on BUSY first. SSD16xx has no standalone power-off command. On that family the discharge lives in the end-of-display sequence selected by **EOPT** (register `0x3F`, waveform byte 227), and `EP42B_400x300` never writes it, so the panel runs whatever its OTP waveform happens to specify.

## Change

Write `0x3F = 0x22` between the update-control write and Master Activation, so the controller runs two TFT discharge scan frames plus its sequenced VCOM/HV shutdown as part of the refresh:

```
init sequence (incl. SWRESET)
0x22 = 0xF7      update control
0x3F = 0x22      EOPT  <-- added
0x20             Master Activation
wait BUSY
```

The discharge completes inside the refresh the client is already waiting on, so the existing `waitforrefresh()` covers it. No teardown sequencing changes, no added delay, no new constants in the power path.

A useful consequence: because the discharge now happens at refresh time rather than teardown time, every path that later removes power — including the latch power-off paths that perform no panel teardown at all — inherits an already-discharged panel from the last completed refresh.

## Scope

Deliberately narrow. `bbepRefreshForFinalCut()` diverges from `bbepRefresh()` only when **all** of these hold:

- `bbep.type == EP42B_400x300`
- the refresh is `REFRESH_FULL`
- a panel-power cut can follow (`pwr_pin` configured)
- the caller knows this activation precedes teardown — boot passes `true` unconditionally; direct-write and partial paths pass `epdKeepAliveWindowMs() == 0`

Everything else takes the untouched `bbepRefresh()` path byte-for-byte: **EP42B 4-gray** (its custom waveform already contains EOPT `0x22`, so it would be a redundant write — and it doubles as a validation control), every other SSD16xx type, UC81xx, split-buffer panels, FastEPD, and switchless boards. Dispatch is on runtime `bbep.type`, never the broad `BBEP_CHIP_SSD16xx` class, since the `0x22 = 0x83`/EOPT evidence is SSD1683-specific and that bucket spans many controller generations.

Note `0x3F = 0x22` (EOPT register) is distinct from command `0x22` (Display Update Control 2); the normal update-control values are unchanged.

## Cost

Two additional scan frames on eligible full refreshes only. No heap, no persistent state, no build flag, no new PlatformIO environment, no protocol or config-schema change. Warm keep-alive sessions are unaffected — they emit no EOPT, since a rail that stays powered has nothing to strand.

## Build

All **17** environments build with `src/display_service.cpp` genuinely recompiled in each (objects deleted first — SCons hashes content, so a `touch` alone silently reuses cached objects):

- 12 CI targets from `.github/firmware-targets.json`, including `esp32-wrover-e-N4R8`, which a bare `pio run` skips
- 4 debug/diagnostic environments
- `nrf52840-reformat` links clean; its `build_src_filter` excludes this file entirely

## Status — draft, not ready to merge

Opened as a draft because the change is **not bench-validated**. Two things remain open:

1. **Does a bare `0x3F` write survive the OTP load?** `0xF7` requests an LUT and temperature load at Master Activation. Every existing instance of EOPT `0x22` in bb_epaper — EP296 partial, Badger 2350, and EP42B 4-gray — supplies it inside a **custom LUT uploaded via `0x32`**, never as a bare register write against an OTP waveform. The datasheet says these waveform bytes "can be overridden by the latest register setting", but that has not been confirmed on this panel. The diagnostic: repeat with update control `0xE7` (clears only the LUT-load bit) — a discharge signature there but not at `0xF7` means the OTP load wins. If it does, the fallback is a custom mono LUT carrying EOPT, as 4-gray already does.
2. **Does the discharge actually fix the field symptom?** Needs a sunlight A/B on EN05/EE05 against baseline, with VCOM/VGL traced from activation through the rail cut. The electrical signature is the primary proof; the sunlight result confirms it addresses the reported failure.

Also worth flagging for reviewers, as follow-ups rather than blockers:

- The eligibility check tests `pwr_pin` only. Boards that cut panel power via **AXP2101 or a device latch** with no `pwr_pin` are skipped, so they keep today's behaviour.
- The `REFRESH_FULL` restriction and the hardcoded `0xF7` are load-bearing on each other — relaxing the mode check without selecting from `{0xF7, 0xC7, 0xFF}` would send a full-refresh byte for a partial.
- Longer term this belongs in `bb_epaper` as a per-call pre-activation option with a named `SSD1608_END_OPTION` constant, rather than a firmware-side replication of `bbepRefresh()`'s sequence.
- **EP426** (4.26") is field-confirmed failing but excluded here: it is not SSD1683-class, and needs its own controller validation before being added.
