### PR TITLE
Report battery voltage from a configured AXP2101

### DIFF
--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -9,6 +9,7 @@
 #include "buzzer_control.h"
 #include "sensor_sht40.h"
 #include "sensor_bq27220.h"
+#include "sensor_axp2101.h"
 #include "communication.h"
 #include "encryption.h"
 #include "boot_screen.h"
@@ -1766,6 +1767,10 @@ static float readBatteryVoltageUncached() {
         if (gaugeV >= 0.0f) {
             return gaugeV;
         }
+    }
+    const float pmicV = axp2101BatteryVoltageVolts(globalConfig.sensors, globalConfig.sensor_count);
+    if (pmicV >= 0.0f) {
+        return pmicV;
     }
     if (globalConfig.power_option.battery_sense_pin == 0xFF) return -1.0;
     uint8_t sensePin = globalConfig.power_option.battery_sense_pin;

--- a/src/sensor_axp2101.cpp
+++ b/src/sensor_axp2101.cpp
@@ -1,0 +1,108 @@
+#include "sensor_axp2101.h"
+
+#include "structs.h"
+#include "display_service.h"
+#include "od_log.h"
+
+#include <Arduino.h>
+#include <Wire.h>
+
+static const SensorData* axp2101_config(const SensorData* sensors, uint8_t count) {
+    if (sensors == nullptr) {
+        return nullptr;
+    }
+    for (uint8_t i = 0; i < count; i++) {
+        if (sensors[i].sensor_type == OD_SENSOR_TYPE_AXP2101) {
+            return &sensors[i];
+        }
+    }
+    return nullptr;
+}
+
+static uint8_t axp2101_bus_id(const SensorData* s) {
+    uint8_t bid = s->bus_id;
+    if (bid == 0xFF) {
+        bid = 0;
+    }
+    return bid;
+}
+
+// Register block read: write `reg`, then requestFrom `len` bytes into the
+// caller-supplied `out`. Returns false on any transaction failure or short read.
+// Allocates nothing. Mirrors bq27220_read_block() in sensor_bq27220.cpp.
+static bool axp2101_read_block(uint8_t addr, uint8_t reg, uint8_t* out, uint8_t len) {
+    Wire.beginTransmission(addr);
+    Wire.write(reg);
+    if (Wire.endTransmission(false) != 0) {
+        return false;
+    }
+    if (Wire.requestFrom(addr, (size_t)len, true) != len) {
+        return false;
+    }
+    for (uint8_t i = 0; i < len; i++) {
+        out[i] = Wire.read();
+    }
+    return true;
+}
+
+static bool axp2101_write_reg(uint8_t addr, uint8_t reg, uint8_t value) {
+    Wire.beginTransmission(addr);
+    Wire.write(reg);
+    Wire.write(value);
+    return Wire.endTransmission() == 0;
+}
+
+float axp2101BatteryVoltageVolts(const SensorData* sensors, uint8_t sensor_count) {
+    const SensorData* s = axp2101_config(sensors, sensor_count);
+    if (s == nullptr) {
+        return -1.0f;
+    }
+    const uint8_t bus = axp2101_bus_id(s);
+    if (!initOrRestoreWireForBus(bus)) {
+        od_log_warn("AXP2101: bus %u init failed", bus);
+        return -1.0f;
+    }
+    const uint8_t addr = axp2101_resolve_addr(s->i2c_addr_7bit);
+    od_log_debug("AXP2101: addr=0x%02X bus=%u", addr, bus);
+
+    uint8_t status = 0;
+    if (!axp2101_read_block(addr, AXP2101_REG_POWER_STATUS_ADDR, &status, 1)) {
+        od_log_warn("AXP2101: power-status read failed @0x%02X", addr);
+        return -1.0f;
+    }
+    const bool batt_present = axp2101_batt_present(status);
+    const bool vbus_present = axp2101_vbus_present(status);
+    od_log_debug("AXP2101: power_status=0x%02X batt=%d vbus=%d",
+                 status, (int)batt_present, (int)vbus_present);
+    if (!batt_present) {
+        od_log_debug("AXP2101: battery not present, returning -1");
+        return -1.0f;
+    }
+
+    uint8_t adc_ctrl = 0;
+    if (!axp2101_read_block(addr, AXP2101_REG_ADC_CHANNEL_CTRL_ADDR, &adc_ctrl, 1)) {
+        od_log_warn("AXP2101: ADC ctrl read failed @0x%02X", addr);
+        return -1.0f;
+    }
+    bool channel_changed = false;
+    const uint8_t adc_ctrl_new = axp2101_adc_enable_bit0(adc_ctrl, &channel_changed);
+    od_log_debug("AXP2101: adc_ctrl=0x%02X -> 0x%02X (changed=%d)",
+                 adc_ctrl, adc_ctrl_new, (int)channel_changed);
+    if (channel_changed) {
+        if (!axp2101_write_reg(addr, AXP2101_REG_ADC_CHANNEL_CTRL_ADDR, adc_ctrl_new)) {
+            od_log_warn("AXP2101: ADC ctrl enable failed @0x%02X", addr);
+            return -1.0f;
+        }
+        delay(AXP2101_ADC_SETTLING_MS);
+    }
+
+    uint8_t vbat_raw[2] = {0, 0};
+    if (!axp2101_read_block(addr, AXP2101_REG_VBAT_H_ADDR, vbat_raw, 2)) {
+        od_log_warn("AXP2101: VBAT read failed @0x%02X", addr);
+        return -1.0f;
+    }
+    const uint16_t mv = axp2101_decode_vbat_mv(vbat_raw[0], vbat_raw[1]);
+    od_log_debug("AXP2101: VBAT raw=[0x%02X,0x%02X] -> %u mV (%.3fV)",
+                 vbat_raw[0], vbat_raw[1], (unsigned)mv, (float)mv / 1000.0f);
+    return (float)mv / 1000.0f;
+}

--- a/src/sensor_axp2101.h
+++ b/src/sensor_axp2101.h
@@ -1,0 +1,108 @@
+// AXP2101 battery-voltage reader for the normal OpenDisplay battery path.
+//
+// Sits alongside sensor_bq27220 in shape: the sensor-specific configuration
+// lookup, address defaulting, bus restoration, and voltage getter all live
+// here. display_service.cpp's readBatteryVoltageUncached() consults this file
+// when the configured sensor set contains an AXP2101 (sensor type 3), which is
+// the case for the Waveshare ESP32-S3-PhotoPainter esp32-s3-wspp preset.
+//
+// The register decoding and bit manipulation are kept as pure `static inline`
+// helpers here so tools/test_sensor_axp2101.cpp can exercise them without a
+// PlatformIO build. See tools/README.md.
+#ifndef SENSOR_AXP2101_H
+#define SENSOR_AXP2101_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+// AXP2101 register layout used by the battery-voltage path. display_service.cpp
+// carries its own AXP2101_* constants for the PMIC init and shutdown block, and
+// four values appear in both places: the 0x34 slave address, 0x00 power status,
+// 0x30 ADC channel control, and 0x34 VBAT high. The duplication is deliberate --
+// those belong to that block, and the pure helpers below must compile as a
+// standalone unit for the host test.
+#define AXP2101_DEFAULT_ADDR_7BIT             0x34u
+#define AXP2101_REG_POWER_STATUS_ADDR         0x00u
+#define AXP2101_REG_ADC_CHANNEL_CTRL_ADDR     0x30u
+#define AXP2101_REG_VBAT_H_ADDR               0x34u  // VBAT high byte; read as 2-byte block with 0x35
+
+// Datasheet reg 0x00: bit 3 = battery presence, bit 5 = VBUS presence.
+// The uncalled readAXP2101Data() diagnostic in display_service.cpp reads these
+// the other way round (0x20 for battery, 0x08 for VBUS). That is a pre-existing
+// defect in unreachable code, flagged in the pull request and left unchanged.
+#define AXP2101_POWER_STATUS_BATT_PRESENT_BIT (1u << 3)
+#define AXP2101_POWER_STATUS_VBUS_PRESENT_BIT (1u << 5)
+
+// Datasheet reg 0x30: bit 0 enables the VBAT-voltage ADC channel. Every other
+// bit is a different channel or an unrelated ADC control and must be preserved.
+#define AXP2101_ADC_ENABLE_VBAT_BIT           (1u << 0)
+
+// Post-enable settling window before the first VBAT read is meaningful. Only
+// applied when the caller has just flipped bit 0 from 0 to 1.
+#define AXP2101_ADC_SETTLING_MS               2u
+
+// Address defaulting: `0` and `0xFF` (SensorData.i2c_addr_7bit sentinel values,
+// see include/opendisplay_structs.h) both mean "use the AXP2101 default 0x34".
+// Any other value is respected as the configured 7-bit address.
+static inline uint8_t axp2101_resolve_addr(uint8_t configured) {
+    if (configured == 0u || configured == 0xFFu) {
+        return AXP2101_DEFAULT_ADDR_7BIT;
+    }
+    return configured;
+}
+
+// Battery-present interpretation of the power-status register.
+static inline bool axp2101_batt_present(uint8_t status_reg) {
+    return (status_reg & AXP2101_POWER_STATUS_BATT_PRESENT_BIT) != 0u;
+}
+
+// VBUS-present interpretation of the power-status register. Reported in the
+// battery reader's debug line; it does not affect the voltage returned.
+static inline bool axp2101_vbus_present(uint8_t status_reg) {
+    return (status_reg & AXP2101_POWER_STATUS_VBUS_PRESENT_BIT) != 0u;
+}
+
+// Returns the value to write back to reg 0x30 so bit 0 is set, with every other
+// bit preserved. `out_channel_changed` receives `true` iff the caller has just
+// flipped the channel from disabled to enabled -- the only case where the
+// caller must allow AXP2101_ADC_SETTLING_MS before the first VBAT sample.
+static inline uint8_t axp2101_adc_enable_bit0(uint8_t current, bool* out_channel_changed) {
+    const bool was_off = (current & AXP2101_ADC_ENABLE_VBAT_BIT) == 0u;
+    if (out_channel_changed != NULL) {
+        *out_channel_changed = was_off;
+    }
+    return (uint8_t)(current | AXP2101_ADC_ENABLE_VBAT_BIT);
+}
+
+// VBAT decoding. Reg 0x34 holds the six valid high bits (bits 7:6 are unused
+// and must be masked), reg 0x35 holds the full low byte. Result is millivolts
+// at 1 mV per count.
+static inline uint16_t axp2101_decode_vbat_mv(uint8_t hi, uint8_t lo) {
+    const uint16_t high_bits = (uint16_t)(hi & 0x3Fu);
+    return (uint16_t)((high_bits << 8) | (uint16_t)lo);
+}
+
+struct SensorData;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Reads the current battery voltage in volts through the OpenDisplay bus
+// abstraction. The caller passes the parsed sensor set rather than this module
+// reaching for a global (see the no-extern rule in CLAUDE.md); the AXP2101 entry
+// is located here so the lookup stays with the sensor-specific code, matching
+// sensor_bq27220.
+//
+// Returns `-1.0f` on any failure -- no AXP2101 in `sensors`, bus init failed,
+// PMIC not answering, short read, or battery absent per reg 0x00 -- so the
+// caller can fall through to its next battery source. Never allocates. Emits an
+// od_log_warn on transaction failure.
+float axp2101BatteryVoltageVolts(const struct SensorData* sensors, uint8_t sensor_count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // SENSOR_AXP2101_H

--- a/tools/README.md
+++ b/tools/README.md
@@ -13,6 +13,10 @@ firmware's config layout.
   boards that flash via USB mass storage.
 - `test_zlib_stream.c` — standalone test harness for the firmware's streaming
   zlib/uzlib decoder (`lib/uzlib`). Not part of the PlatformIO build.
+- `test_sensor_axp2101.cpp` — standalone host test for the AXP2101 battery-
+  voltage helpers in `src/sensor_axp2101.h` (VBAT decoding, targeted ADC-enable,
+  address defaulting, and I2C-failure fall-through). Not part of the PlatformIO
+  build. See the header comment for the exact build line.
 - `ble_crypto.py` / `config_packet.py` — shared helpers. `ble_crypto.py` is
   inlined into `od-device-cli.py` and kept here for reference. `config_packet.py`
   is imported by `provision_firmware.py`.

--- a/tools/test_sensor_axp2101.cpp
+++ b/tools/test_sensor_axp2101.cpp
@@ -1,0 +1,269 @@
+// Host test for src/sensor_axp2101.h -- the AXP2101 battery-voltage helpers.
+//
+// Build and run from the repo root:
+//
+//   g++ -std=c++17 -Wall -Wextra -Werror -O1 -fsanitize=undefined,address -I include -I src tools/test_sensor_axp2101.cpp -o /tmp/test_sensor_axp2101
+//   /tmp/test_sensor_axp2101
+//
+// Like tools/test_link_owner.cpp, this is as much a written-down statement of
+// the intended semantics as it is a test. It covers:
+//
+//   - VBAT decoding with upper unused bits clear and set
+//   - ADC bit-0 enable while preserving every other bit
+//   - Battery-present status set and clear
+//   - Default address selection for zero and 0xFF
+//   - Configured address preservation
+//   - No configured AXP2101 (walked via a SensorData-shaped array)
+//   - Short or failed I2C reads (walked via a fake bus driving the same helpers)
+//
+// The pure helpers under test have no Arduino/Wire dependency, so no hostshim
+// is required. The fake-bus scenarios call the SAME helpers the production
+// reader calls, but they re-implement its call sequence rather than driving
+// axp2101BatteryVoltageVolts() itself. That ordering and the Wire I/O are what
+// on-device testing covers, not this file.
+
+#include "sensor_axp2101.h"
+#include "opendisplay_structs.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cstdint>
+
+// --- tiny harness ----------------------------------------------------------
+static int g_checks = 0;
+static int g_failures = 0;
+
+static void check(bool cond, const char* what) {
+    g_checks++;
+    if (!cond) {
+        g_failures++;
+        std::printf("FAIL: %s\n", what);
+    }
+}
+
+extern "C" void __ubsan_on_report(void) {
+    std::printf("FAIL: UBSan report\n");
+    std::exit(1);
+}
+
+// Fake bus for the "short or failed I2C reads" case. Records writes so the test
+// can verify targeted ADC-enable semantics, and lets each register return either
+// a canned byte or an error.
+struct FakeBus {
+    // Canned responses for the three registers the reader touches. If .ok is
+    // false, the read fails (mirrors an I2C NAK or a short read).
+    struct Reply {
+        bool ok;
+        uint8_t value;
+    };
+    Reply power_status{true, 0x08};                // battery present by default
+    Reply adc_ctrl{true, 0x00};                    // channel currently disabled
+    Reply vbat_hi{true, 0x0F};                     // 0x0FB8 -> 4024 mV
+    Reply vbat_lo{true, 0xB8};
+
+    // Recorded writes.
+    bool adc_write_seen = false;
+    uint8_t adc_write_value = 0xFF;
+};
+
+// Executes the same production sequence readBatteryVoltageUncached's AXP2101
+// arm does, but against FakeBus. Returns millivolts on success, -1 on any
+// failure -- mirroring axp2101BatteryVoltageVolts()'s -1.0f return.
+static int fake_read_vbat_mv(FakeBus& bus, uint8_t addr) {
+    (void)addr;
+    if (!bus.power_status.ok) return -1;
+    if (!axp2101_batt_present(bus.power_status.value)) return -1;
+    if (!bus.adc_ctrl.ok) return -1;
+    bool changed = false;
+    const uint8_t adc_new = axp2101_adc_enable_bit0(bus.adc_ctrl.value, &changed);
+    if (changed) {
+        bus.adc_write_seen = true;
+        bus.adc_write_value = adc_new;
+        // (Production delays AXP2101_ADC_SETTLING_MS here; no-op in the test.)
+    }
+    if (!bus.vbat_hi.ok || !bus.vbat_lo.ok) return -1;
+    return (int)axp2101_decode_vbat_mv(bus.vbat_hi.value, bus.vbat_lo.value);
+}
+
+int main(void) {
+    // ---- VBAT decoding with upper unused bits clear -------------------------
+    {
+        // 0x0F B8 -- the ESPHome-observed sample -- must decode to 4024 mV.
+        check(axp2101_decode_vbat_mv(0x0F, 0xB8) == 4024, "vbat decode 0x0FB8 == 4024 mV");
+        check(axp2101_decode_vbat_mv(0x00, 0x00) == 0, "vbat decode 0x0000 == 0 mV");
+        check(axp2101_decode_vbat_mv(0x00, 0xFF) == 255, "vbat decode 0x00FF == 255 mV");
+        check(axp2101_decode_vbat_mv(0x01, 0x00) == 256, "vbat decode 0x0100 == 256 mV");
+        check(axp2101_decode_vbat_mv(0x3F, 0xFF) == 16383, "vbat decode 0x3FFF == 16383 mV");
+    }
+
+    // ---- VBAT decoding with upper unused bits SET ---------------------------
+    {
+        // Bits 7:6 of reg 0x34 are unused; the decoder must mask them off so
+        // spurious garbage in that field cannot inflate the reading.
+        check(axp2101_decode_vbat_mv(0xC0, 0x00) == 0,
+              "vbat unused bits 0xC0 masked -> 0 mV");
+        check(axp2101_decode_vbat_mv(0xCF, 0xB8) == 4024,
+              "vbat 0xCFB8 (unused bits set) decodes same as 0x0FB8");
+        check(axp2101_decode_vbat_mv(0xFF, 0xFF) == 16383,
+              "vbat 0xFFFF decodes as 0x3FFF -> 16383 mV");
+    }
+
+    // ---- ADC bit-0 enable while preserving every other bit ------------------
+    {
+        // From all-zero: bit 0 flips 0->1, no other bit changes.
+        bool changed = false;
+        uint8_t next = axp2101_adc_enable_bit0(0x00, &changed);
+        check(next == 0x01, "adc enable from 0x00 -> 0x01");
+        check(changed, "adc enable from 0x00 flags channel change");
+
+        // From every other bit set: bit 0 flips 0->1, all other bits preserved.
+        changed = false;
+        next = axp2101_adc_enable_bit0(0xFE, &changed);
+        check(next == 0xFF, "adc enable from 0xFE preserves 7..1, sets bit 0 -> 0xFF");
+        check(changed, "adc enable from 0xFE flags channel change");
+
+        // Already enabled (0x01): value unchanged, no channel-change flag.
+        changed = true;
+        next = axp2101_adc_enable_bit0(0x01, &changed);
+        check(next == 0x01, "adc enable from 0x01 stays 0x01");
+        check(!changed, "adc enable from 0x01 does not flag channel change");
+
+        // Already enabled with siblings set: value unchanged, no flag.
+        changed = true;
+        next = axp2101_adc_enable_bit0(0xA5, &changed);
+        check(next == 0xA5, "adc enable from 0xA5 stays 0xA5 (bit 0 already set)");
+        check(!changed, "adc enable from 0xA5 does not flag channel change");
+
+        // NULL out-pointer must be tolerated.
+        next = axp2101_adc_enable_bit0(0x00, nullptr);
+        check(next == 0x01, "adc enable with null out-pointer still returns 0x01");
+    }
+
+    // ---- Battery-present status set and clear -------------------------------
+    {
+        check(!axp2101_batt_present(0x00), "batt present false when reg 0x00 is zero");
+        check(axp2101_batt_present(0x08), "batt present true when bit 3 set");
+        check(!axp2101_batt_present(0xF7), "batt present false when only bit 3 clear");
+        check(axp2101_batt_present(0xFF), "batt present true when every bit set");
+        // Bit 3 is battery, bit 5 is VBUS -- they are DISTINCT and must not
+        // shadow each other (this is exactly what mainline had swapped).
+        check(!axp2101_batt_present(0x20), "0x20 alone (VBUS bit) does NOT imply battery present");
+        check(axp2101_vbus_present(0x20), "0x20 alone is VBUS present");
+        check(!axp2101_vbus_present(0x08), "0x08 alone (batt bit) does NOT imply VBUS present");
+    }
+
+    // ---- Default address selection for zero and 0xFF ------------------------
+    {
+        check(axp2101_resolve_addr(0x00) == 0x34, "configured 0x00 -> default 0x34");
+        check(axp2101_resolve_addr(0xFF) == 0x34, "configured 0xFF -> default 0x34");
+    }
+
+    // ---- Configured address preservation ------------------------------------
+    {
+        // A valid 7-bit address must be respected verbatim -- no defaulting.
+        check(axp2101_resolve_addr(0x34) == 0x34, "configured 0x34 respected");
+        check(axp2101_resolve_addr(0x35) == 0x35, "configured 0x35 respected");
+        check(axp2101_resolve_addr(0x01) == 0x01, "configured 0x01 respected (edge)");
+        check(axp2101_resolve_addr(0x7F) == 0x7F, "configured 0x7F respected (top of 7-bit)");
+    }
+
+    // ---- No configured AXP2101 ---------------------------------------------
+    // The reader must not consult AXP2101 when the parsed sensor set has no
+    // entry of type OD_SENSOR_TYPE_AXP2101. This mirrors the walk that
+    // axp2101_config() performs in sensor_axp2101.cpp against globalConfig.
+    {
+        auto find_axp = [](const SensorData* sensors, uint8_t count) -> const SensorData* {
+            for (uint8_t i = 0; i < count; i++) {
+                if (sensors[i].sensor_type == OD_SENSOR_TYPE_AXP2101) return &sensors[i];
+            }
+            return nullptr;
+        };
+
+        SensorData empty{};
+        check(find_axp(&empty, 0) == nullptr, "no sensors -> no AXP2101 found");
+
+        SensorData sht{};
+        sht.sensor_type = OD_SENSOR_TYPE_SHT40;
+        check(find_axp(&sht, 1) == nullptr, "SHT40 only -> no AXP2101 found");
+
+        SensorData bq{};
+        bq.sensor_type = OD_SENSOR_TYPE_BQ27220;
+        check(find_axp(&bq, 1) == nullptr, "BQ27220 only -> no AXP2101 found");
+
+        SensorData mixed[3]{};
+        mixed[0].sensor_type = OD_SENSOR_TYPE_SHT40;
+        mixed[1].sensor_type = OD_SENSOR_TYPE_AXP2101;
+        mixed[1].bus_id = 0;
+        mixed[1].i2c_addr_7bit = 0xFF;
+        mixed[2].sensor_type = OD_SENSOR_TYPE_BQ27220;
+        const SensorData* hit = find_axp(mixed, 3);
+        check(hit == &mixed[1], "mixed sensor set finds the AXP2101 entry");
+        check(axp2101_resolve_addr(hit->i2c_addr_7bit) == 0x34,
+              "PhotoPainter-style entry (addr 0xFF) resolves to default 0x34");
+    }
+
+    // ---- Short or failed I2C reads -----------------------------------------
+    // Every failure mode returns -1 (matching axp2101BatteryVoltageVolts's
+    // -1.0f) and does NOT touch the ADC-enable write when a preceding step
+    // has already failed. Success case verifies the ADC-enable is issued
+    // exactly once and only when the channel actually flipped.
+    {
+        // Success baseline: pre-shutdown ESPHome sample.
+        FakeBus b;
+        int mv = fake_read_vbat_mv(b, 0x34);
+        check(mv == 4024, "success path decodes 4024 mV");
+        check(b.adc_write_seen, "success path issued ADC-enable write");
+        check(b.adc_write_value == 0x01, "success path wrote only bit 0 to reg 0x30");
+    }
+    {
+        // Power-status read failure -> -1, no ADC-enable write.
+        FakeBus b;
+        b.power_status.ok = false;
+        int mv = fake_read_vbat_mv(b, 0x34);
+        check(mv == -1, "power-status read failure returns -1");
+        check(!b.adc_write_seen, "power-status failure aborts before ADC-enable write");
+    }
+    {
+        // Battery-present clear -> -1, no ADC-enable write.
+        FakeBus b;
+        b.power_status.value = 0x00;
+        int mv = fake_read_vbat_mv(b, 0x34);
+        check(mv == -1, "battery-absent returns -1");
+        check(!b.adc_write_seen, "battery-absent aborts before ADC-enable write");
+    }
+    {
+        // ADC ctrl read failure -> -1, no ADC-enable write.
+        FakeBus b;
+        b.adc_ctrl.ok = false;
+        int mv = fake_read_vbat_mv(b, 0x34);
+        check(mv == -1, "adc-ctrl read failure returns -1");
+        check(!b.adc_write_seen, "adc-ctrl read failure aborts before ADC-enable write");
+    }
+    {
+        // ADC channel already enabled: no write issued (targeted enable is a no-op).
+        FakeBus b;
+        b.adc_ctrl.value = 0x81;   // bit 0 already set, other bits present
+        int mv = fake_read_vbat_mv(b, 0x34);
+        check(mv == 4024, "already-enabled channel still decodes correctly");
+        check(!b.adc_write_seen, "already-enabled channel does NOT re-write reg 0x30");
+    }
+    {
+        // VBAT high-byte short read -> -1.
+        FakeBus b;
+        b.vbat_hi.ok = false;
+        int mv = fake_read_vbat_mv(b, 0x34);
+        check(mv == -1, "VBAT high-byte read failure returns -1");
+        check(b.adc_write_seen, "VBAT read failure still records the earlier ADC-enable");
+    }
+    {
+        // VBAT low-byte short read -> -1.
+        FakeBus b;
+        b.vbat_lo.ok = false;
+        int mv = fake_read_vbat_mv(b, 0x34);
+        check(mv == -1, "VBAT low-byte read failure returns -1");
+    }
+
+    std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Fixes #154

## Summary

Add AXP2101 VBAT acquisition to the existing battery-voltage path when the runtime sensor configuration contains `OD_SENSOR_TYPE_AXP2101`.

This change is limited to voltage acquisition. PMIC rail policy, panel shutdown, audio hardware, shared-I2C shutdown handling, device detection, and website presets remain unchanged.

## Intended behavior

- Locate the configured AXP2101 sensor.
- Respect its bus and optional seven-bit address.
- Use the existing OpenDisplay I2C initialization and restoration path.
- Enable only the battery-voltage ADC channel while preserving other ADC-control bits.
- Decode the two VBAT registers at the AXP2101 scale.
- Feed volts through the existing cache and BLE manufacturer-data path.
- Preserve BQ27220 and analog-sense behavior.
- Add no heap allocation and retain production polling intervals.

## Flagged, deliberately not fixed here: `readAXP2101Data()`

While working in this file we found that the pre-existing `readAXP2101Data()` diagnostic reads the
AXP2101 using AXP192 register semantics. Every value it decodes is affected:

- All three voltage reads use a 12-bit `((H<<4)|(L&0x0F))` field with AXP192 step sizes — 0.5 mV for
  VBAT, 1.7 mV for VBUS, 1.4 mV for SYS. The AXP2101 encodes these as six valid high bits followed
  by a full low byte, at 1 mV per count.
- It writes `0xFF` to ADC-control register `0x30`, enabling every ADC channel and overwriting every
  unrelated control bit, where only bit 0 is needed.
- It reads battery presence at bit 5 and VBUS presence at bit 3 of the power-status register, which
  is the reverse of the datasheet.

**The function has no callers anywhere in the tree** — only a declaration in `display_service.h` and
its own definition — so none of this is reachable at runtime today.

The mismatch appears confined to this one function. `initAXP2101()` and `powerDownAXP2101()` use a
different register set and are exercised on every boot, and the `0xFF` writes in the power-down path
are legitimate write-one-to-clear on the IRQ status registers, not the same bug.

It is left unchanged here on purpose. `CLAUDE.md` asks that pre-existing problems be flagged rather
than fixed as a side effect of unrelated work, and nothing in the hardware test cycle below could
exercise a fix to unreachable code. I intend to fix it myself in a follow-up — see *Follow-up work*
at the end.

## Scope of impact

`esp32-s3-wspp` is the only preset in the opendisplay.org catalog with `sensor_type: 3`, and it sets `battery_sense_pin: 0xFF`. No existing configuration has both an AXP2101 and an analog battery-sense pin, so the new AXP2101-before-analog precedence displaces nothing. That preset also omits `i2c_addr_7bit` entirely, which parses as `0` — the `0`/`0xFF` → `0x34` address defaulting is what makes the fix work on real hardware, not a theoretical convenience.

## Testing

### Host tests

49 checks exercising VBAT decode, ADC bit-0 enable/preserve, address selection, battery-presence flag, and failed read handling. Compiled and run off-target with `-fsanitize=undefined,address`. See `tools/test_sensor_axp2101.cpp`.

The pure helpers are covered directly. The fake-bus scenarios re-implement the production call sequence rather than driving it, so ordering changes inside `axp2101BatteryVoltageVolts()` would not fail the test; the Wire I/O and the call ordering are what the hardware cycle covers.

### CI build matrix

All 12 environments in `.github/firmware-targets.json` compile clean at every one of the four test
states, in both the production and diagnostic build profiles. No environment regressed.

### Hardware test cycle

Four firmware states were built, flashed and serial-captured on two physical devices — eight
captures, all taken in a single session with an identical observation window (boot through setup
completion, then a fixed 150-second hold), so every comparison is like-for-like:

| State | Contents | Profile |
|---|---|---|
| `00-main` | Unmodified upstream main | Production |
| `01-main-diag` | Main + interval overrides + `OD_LOG_DEBUG` | Diagnostic |
| `02-fix-diag` | Main + diagnostic + this fix | Diagnostic |
| `03-fix-main` | Main + this fix only | Production |

| Device | Role |
|---|---|
| Waveshare ESP32-S3-PhotoPainter Rev 2.0 (`esp32-s3-N16R8`) | Positive — has configured AXP2101 |
| Seeed XIAO 7.5-inch panel, XIAO ESP32-C3 (`esp32-c3-N4`) | Negative — no AXP2101 |

**`00-main` vs `03-fix-main` (PhotoPainter):** the complete diff, after timestamp normalization, is
the free-heap line plus the two post-shutdown I²C warnings explained under *Known separate issue*
below. Boot, configuration load, display refresh, panel force-off and BLE advertising are otherwise
line-for-line identical.

**`01-main-diag` vs `02-fix-diag` (PhotoPainter):** `02` reads 4137 mV at t=1.983 s and 4138 mV at
t=36.425 s from the AXP2101, and that voltage reaches the BLE advertisement — `02` publishes
`… 9D 03`, i.e. voltage low byte `0x9D` with the status bit-8 flag set: `0x019D` = 413 × 10 mV =
4130 mV, the 10 mV quantization of 4138 mV. `01` publishes `… 00 02`, encoding zero.

**C3 negative control:** free heap is **134 824 B in all four states**, and no AXP2101 log line
appears anywhere in any capture — the arm is never entered on a device with no AXP2101 in its
sensor configuration. The only textual differences between the captures are one partially-written
line caught by the serial monitor attaching a few milliseconds earlier in one run, and the
chip-temperature byte in the manufacturer data, which drifts between runs.

**Footprint (`esp32-s3-N16R8`):**

| Measure | `00-main` | `03-fix-main` | Delta |
|---|---|---|---|
| Flash | 1 527 110 B | 1 527 742 B | **+632 B** |
| Static RAM | 103 308 B | 103 308 B | **unchanged** |
| Free heap at setup-complete | 168 168 B | 167 772 B | **−396 B** |

The 396-byte heap difference is not the new code's footprint — static RAM is byte-identical. It is
resident heap arising from the I²C transactions the read performs during boot. It tracks the fix and
not the diagnostics: `00-main` and `01-main-diag` both report 168 168 B, `02-fix-diag` and
`03-fix-main` both report 167 772 B.

**Patch-ID:** `cef298c94ca80e567edb198d702b50ec29c1081b` — the fix commit is byte-for-byte identical
whether applied alone or on top of the diagnostic commit, confirming the two are independent.

### Negative-coverage limitation

Negative testing was performed on the ESP32-C3 only. A second, S3-class negative device (TRMNL 7.5-inch OG DIY Kit, XIAO ESP32-S3 Plus) was planned but the unit was not delivered. Given the C3 result above and the preset-catalog scope, the remaining untested surface is a second S3 board with no AXP2101 configured.

## Known separate issue: the PMIC is unreachable after panel shutdown

The PhotoPainter logs above show two I²C warnings after the panel powers down. This pull request is
what makes them visible, so they need explaining.

At the end of the boot render the device runs its shutdown path: `powerDownAXP2101()` disables the
ALDO1–4 rails among others and puts the PMIC to sleep, then `pwrmgm()` calls `Wire.end()` and drives
GPIO47/GPIO48 — this preset's bus pins — high as push-pull outputs. Every PMIC transaction after
that point fails with `ESP_ERR_INVALID_STATE`.

The cause is known from separate isolation testing on this hardware, not from this pull request: the
schematic ties `Audio_VCC` to ALDO3, and de-energizing it leaves the ES8311/ES7210 I²C pins
unpowered, so their protection diodes clamp the shared SDA/SCL lines and take down every device on
the bus, the PMIC included. The software teardown in `pwrmgm()` would be enough on its own as well;
both happen here.

**Nothing in this change fixes, hides, or works around that.** In that window the reader returns
`-1.0f`, exactly as it does for any other failed transaction, and the voltage this pull request adds
is the pre-shutdown reading.

**What this costs, and where.** The read itself is cheap, and it is what every AXP2101 board pays:
three register reads on the configured bus — power status, ADC control, and the VBAT pair — plus one
register write and a 2 ms settling delay whenever the VBAT ADC channel reads back disabled. On the
PhotoPainter it does read back disabled on both pre-shutdown samples in the capture, so each read
there is three reads, one write and 2 ms. That happens at most once per cache interval.

The 69 ms figure is not that cost. It is a transaction timing out against a bus that has already
been torn down, and it only arises in the window after `pwrmgm(false)` has run. That teardown is
gated on `sensor_type == OD_SENSOR_TYPE_AXP2101` — the same predicate as the new read — so the set
of boards that can see it is exactly the set that enters this path, and `esp32-s3-wspp` is currently
the only preset configuring one. In practice that means the PhotoPainter, after its panel shutdown,
and nothing else.

Within that window it is consistent: 69 ms on every attempt in the diagnostic capture (43.710 →
43.779 s, and identically at 53 s, 63 s and 73 s). In production the read is driven by the
60-second manufacturer-data update rather than by the 30-second cache, so the `03-fix-main` capture
shows one stall per minute, at 120 s and 180 s and nowhere else. Mainline never attempted a PMIC
read at all, so it never paid this. It resolves with the underlying problem, which I intend to fix
myself — see *Follow-up work* below.

## Follow-up work

Both problems this pull request flags are mine to fix, not requests for someone else to pick up.
Unless you would rather they were handled differently, I will take them in order once this merges,
each as its own issue followed by its own pull request, using the same pattern as this one — an
isolated commit against a pinned baseline, host tests, the full CI matrix, and a before/after
hardware capture on every available device:

1. **`readAXP2101Data()`** — correct its VBAT decode, targeted ADC enable and status-bit reading
   against the shared helpers added here, or remove the function if you would prefer that. Small,
   and it needs a decision from you on which of the two you want.
2. **The post-shutdown I²C failure** — the larger piece. It needs an OpenDisplay-native shutdown
   lifecycle that keeps the powered devices on the shared bus reachable, with the audio parts put
   into their documented low-power states rather than having their rail removed. I have the
   isolation testing behind it and will bring the evidence with the issue.

Happy to reorder, split, or drop either if that does not match how you would like this area handled.

AI-enabled workflow disclosure: this change was produced with AI assistance under a human-driven, human-in-the-loop process. GitHub Copilot was the harness; planning, implementation, review, and log analysis were carried out across multiple AI harnesses and models, each stage reviewed by a human operator. All hardware observations were produced on physical devices by that operator, and the raw serial captures, build output, and flash logs are retained as evidence.
